### PR TITLE
feat: Use .actor/actor.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd ./my/awesome/project
 apify init
 ```
 This command will only set up local actor development environment in an existing directory,
-i.e. it will create the `apify.json` file and `apify_storage` directory.
+i.e. it will create the `.actor/actor.json` file and `apify_storage` directory.
 
 Before you can run your project using `apify run`, you have to set up the right start command in `package.json` under scripts.start. For example:
 ```text
@@ -139,24 +139,24 @@ This command can also be used to run other actors, for example:
 apify call apify/hello-world
 ```
 
-### So what's in this `apify.json` file?
+### So what's in this `.actor/actor.json` file?
 
 This file associates your local development project with an actor on the Apify platform.
 It contains information such as actor name, version, build tag and environment variables.
 Make sure you commit this file to the Git repository.
 
-For example, `apify.json` file can look as follows:
+For example, `.actor/actor.json` file can look as follows:
 
 ```json
 {
+    "actorSpecification": 1,
     "name": "dataset-to-mysql",
     "version": "0.1",
     "buildTag": "latest",
-    "env": {
+    "environmentVariables": {
       "MYSQL_USER": "my_username",
       "MYSQL_PASSWORD": "@mySecretPassword"
-    },
-    "template": "basic"
+    }
 }
 ```
 
@@ -164,48 +164,48 @@ For example, `apify.json` file can look as follows:
 
 There are two options how you can set up environment variables for actors.
 
-### Set up environment variables in `apify.json`
+### Set up environment variables in `.actor/actor.json`
 All keys from `env` will be set as environment variables into Apify platform after you push actor to Apify. Current values on Apify will be overridden.
 ```json
 {
+    "actorSpecification": 1,
     "name": "dataset-to-mysql",
     "version": "0.1",
     "buildTag": "latest",
-    "env": {
+    "environmentVariables": {
       "MYSQL_USER": "my_username",
       "MYSQL_PASSWORD": "@mySecretPassword"
-    },
-    "template": "basic"
+    }
 }
 ```
 
 ### Set up environment variables in Apify Console
 In [Apify Console](https://console.apify.com/actors) select your actor, you can set up variables into Source tab.
-After setting up variables in the app, set up `env` to `null` apify.json. Otherwise, variables from `apify.json` will override variables in the app.
+After setting up variables in the app, remove the `environmentVariables` from `.actor/actor.json`. Otherwise, variables from `.actor/actor.json` will override variables in the app.
 ```json
 {
+    "actorSpecification": 1,
     "name": "dataset-to-mysql",
     "version": "0.1",
-    "buildTag": "latest",
-    "env": null,
-    "template": "basic"
+    "buildTag": "latest"
 }
 ```
 
 
-#### How to set secret environment variables in `apify.json`
+#### How to set secret environment variables in `.actor/actor.json`
 
 CLI provides commands to manage secrets environment variables. Secrets are stored to the ~/.apify directory.
 Adds a new secret using command:
 ```bash
 apify secrets:add mySecretPassword pwd1234
 ```
-After adding a new secret you can use the secret in apify.json
+After adding a new secret you can use the secret in `.actor/actor.json`
 ```text
 {
+    "actorSpecification": 1,
     "name": "dataset-to-mysql",
     ...
-    "env": {
+    "environmentVariables": {
       "MYSQL_PASSWORD": "@mySecretPassword"
     },
     ...
@@ -350,7 +350,7 @@ USAGE
 
 ARGUMENTS
   ACTID  Name or ID of the actor to run (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the command
-         runs the remote actor specified in the "apify.json" file.
+         runs the remote actor specified in the ".actor/actor.json" file.
 
 OPTIONS
   -b, --build=build                      Tag or number of the build to run (e.g. "latest" or "1.2.34").
@@ -359,7 +359,7 @@ OPTIONS
   -w, --wait-for-finish=wait-for-finish  Seconds for waiting to run to finish, if no value passed, it waits forever.
 
 DESCRIPTION
-  The actor is run under your current Apify account, therefore you need to be logged in by calling "apify login". It 
+  The actor is run under your current Apify account, therefore you need to be logged in by calling "apify login". It
   takes input for the actor from the default local key-value store by default.
 ```
 
@@ -410,7 +410,7 @@ ARGUMENTS
   ACTORNAME  Name of the actor. If not provided, you will be prompted for it.
 
 DESCRIPTION
-  The command only creates the "apify.json" file and the "storage" directory in the current directory, but will not 
+  The command only creates the ".actor/actor.json" file and the "storage" directory in the current directory, but will not
   touch anything else.
 
   WARNING: The directory at "storage" will be overwritten if it already exists.
@@ -430,7 +430,7 @@ OPTIONS
   -t, --token=token  [Optional] Apify API token
 
 DESCRIPTION
-  The API token and other account information is stored in the ~/.apify directory, from where it is read by all other 
+  The API token and other account information is stored in the ~/.apify directory, from where it is read by all other
   "apify" commands. To log out, call "apify logout".
 ```
 
@@ -461,24 +461,24 @@ USAGE
 
 ARGUMENTS
   ACTORID  ID of an existing actor on the Apify platform where the files will be pushed. If not provided, the command
-           will create or modify the actor with the name specified in "apify.json" file.
+           will create or modify the actor with the name specified in ".actor/actor.json" file.
 
 OPTIONS
   -b, --build-tag=build-tag              Build tag to be applied to the successful actor build. By default, it is taken
-                                         from the "apify.json" file
+                                         from the ".actor/actor.json" file
 
   -v, --version=version                  Actor version number to which the files should be pushed. By default, it is
-                                         taken from the "apify.json" file.
+                                         taken from the ".actor/actor.json" file.
 
   -w, --wait-for-finish=wait-for-finish  Seconds for waiting to build to finish, if no value passed, it waits forever.
 
   --version-number=version-number        DEPRECATED: Use flag version instead. Actor version number to which the files
-                                         should be pushed. By default, it is taken from the "apify.json" file.
+                                         should be pushed. By default, it is taken from the ".actor/actor.json" file.
 
 DESCRIPTION
-  The actor settings are read from the "apify.json" file in the current directory, but they can be overridden using 
+  The actor settings are read from the ".actor/actor.json" file in the current directory, but they can be overridden using
   command-line options.
-  NOTE: If the source files are smaller than 3 MB then they are uploaded as 
+  NOTE: If the source files are smaller than 3 MB then they are uploaded as
   "Multiple source files", otherwise they are uploaded as "Zip file".
 
   WARNING: If the target actor already exists in your Apify account, it will be overwritten!
@@ -510,7 +510,7 @@ DESCRIPTION
    example, this causes the actor input, as well as all other data in key-value stores, datasets or request queues to be
    stored in the "storage" directory, rather than on the Apify platform.
 
-  NOTE: You can override the default behaviour of command overriding npm start script value in a package.json file. You 
+  NOTE: You can override the default behaviour of command overriding npm start script value in a package.json file. You
   can set up your own main file or environment variables by changing it.
 ```
 
@@ -528,11 +528,12 @@ DESCRIPTION
   Example:
   $ apify secrets:add mySecret TopSecretValue123
 
-  Now the "mySecret" value can be used in an environment variable defined in "apify.json" file by adding the "@" prefix:
+  Now the "mySecret" value can be used in an environment variable defined in ".actor/actor.json" file by adding the "@" prefix:
 
   {
+    "actorSpecification": 1,
     "name": "my_actor",
-    "env": { "SECRET_ENV_VAR": "@mySecret" },
+    "environmentVariables": { "SECRET_ENV_VAR": "@mySecret" },
     "version": "0.1
   }
 

--- a/src/commands/call.js
+++ b/src/commands/call.js
@@ -123,7 +123,7 @@ CallCommand.args = [
         name: 'actId',
         required: false,
         description: 'Name or ID of the actor to run (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). '
-            + 'If not provided, the command runs the remote actor specified in the "apify.json" file.',
+            + 'If not provided, the command runs the remote actor specified in the ".actor/actor.json" file.',
     },
 ];
 

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -9,7 +9,7 @@ const { ApifyCommand } = require('../lib/apify_command');
 const execWithLog = require('../lib/exec');
 const outputs = require('../lib/outputs');
 const { updateLocalJson } = require('../lib/files');
-const { setLocalConfig, setLocalEnv, getNpmCmd, validateActorName } = require('../lib/utils');
+const { setLocalConfig, setLocalEnv, getNpmCmd, validateActorName, getLocalConfig } = require('../lib/utils');
 const { EMPTY_LOCAL_CONFIG } = require('../lib/consts');
 
 class CreateCommand extends ApifyCommand {
@@ -78,7 +78,9 @@ class CreateCommand extends ApifyCommand {
         const unzip = unzipper.Extract({ path: actFolderDir });
         await zipStream.pipe(unzip).promise();
 
-        await setLocalConfig(Object.assign(EMPTY_LOCAL_CONFIG, { name: actorName, template: templateName }), actFolderDir);
+        // There may be .actor/actor.json file in used template - let's try to load it and change the name prop value to actorName
+        const localConfig = await getLocalConfig();
+        await setLocalConfig(Object.assign(localConfig || EMPTY_LOCAL_CONFIG, { name: actorName }), actFolderDir);
         await setLocalEnv(actFolderDir);
         await updateLocalJson(path.join(actFolderDir, 'package.json'), { name: actorName });
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { ApifyCommand } = require('../lib/apify_command');
 const outputs = require('../lib/outputs');
 const { setLocalConfig, setLocalEnv, getLocalConfig } = require('../lib/utils');
-const { EMPTY_LOCAL_CONFIG, DEFAULT_LOCAL_STORAGE_DIR } = require('../lib/consts');
+const { EMPTY_LOCAL_CONFIG, DEFAULT_LOCAL_STORAGE_DIR, LOCAL_CONFIG_PATH } = require('../lib/consts');
 
 class InitCommand extends ApifyCommand {
     async run() {
@@ -12,7 +12,7 @@ class InitCommand extends ApifyCommand {
         const cwd = process.cwd();
 
         if (getLocalConfig()) {
-            outputs.warning('Skipping creation of apify.json, the file already exists in the current directory.');
+            outputs.warning('Skipping creation of .actor/actor.json, the file already exists in the current directory.');
         } else {
             if (!actorName) {
                 const answer = await inquirer.prompt([{ name: 'actName', message: 'Actor name:', default: path.basename(cwd) }]);
@@ -26,7 +26,7 @@ class InitCommand extends ApifyCommand {
 }
 
 InitCommand.description = 'Initializes a new actor project in an existing directory.\n'
-    + `The command only creates the "apify.json" file and the "${DEFAULT_LOCAL_STORAGE_DIR}" directory in the current directory, `
+    + `The command only creates the "${LOCAL_CONFIG_PATH}" file and the "${DEFAULT_LOCAL_STORAGE_DIR}" directory in the current directory, `
     + 'but will not touch anything else.\n\n'
     + `WARNING: The directory at "${DEFAULT_LOCAL_STORAGE_DIR}" will be overwritten if it already exists.`;
 

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -71,8 +71,8 @@ class RunCommand extends ApifyCommand {
         if (proxy && proxy.password) localEnvVars[ENV_VARS.PROXY_PASSWORD] = proxy.password;
         if (userId) localEnvVars[ENV_VARS.USER_ID] = userId;
         if (token) localEnvVars[ENV_VARS.TOKEN] = token;
-        if (localConfig.env) {
-            const updatedEnv = replaceSecretsValue(localConfig.env);
+        if (localConfig.environmentVariables) {
+            const updatedEnv = replaceSecretsValue(localConfig.environmentVariables);
             Object.assign(localEnvVars, updatedEnv);
         }
         // NOTE: User can overwrite env vars

--- a/src/lib/consts.js
+++ b/src/lib/consts.js
@@ -7,10 +7,11 @@ exports.DEFAULT_LOCAL_STORAGE_DIR = 'storage';
 exports.LEGACY_LOCAL_STORAGE_DIR = 'apify_storage';
 
 exports.EMPTY_LOCAL_CONFIG = {
+    actorSpecification: 1,
     name: null,
     version: '0.0',
     buildTag: 'latest',
-    env: null,
+    environmentVariables: {},
 };
 
 exports.GLOBAL_CONFIGS_FOLDER = path.join(os.homedir(), '.apify');
@@ -19,7 +20,13 @@ exports.AUTH_FILE_PATH = path.join(exports.GLOBAL_CONFIGS_FOLDER, 'auth.json');
 
 exports.SECRETS_FILE_PATH = path.join(exports.GLOBAL_CONFIGS_FOLDER, 'secrets.json');
 
-exports.LOCAL_CONFIG_NAME = 'apify.json';
+exports.DEPRECATED_LOCAL_CONFIG_NAME = 'apify.json';
+
+exports.ACTOR_SPECIFICATION_FOLDER = '.actor';
+
+exports.LOCAL_CONFIG_NAME = 'actor.json';
+
+exports.LOCAL_CONFIG_PATH = path.join(exports.ACTOR_SPECIFICATION_FOLDER, exports.LOCAL_CONFIG_NAME);
 
 exports.INPUT_FILE_REG_EXP = new RegExp(`^${KEY_VALUE_STORE_KEYS.INPUT}\\..*`);
 

--- a/test/commands/config.js
+++ b/test/commands/config.js
@@ -9,10 +9,12 @@ if (!TEST_USER_TOKEN) {
 
 exports.testUserClient = new ApifyClient({
     token: TEST_USER_TOKEN,
+    baseUrl: process.env.APIFY_CLIENT_BASE_URL,
 });
 
 exports.badUserClient = new ApifyClient({
     token: TEST_USER_BAD_TOKEN,
+    baseUrl: process.env.APIFY_CLIENT_BASE_URL,
 });
 
 exports.TEST_USER_TOKEN = TEST_USER_TOKEN;

--- a/test/commands/create.js
+++ b/test/commands/create.js
@@ -6,6 +6,7 @@ const path = require('path');
 const loadJson = require('load-json-file');
 const { rimrafPromised } = require('../../src/lib/files');
 const { getLocalKeyValueStorePath } = require('../../src/lib/utils');
+const { LOCAL_CONFIG_PATH } = require('../../src/lib/consts');
 
 const actName = 'my-act';
 const ACT_TEMPLATE = 'project_empty';
@@ -30,13 +31,18 @@ describe('apify create', () => {
         /* eslint-disable no-unused-expressions */
         await command.run(['create', actName, '--template', ACT_TEMPLATE]);
 
+        // Check that create command won't create the deprecated apify.json file
+        // TODO: we can remove this later
         const apifyJsonPath = path.join(actName, 'apify.json');
+        const actorJsonPath = path.join(actName, LOCAL_CONFIG_PATH);
+
         // check files structure
         expect(fs.existsSync(actName)).to.be.true;
         expect(fs.existsSync(path.join(actName, 'package.json'))).to.be.true;
-        expect(fs.existsSync(apifyJsonPath)).to.be.true;
+        expect(fs.existsSync(apifyJsonPath)).to.be.false;
+        expect(fs.existsSync(actorJsonPath)).to.be.true;
         expect(fs.existsSync(path.join(actName, getLocalKeyValueStorePath(), 'INPUT.json'))).to.be.true;
-        expect(loadJson.sync(apifyJsonPath).template).to.be.eql(ACT_TEMPLATE);
+        expect(loadJson.sync(actorJsonPath).name).to.be.eql(actName);
         expect(fs.existsSync('storage')).to.be.false;
     });
 

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const command = require('@oclif/command');
 const loadJson = require('load-json-file');
 const { rimrafPromised } = require('../../src/lib/files');
-const { EMPTY_LOCAL_CONFIG } = require('../../src/lib/consts');
+const { EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH } = require('../../src/lib/consts');
 
 const actName = 'my-act-init';
 
@@ -17,9 +17,12 @@ describe('apify init', () => {
     it('correctly creates basic structure', async () => {
         await command.run(['init', actName]);
 
+        // Check that it won't create deprecated config
+        // TODO: We can remove this later
         const apifyJsonPath = 'apify.json';
-        expect(fs.existsSync(apifyJsonPath)).to.be.eql(true);
-        expect(loadJson.sync(apifyJsonPath)).to.be.eql(Object.assign(EMPTY_LOCAL_CONFIG, { name: actName }));
+        expect(fs.existsSync(apifyJsonPath)).to.be.eql(false);
+
+        expect(loadJson.sync(LOCAL_CONFIG_PATH)).to.be.eql(Object.assign(EMPTY_LOCAL_CONFIG, { name: actName }));
     });
 
     after(async () => {

--- a/test/commands/run.js
+++ b/test/commands/run.js
@@ -5,7 +5,7 @@ const path = require('path');
 const writeJson = require('write-json-file');
 const loadJson = require('load-json-file');
 const { ENV_VARS } = require('@apify/consts');
-const { GLOBAL_CONFIGS_FOLDER, AUTH_FILE_PATH } = require('../../src/lib/consts');
+const { GLOBAL_CONFIGS_FOLDER, AUTH_FILE_PATH, LOCAL_CONFIG_PATH, EMPTY_LOCAL_CONFIG } = require('../../src/lib/consts');
 const { rimrafPromised } = require('../../src/lib/files');
 const { TEST_USER_TOKEN } = require('./config');
 const { getLocalKeyValueStorePath, getLocalDatasetPath, getLocalRequestQueuePath, getLocalStorageDir } = require('../../src/lib/utils');
@@ -48,7 +48,7 @@ describe('apify run', () => {
         expect(actOutput).to.be.eql(expectOutput);
     });
 
-    it('run with env vars from apify.json', async () => {
+    it('run with env vars from .actor/actor.json', async () => {
         const testEnvVars = {
             TEST_LOCAL: 'testValue',
         };
@@ -64,9 +64,9 @@ describe('apify run', () => {
         });
         `;
         fs.writeFileSync('main.js', actCode, { flag: 'w' });
-        const apifyJson = loadJson.sync('apify.json');
-        apifyJson.env = testEnvVars;
-        writeJson.sync('apify.json', apifyJson);
+        const apifyJson = EMPTY_LOCAL_CONFIG;
+        apifyJson.environmentVariables = testEnvVars;
+        writeJson.sync(LOCAL_CONFIG_PATH, apifyJson);
 
         await command.run(['run']);
 


### PR DESCRIPTION
This adds support for actor specification in `.actor/actor.json` file. It should migrate existing `apify.json` file into `.actor/actor.json`.

I've also updated the README.md

As some of the features I've needed to test were not in prod console/worker - I've added support for `process.env.APIFY_CLIENT_BASE_URL`. With that it's possible to run tests against localhost/staging. I've kept in in PR, can remove it... 

closes #289 