### PR TITLE
feat: Add a post-create message to Python actors

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -46,8 +46,9 @@ class CreateCommand extends ApifyCommand {
             });
 
         actorName = await ensureValidActorName(actorName);
+        let messages = null;
         if (manifestPromise) {
-            ({ archiveUrl: templateArchiveUrl, skipOptionalDeps } = await getTemplateDefinition(templateName, manifestPromise));
+            ({ archiveUrl: templateArchiveUrl, skipOptionalDeps, messages } = await getTemplateDefinition(templateName, manifestPromise));
         }
 
         const cwd = process.cwd();
@@ -143,6 +144,9 @@ class CreateCommand extends ApifyCommand {
 
         if (dependenciesInstalled) {
             outputs.success(`Actor '${actorName}' was created. To run it, run "cd ${actorName}" and "apify run".`);
+            if (messages?.postCreate) {
+                outputs.info(messages?.postCreate);
+            }
         } else {
             outputs.success(`Actor '${actorName}' was created. Please install its dependencies to be able to run it using "apify run".`);
         }


### PR DESCRIPTION
Python actors require some post-create instructions:
- how to add additonal dependencies
- how to install Playwright and its browsers

This PR adds an option to have a post-create message in the template definition, and to show it after you run `apify create` with a specific template.

The accompanying PR in actor-templates is here: https://github.com/apify/actor-templates/pull/135