### PR TITLE
chore: remove forgotten console.dir

### DIFF
--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -136,7 +136,6 @@ class PushCommand extends ApifyCommand {
         }
 
         build = await apifyClient.build(build.id).get();
-        console.dir(build);
 
         outputs.link('Actor build detail', `https://console.apify.com/actors/${build.actId}#/builds/${build.buildNumber}`);
 


### PR DESCRIPTION
Or was this there on purpose? I remember someone was complaining about this on Slack, but I can't find the conversation.