### PR TITLE
fix: improve source file format detection

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "apify-cli",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "apify-cli",
-            "version": "0.8.1",
+            "version": "0.8.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/actor-templates": "^0.1.3",
@@ -28,6 +28,7 @@
                 "got-scraping": "^3.2.9",
                 "inquirer": "^7.3.3",
                 "is-online": "^10.0.0",
+                "istextorbinary": "^6.0.0",
                 "load-json-file": "^6.2.0",
                 "mime": "^2.6.0",
                 "minimist": "^1.2.5",
@@ -1411,6 +1412,17 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/binaryextensions": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.18.0.tgz",
+            "integrity": "sha512-PQu3Kyv9dM4FnwB7XGj1+HucW+ShvJzJqjuw1JkKVs1mWdwOKVcRjOi+pV9X52A0tNvrPCsPkbFFQb+wE1EAXw==",
+            "engines": {
+                "node": ">=0.8"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
             }
         },
         "node_modules/bl": {
@@ -4470,6 +4482,21 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
+        "node_modules/istextorbinary": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-6.0.0.tgz",
+            "integrity": "sha512-4j3UqQCa06GAf6QHlN3giz2EeFU7qc6Q5uB/aY7Gmb3xmLDLepDOtsZqkb4sCfJgFvTbLUinNw0kHgHs8XOHoQ==",
+            "dependencies": {
+                "binaryextensions": "^4.18.0",
+                "textextensions": "^5.14.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/jake": {
             "version": "10.8.5",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
@@ -6726,6 +6753,17 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
+        "node_modules/textextensions": {
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.15.0.tgz",
+            "integrity": "sha512-MeqZRHLuaGamUXGuVn2ivtU3LA3mLCCIO5kUGoohTCoGmCBg/+8yPhWVX9WSl9telvVd8erftjFk9Fwb2dD6rw==",
+            "engines": {
+                "node": ">=0.8"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -8242,6 +8280,11 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
+        },
+        "binaryextensions": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.18.0.tgz",
+            "integrity": "sha512-PQu3Kyv9dM4FnwB7XGj1+HucW+ShvJzJqjuw1JkKVs1mWdwOKVcRjOi+pV9X52A0tNvrPCsPkbFFQb+wE1EAXw=="
         },
         "bl": {
             "version": "1.2.3",
@@ -10476,6 +10519,15 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
+        "istextorbinary": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-6.0.0.tgz",
+            "integrity": "sha512-4j3UqQCa06GAf6QHlN3giz2EeFU7qc6Q5uB/aY7Gmb3xmLDLepDOtsZqkb4sCfJgFvTbLUinNw0kHgHs8XOHoQ==",
+            "requires": {
+                "binaryextensions": "^4.18.0",
+                "textextensions": "^5.14.0"
+            }
+        },
         "jake": {
             "version": "10.8.5",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
@@ -12212,6 +12264,11 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "textextensions": {
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.15.0.tgz",
+            "integrity": "sha512-MeqZRHLuaGamUXGuVn2ivtU3LA3mLCCIO5kUGoohTCoGmCBg/+8yPhWVX9WSl9telvVd8erftjFk9Fwb2dD6rw=="
         },
         "through": {
             "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-cli",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Apify command-line interface helps you create, develop, build and run Apify actors, and manage the Apify cloud platform.",
     "main": "index.js",
     "scripts": {
@@ -69,6 +69,7 @@
         "got-scraping": "^3.2.9",
         "inquirer": "^7.3.3",
         "is-online": "^10.0.0",
+        "istextorbinary": "^6.0.0",
         "load-json-file": "^6.2.0",
         "mime": "^2.6.0",
         "minimist": "^1.2.5",


### PR DESCRIPTION
The source file format detection was not working for e.g. `.tgz` files, because their MIME type was not detected correctly.
I added the right MIME type definition for the `.tgz` files, but then I decided to fix one old TODO and rework the file format detection a bit.

Now if we can't detect the MIME type of the file, we don't automatically assume it to be text, but instead we try to detect its encoding from the contents, using the `isTextOrBinary` package.
It should be relatively fast, since:
- it's done only for files which couldn't be determined via MIME type
- it's done only when the total size of the pushed files is <3MB
- it reads only a few bytes in the start, middle and end of each file, not the whole file, and checks if they are in the Unicode characters range, or not

This should not change the behavior for files which were really text, it should just detect binary files better, so it's not a breaking change.