### PR TITLE
if .apifyignore exists, use it instead of .gitignore

### DIFF
--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -67,6 +67,9 @@ class PushCommand extends ApifyCommand {
         const filePathsToPush = await getActorLocalFilePaths();
         const filesSize = await sumFilesSizeInBytes(filePathsToPush);
 
+        outputs.info('Local files size is: ' + filesSize);
+        outputs.info('Local files to be pushed: ' + filePathsToPush);
+
         let sourceType;
         let sourceFiles;
         let tarballUrl;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -204,11 +204,29 @@ const createSourceFiles = async (paths) => {
  * Get actor local files, omit files defined in .gitignore and .git folder
  * All dot files(.file) and folders(.folder/) are included.
  */
-const getActorLocalFilePaths = () => globby(['*', '**/**'], {
-    ignore: ['.git/**'],
-    gitignore: true,
-    dot: true,
-});
+const getActorLocalFilePaths = () => {
+
+  let opt;
+
+  if (fs.existsSync('.apifyignore')) {
+    info('Using .apifyignore for ignore list.');
+    const ignorelist = fs.readFileSync('.apifyignore', 'UTF-8').split(/\r?\n/).filter( (line) => line !== '');
+    opt = {
+      ignore: ['.git/**', ...ignorelist],
+      gitignore: false,
+      dot: true,
+    }
+
+  } else {
+    info('Using .gitignore for ignore list.');
+    opt = {
+      ignore: ['.git/**'],
+      gitignore: true,
+      dot: true,
+    }
+  }
+  return globby(['*', '**/**'], opt)
+};
 
 /**
  * Create zip file with all actor files specified with pathsToZip


### PR DESCRIPTION
fixes #170 