### PR TITLE
Abstract reading input schema

### DIFF
--- a/src/commands/edit-input-schema.js
+++ b/src/commands/edit-input-schema.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 const cors = require('cors');
 const detectIndent = require('detect-indent');
@@ -83,8 +84,8 @@ class EditInputSchemaCommand extends ApifyCommand {
         apiRouter.get('/input-schema', (req, res) => {
             let inputSchemaStr;
             try {
-                inputSchemaStr = fs.existsSync(inputSchemaPath) ? fs.readFileSync(inputSchemaPath, { encoding: 'utf-8' }) : '{}';
-                if (inputSchemaStr.length > 2) {
+                inputSchemaStr = fs.existsSync(inputSchemaPath) ? fs.readFileSync(inputSchemaPath, { encoding: 'utf-8' }) : '{}\n';
+                if (inputSchemaStr.length > 3) {
                     jsonIndentation = detectIndent(inputSchemaStr).indent || jsonIndentation;
                 }
                 if (inputSchemaStr) {
@@ -93,7 +94,7 @@ class EditInputSchemaCommand extends ApifyCommand {
                 if (fs.existsSync(inputSchemaPath)) {
                     outputs.info(`Input schema loaded from "${inputSchemaPath}"`);
                 } else {
-                    outputs.info(`Empty input schema created at ${inputSchemaPath}.`);
+                    outputs.info(`Empty input schema initialized.`);
                 }
             } catch (err) {
                 const errorMessage = `Reading input schema from disk failed with: ${err.message}`;
@@ -124,6 +125,12 @@ class EditInputSchemaCommand extends ApifyCommand {
                 const inputSchemaObj = req.body;
                 let inputSchemaStr = JSON.stringify(inputSchemaObj, null, jsonIndentation);
                 if (appendFinalNewline) inputSchemaStr += '\n';
+
+                const inputSchemaDir = path.dirname(inputSchemaPath);
+                if (!fs.existsSync(inputSchemaDir)) {
+                    fs.mkdirSync(inputSchemaDir, { recursive: true });
+                }
+
                 fs.writeFileSync(inputSchemaPath, inputSchemaStr, { encoding: 'utf-8', flag: 'w+' });
                 res.end();
                 outputs.info('Input schema saved to disk.');

--- a/src/commands/edit-input-schema.js
+++ b/src/commands/edit-input-schema.js
@@ -22,9 +22,9 @@ class EditInputSchemaCommand extends ApifyCommand {
         const { args } = this.parse(EditInputSchemaCommand);
 
         // This call fails if no input schema is found on any of the default locations
-        const { path } = await readInputSchema(args.path);
+        const { schema: existingSchema, path } = await readInputSchema(args.path);
 
-        if (!path) {
+        if (existingSchema && !path) {
             // If path is not returned, it means the input schema must be directly embedded as object in actor.json
             throw new Error('Cannot edit an input schema directly embedded in .actor/actor.json at this time. Please, submit a feature request!');
         }

--- a/src/commands/edit-input-schema.js
+++ b/src/commands/edit-input-schema.js
@@ -9,7 +9,7 @@ const { cryptoRandomObjectId } = require('@apify/utilities');
 
 const { ApifyCommand } = require('../lib/apify_command');
 const outputs = require('../lib/outputs');
-const { readInputSchema, DEFAULT_INPUT_SCHEMA_PATHS } = require('../lib/input_schema');
+const { readInputSchema } = require('../lib/input_schema');
 
 const INPUT_SCHEMA_EDITOR_BASE_URL = 'https://apify.github.io/input-schema-editor-react/';
 const INPUT_SCHEMA_EDITOR_ORIGIN = new URL(INPUT_SCHEMA_EDITOR_BASE_URL).origin;
@@ -20,20 +20,13 @@ const API_VERSION = 'v1';
 class EditInputSchemaCommand extends ApifyCommand {
     async run() {
         const { args } = this.parse(EditInputSchemaCommand);
-        let path = null;
 
-        // This call fails if the input schema is invalid JSON
-        const inputSchemaWithPath = await readInputSchema(args.path);
+        // This call fails if no input schema is found on any of the default locations
+        const { path } = await readInputSchema(args.path);
 
-        if (!inputSchemaWithPath) {
-            outputs.warning('Input schema has not been found. Default one will be created.');
-            fs.writeFileSync(DEFAULT_INPUT_SCHEMA_PATHS[0], '{}');
-            path = DEFAULT_INPUT_SCHEMA_PATHS[0];
-        } else if (!inputSchemaWithPath.path) {
-            // If path is not returned in inputSchemaWithPath, it means the input schema must be directly embedded as object in actor.json
+        if (!path) {
+            // If path is not returned, it means the input schema must be directly embedded as object in actor.json
             throw new Error('Cannot edit an input schema directly embedded in .actor/actor.json at this time. Please, submit a feature request!');
-        } else {
-            path = inputSchemaWithPath.path;
         }
 
         outputs.warning('This command is still experimental and might break at any time. Use at your own risk.\n');

--- a/src/commands/vis.js
+++ b/src/commands/vis.js
@@ -9,7 +9,13 @@ class ValidateInputSchemaCommand extends ApifyCommand {
     async run() {
         const { args } = this.parse(ValidateInputSchemaCommand);
 
-        const { schema: inputSchema } = await readInputSchema(args.path);
+        const inputSchemaWithPath = await readInputSchema(args.path);
+
+        if (!inputSchemaWithPath) {
+            throw new Error('Input schema has not been found.');
+        }
+
+        const { schema: inputSchema } = inputSchemaWithPath;
 
         if (_.isEmpty(inputSchema)) {
             throw new Error('Input schema is empty.');

--- a/src/commands/vis.js
+++ b/src/commands/vis.js
@@ -9,13 +9,7 @@ class ValidateInputSchemaCommand extends ApifyCommand {
     async run() {
         const { args } = this.parse(ValidateInputSchemaCommand);
 
-        const inputSchemaWithPath = await readInputSchema(args.path);
-
-        if (!inputSchemaWithPath) {
-            throw new Error('Input schema has not been found.');
-        }
-
-        const { schema: inputSchema } = inputSchemaWithPath;
+        const { schema: inputSchema } = await readInputSchema(args.path);
 
         if (_.isEmpty(inputSchema)) {
             throw new Error('Input schema is empty.');

--- a/src/commands/vis.js
+++ b/src/commands/vis.js
@@ -1,70 +1,23 @@
+const _ = require('underscore');
 const { validateInputSchema } = require('@apify/input_schema');
 const Ajv = require('ajv');
-const fs = require('fs');
-const path = require('path');
 const { ApifyCommand } = require('../lib/apify_command');
-const { ACTOR_SPECIFICATION_FOLDER } = require('../lib/consts');
+const { readInputSchema } = require('../lib/input_schema');
 const outputs = require('../lib/outputs');
-const { getLocalConfig } = require('../lib/utils');
-
-const DEFAULT_INPUT_SCHEMA_PATHS = [
-    '.actor/INPUT_SCHEMA.json',
-    './INPUT_SCHEMA.json',
-];
 
 class ValidateInputSchemaCommand extends ApifyCommand {
-    validateInputSchemaObject(inputSchema) {
-        const validator = new Ajv({ strict: false });
-        validateInputSchema(validator, inputSchema); // This one throws an error in a case of invalid schema.
-        outputs.success('Input schema is valid.');
-    }
-
-    readAndValidateInputSchemaOnPath(inputSchemaPath) {
-        outputs.info(`Validating input schema stored at ${inputSchemaPath}`);
-        if (!fs.existsSync(inputSchemaPath)) {
-            throw new Error(`Input schema has not been found at ${inputSchemaPath}.`);
-        }
-        try {
-            const inputSchema = JSON.parse(fs.readFileSync(inputSchemaPath).toString());
-            this.validateInputSchemaObject(inputSchema);
-        } catch (err) {
-            throw new Error(`Input schema is not a valid JSON (${err})`);
-        }
-    }
-
     async run() {
         const { args } = this.parse(ValidateInputSchemaCommand);
 
-        if (args.path) {
-            this.readAndValidateInputSchemaOnPath(args.path);
-            return;
+        const { schema: inputSchema } = await readInputSchema(args.path);
+
+        if (_.isEmpty(inputSchema)) {
+            throw new Error('Input schema is empty.');
         }
 
-        const localConfig = getLocalConfig();
-
-        if (typeof localConfig?.input === 'object') {
-            outputs.info('Validating input schema directly embedded in .actor/actor.json');
-            this.validateInputSchemaObject(localConfig.input);
-            return;
-        }
-
-        if (typeof localConfig?.input === 'string') {
-            outputs.info(`Found path to input schema (${localConfig?.input}) in .actor/actor.json`);
-            this.readAndValidateInputSchemaOnPath(path.join(ACTOR_SPECIFICATION_FOLDER, localConfig.input));
-            return;
-        }
-
-        if (fs.existsSync(DEFAULT_INPUT_SCHEMA_PATHS[0])) {
-            this.readAndValidateInputSchemaOnPath(DEFAULT_INPUT_SCHEMA_PATHS[0]);
-            return;
-        }
-
-        if (fs.existsSync(DEFAULT_INPUT_SCHEMA_PATHS[1])) {
-            this.readAndValidateInputSchemaOnPath(DEFAULT_INPUT_SCHEMA_PATHS[1]);
-            return;
-        }
-
-        throw new Error('No input schema found.');
+        const validator = new Ajv({ strict: false });
+        validateInputSchema(validator, inputSchema); // This one throws an error in a case of invalid schema.
+        outputs.success('Input schema is valid.');
     }
 }
 

--- a/src/commands/vis.js
+++ b/src/commands/vis.js
@@ -1,4 +1,3 @@
-const _ = require('underscore');
 const { validateInputSchema } = require('@apify/input_schema');
 const Ajv = require('ajv');
 const { ApifyCommand } = require('../lib/apify_command');
@@ -9,10 +8,16 @@ class ValidateInputSchemaCommand extends ApifyCommand {
     async run() {
         const { args } = this.parse(ValidateInputSchemaCommand);
 
-        const { schema: inputSchema } = await readInputSchema(args.path);
+        const { inputSchema, inputSchemaPath } = await readInputSchema(args.path);
 
-        if (_.isEmpty(inputSchema)) {
-            throw new Error('Input schema is empty.');
+        if (!inputSchema) {
+            throw new Error(`Input schema has not been found at ${inputSchemaPath}.`);
+        }
+
+        if (inputSchemaPath) {
+            outputs.info(`Validating input schema stored at ${inputSchemaPath}`);
+        } else {
+            outputs.info(`Validating input schema embedded in .actor/actor.json`);
         }
 
         const validator = new Ajv({ strict: false });

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -27,7 +27,7 @@ const readInputSchemaOnPath = async (inputSchemaPath) => {
  * If the returned path is "null", the input schema is directly embedded in actor.json.
  *
  * @param {string} forcePath
- * @returns {{schema: object, path: string | null} | null}
+ * @returns {{schema: object, path: string | null}}
  */
 const readInputSchema = async (forcePath) => {
     if (forcePath) {
@@ -70,10 +70,9 @@ const readInputSchema = async (forcePath) => {
         };
     }
 
-    return null;
+    throw new Error('Input schema has not been found.');
 };
 
 module.exports = {
     readInputSchema,
-    DEFAULT_INPUT_SCHEMA_PATHS,
 };

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const { ACTOR_SPECIFICATION_FOLDER } = require('./consts');
+const outputs = require('./outputs');
+const { getLocalConfig } = require('./utils');
+
+const DEFAULT_INPUT_SCHEMA_PATHS = [
+    '.actor/INPUT_SCHEMA.json',
+    './INPUT_SCHEMA.json',
+];
+
+const readInputSchemaOnPath = async (inputSchemaPath) => {
+    outputs.info(`Reading input schema stored at ${inputSchemaPath}`);
+    if (!fs.existsSync(inputSchemaPath)) {
+        throw new Error(`Input schema has not been found at ${inputSchemaPath}.`);
+    }
+    try {
+        const inputSchema = JSON.parse(fs.readFileSync(inputSchemaPath).toString());
+        return inputSchema;
+    } catch (err) {
+        throw new Error(`Input schema is not a valid JSON (${err})`);
+    }
+};
+
+/**
+ * Reads and returns the input schema from the default location. If no input schema is found, the function throws.
+ * If the returned path is "null", the input schema is directly embedded in actor.json.
+ *
+ * @param {string} forcePath
+ * @returns {{schema: object, path: string | null}}
+ */
+const readInputSchema = async (forcePath) => {
+    if (forcePath) {
+        return {
+            schema: await readInputSchemaOnPath(forcePath),
+            path,
+        };
+    }
+
+    const localConfig = getLocalConfig();
+
+    if (typeof localConfig?.input === 'object') {
+        outputs.info('Note: Input schema is directly embedded in .actor/actor.json');
+        return {
+            schema: localConfig.input,
+            path: null,
+        };
+    }
+
+    if (typeof localConfig?.input === 'string') {
+        outputs.info('Note: Input schema is explicitly referenced in .actor/actor.json');
+        const fullPath = path.join(ACTOR_SPECIFICATION_FOLDER, localConfig.input);
+        return {
+            schema: await readInputSchemaOnPath(fullPath),
+            path: fullPath,
+        };
+    }
+
+    if (fs.existsSync(DEFAULT_INPUT_SCHEMA_PATHS[0])) {
+        return {
+            schema: await readInputSchemaOnPath(DEFAULT_INPUT_SCHEMA_PATHS[0]),
+            path: DEFAULT_INPUT_SCHEMA_PATHS[0],
+        };
+    }
+
+    if (fs.existsSync(DEFAULT_INPUT_SCHEMA_PATHS[1])) {
+        return {
+            schema: await readInputSchemaOnPath(DEFAULT_INPUT_SCHEMA_PATHS[1]),
+            path: DEFAULT_INPUT_SCHEMA_PATHS[1],
+        };
+    }
+
+    throw new Error('Input schema has not been found.');
+};
+
+module.exports = {
+    readInputSchema,
+};

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -1,20 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const { ACTOR_SPECIFICATION_FOLDER } = require('./consts');
-const outputs = require('./outputs');
 const { getLocalConfig, getJsonFileContent } = require('./utils');
 
 const DEFAULT_INPUT_SCHEMA_PATHS = [
     '.actor/INPUT_SCHEMA.json',
     './INPUT_SCHEMA.json',
 ];
-
-const readInputSchemaOnPath = async (inputSchemaPath) => {
-    if (!fs.existsSync(inputSchemaPath)) {
-        return null;
-    }
-    return getJsonFileContent(inputSchemaPath);
-};
 
 /**
  * Return the input schema from the default location.
@@ -29,7 +21,7 @@ const readInputSchemaOnPath = async (inputSchemaPath) => {
 const readInputSchema = async (forcePath) => {
     if (forcePath) {
         return {
-            inputSchema: await readInputSchemaOnPath(forcePath),
+            inputSchema: await getJsonFileContent(forcePath),
             inputSchemaPath: forcePath,
         };
     }
@@ -46,21 +38,21 @@ const readInputSchema = async (forcePath) => {
     if (typeof localConfig?.input === 'string') {
         const fullPath = path.join(ACTOR_SPECIFICATION_FOLDER, localConfig.input);
         return {
-            inputSchema: await readInputSchemaOnPath(fullPath),
+            inputSchema: await getJsonFileContent(fullPath),
             inputSchemaPath: fullPath,
         };
     }
 
     if (fs.existsSync(DEFAULT_INPUT_SCHEMA_PATHS[0])) {
         return {
-            inputSchema: await readInputSchemaOnPath(DEFAULT_INPUT_SCHEMA_PATHS[0]),
+            inputSchema: await getJsonFileContent(DEFAULT_INPUT_SCHEMA_PATHS[0]),
             inputSchemaPath: DEFAULT_INPUT_SCHEMA_PATHS[0],
         };
     }
 
     if (fs.existsSync(DEFAULT_INPUT_SCHEMA_PATHS[1])) {
         return {
-            inputSchema: await readInputSchemaOnPath(DEFAULT_INPUT_SCHEMA_PATHS[1]),
+            inputSchema: await getJsonFileContent(DEFAULT_INPUT_SCHEMA_PATHS[1]),
             inputSchemaPath: DEFAULT_INPUT_SCHEMA_PATHS[1],
         };
     }

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -27,7 +27,7 @@ const readInputSchemaOnPath = async (inputSchemaPath) => {
  * If the returned path is "null", the input schema is directly embedded in actor.json.
  *
  * @param {string} forcePath
- * @returns {{schema: object, path: string | null}}
+ * @returns {{schema: object, path: string | null} | null}
  */
 const readInputSchema = async (forcePath) => {
     if (forcePath) {
@@ -70,9 +70,10 @@ const readInputSchema = async (forcePath) => {
         };
     }
 
-    throw new Error('Input schema has not been found.');
+    return null;
 };
 
 module.exports = {
     readInputSchema,
+    DEFAULT_INPUT_SCHEMA_PATHS,
 };

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { ACTOR_SPECIFICATION_FOLDER } = require('./consts');
 const outputs = require('./outputs');
-const { getLocalConfig } = require('./utils');
+const { getLocalConfig, getJsonFileContent } = require('./utils');
 
 const DEFAULT_INPUT_SCHEMA_PATHS = [
     '.actor/INPUT_SCHEMA.json',
@@ -14,12 +14,7 @@ const readInputSchemaOnPath = async (inputSchemaPath) => {
     if (!fs.existsSync(inputSchemaPath)) {
         throw new Error(`Input schema has not been found at ${inputSchemaPath}.`);
     }
-    try {
-        const inputSchema = JSON.parse(fs.readFileSync(inputSchemaPath).toString());
-        return inputSchema;
-    } catch (err) {
-        throw new Error(`Input schema is not a valid JSON (${err})`);
-    }
+    return getJsonFileContent(inputSchemaPath);
 };
 
 /**


### PR DESCRIPTION
This PR generalizes the way we read input schema so it is usable both in `vis` command and in the hidden `edit-input-schema` command.