### PR TITLE
chore: Disable actor template prompt looping around

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -51,6 +51,8 @@ class CreateCommand extends ApifyCommand {
                 message: 'Please select the template for your new actor',
                 default: choices[0],
                 choices,
+                loop: false,
+                pageSize: 8, // Due to the answers wrapping, the prompt looks best if the `pageSize` is a multiple of 2
             }]);
             templateName = answer.template;
         }


### PR DESCRIPTION
When the actor prompt was looping around, it was a bit unintuitive to see that you've seen all possible templates, plus when some templates were wrapping, it was displaying a fragment of the wrapped template right under the question, making it look weird.

This disables the prompt looping, making it behave a bit better in general.

