### PR TITLE
chore: update GitHub actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,22 +13,23 @@ jobs:
         runs-on: ${{ matrix.os }}
 
         strategy:
+            max-parallel: 1
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 node-version: [ 16, 18 ]
 
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
             -
                 name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{ matrix.node-version }}
             -
                 name: Cache Node Modules
                 if: ${{ matrix.node-version == 16 }}
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: |
                         node_modules
@@ -50,15 +51,15 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
             -
                 name: Use Node.js 16
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: 16
             -
                 name: Load Cache
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: |
                         node_modules

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,6 @@ jobs:
         runs-on: ${{ matrix.os }}
 
         strategy:
-            max-parallel: 1
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 node-version: [ 16, 18 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,23 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [ 16, 18 ]
 
     steps:
       -
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       -
         name: Cache Node Modules
         if: ${{ matrix.node-version == 16 }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -54,15 +55,15 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       -
         name: Load Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -80,15 +81,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       -
         name: Load Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      max-parallel: 1
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [ 16, 18 ]


### PR DESCRIPTION
~Doing any changes to `apify-cli` is a pain, because the tests keep failing if they're run in parallel. This makes them run serially, which takes longer, but at least you don't have to retry them.~ EDIT: turns out this does not help, so I reverted that part.

I also updated the `actions/xxx` versions to fix the warnings about Node 12 deprecations.