### PR TITLE
Prepare for release on Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,3 +114,11 @@ jobs:
           git_tag=v`node -p "require('./package.json').version"`
           git tag $git_tag
           git push origin $git_tag
+      -
+        name: Update Homebrew formula in homebrew-tap repo
+        if: env.RELEASE_TAG == 'latest'
+        run: |
+          PACKAGE_VERSION=`node -p "require('./package.json').version"`
+          gh workflow run update_formula.yaml --repo apify/homebrew-tap --field package=apify-cli --field version=$PACKAGE_VERSION
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_WORKFLOW_CALL_GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ However, we recommend using JavaScript / Node.js, for which we provide most libr
 
 ## Installation
 
+### Via Homebrew
+
+On macOS (or Linux), you can install the Apify CLI via the [Homebrew package manager](https://brew.sh).
+
+```bash
+brew install apify/tap/apify-cli
+```
+
+### Via NPM
+
 First, make sure you have [Node.js](https://nodejs.org) version 16 or higher with NPM installed on your computer:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,6 +3,16 @@ sidebar_label: Installation
 title: Installation
 ---
 
+## Via Homebrew
+
+On macOS (or Linux), you can install the Apify CLI via the [Homebrew package manager](https://brew.sh).
+
+```bash
+brew install apify/tap/apify-cli
+```
+
+## Via NPM
+
 First, make sure you have [Node.js](https://nodejs.org) version 16 or higher with NPM installed on your computer:
 
 ```bash


### PR DESCRIPTION
This:
- updates the docs to mention the possibility of installing the CLI via Homebrew
- calls the workflow to update the CLI version in the Homebrew formula in the `apify/homebrew-tap` repo once the new latest version is published