### PR TITLE
Use correct "omit optional dependencies" argument based on NPM version

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -18,6 +18,7 @@ const {
     getPythonCommand,
     detectNodeVersion,
     isNodeVersionSupported,
+    detectNpmVersion,
 } = require('../lib/utils');
 const { EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH, PYTHON_VENV_PATH, SUPPORTED_NODEJS_VERSION } = require('../lib/consts');
 const { httpsGet, ensureValidActorName, getTemplateDefinition } = require('../lib/create-utils');
@@ -91,7 +92,14 @@ class CreateCommand extends ApifyCommand {
                     // Run npm install in actor dir.
                     // For efficiency, don't install Puppeteer for templates that don't use it
                     const cmdArgs = ['install'];
-                    if (skipOptionalDeps) cmdArgs.push('--no-optional');
+                    if (skipOptionalDeps) {
+                        const currentNpmVersion = detectNpmVersion();
+                        if (semver.gte(currentNpmVersion, '7.0.0')) {
+                            cmdArgs.push('--omit=optional');
+                        } else {
+                            cmdArgs.push('--no-optional');
+                        }
+                    }
                     await execWithLog(getNpmCmd(), cmdArgs, { cwd: actFolderDir });
                     dependenciesInstalled = true;
                 } else {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -551,6 +551,18 @@ const isNodeVersionSupported = (installedNodeVersion) => {
     return semver.gte(installedNodeVersion, minimumSupportedNodeVersion);
 };
 
+const detectNpmVersion = () => {
+    const npmCommand = getNpmCmd();
+    try {
+        const spawnResult = spawnSync(npmCommand, ['--version'], { encoding: 'utf-8' });
+        if (!spawnResult.error && spawnResult.stdout) {
+            return spawnResult.stdout.trim().replace(/^v/, '');
+        }
+    } catch {
+        return undefined;
+    }
+};
+
 module.exports = {
     getLoggedClientOrThrow,
     getLocalConfig,
@@ -583,4 +595,5 @@ module.exports = {
     getPythonCommand,
     detectNodeVersion,
     isNodeVersionSupported,
+    detectNpmVersion,
 };


### PR DESCRIPTION
NPM 7 deprecated the `--no-optional` argument and started recommending `--omit=optional` instead. This detects which NPM version is used, and uses the correct argument, so that this deprecation warning is not shown anymore:

<img width="610" alt="Screenshot 2023-03-09 at 13 00 48" src="https://user-images.githubusercontent.com/2934111/224017103-d72c8a9b-ce58-4035-b5a6-568f955f8d8c.png">
