### PR TITLE
Improve log messages for different build statuses

### DIFF
--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -156,8 +156,12 @@ class PushCommand extends ApifyCommand {
 
         if (build.status === ACT_JOB_STATUSES.SUCCEEDED) {
             outputs.success('Actor was deployed to Apify cloud and built there.');
-        } else if (build.status === ACT_JOB_STATUSES.RUNNING) {
+        } else if (build.status === ACT_JOB_STATUSES.RUNNING || build.status === ACT_JOB_STATUSES.READY) {
             outputs.warning('Build is still running!');
+        } else if (build.status === ACT_JOB_STATUSES.ABORTED || build.status === ACT_JOB_STATUSES.ABORTING) {
+            outputs.warning('Build was aborted!');
+        } else if (build.status === ACT_JOB_STATUSES.TIMED_OUT || build.status === ACT_JOB_STATUSES.TIMING_OUT) {
+            outputs.warning('Build timed out!');
         } else {
             outputs.error('Build failed!');
         }

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -156,8 +156,10 @@ class PushCommand extends ApifyCommand {
 
         if (build.status === ACT_JOB_STATUSES.SUCCEEDED) {
             outputs.success('Actor was deployed to Apify cloud and built there.');
-        } else if (build.status === ACT_JOB_STATUSES.RUNNING || build.status === ACT_JOB_STATUSES.READY) {
-            outputs.warning('Build is still running!');
+        } else if (build.status === ACT_JOB_STATUSES.READY) {
+            outputs.warning('Build is waiting for allocation.');
+        } else if (build.status === ACT_JOB_STATUSES.RUNNING) {
+            outputs.warning('Build is still running.');
         } else if (build.status === ACT_JOB_STATUSES.ABORTED || build.status === ACT_JOB_STATUSES.ABORTING) {
             outputs.warning('Build was aborted!');
         } else if (build.status === ACT_JOB_STATUSES.TIMED_OUT || build.status === ACT_JOB_STATUSES.TIMING_OUT) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -385,7 +385,7 @@ const purgeDefaultKeyValueStore = async () => {
     await Promise.all(deletePromises);
 };
 
-const outputJobLog = async (job, jobStatus, timeout) => {
+const outputJobLog = async (job, timeout) => {
     const { id: logId, status } = job;
     // In case job was already done just output log
     if (ACT_JOB_TERMINAL_STATUSES.includes(status)) {


### PR DESCRIPTION
Fixes https://github.com/apify/apify-core/issues/9403.

There was a bug that someone started a build from the CLI, the build spent too long in status `READY`, and the CLI logged "Build failed!" because the "is build running" condition didn't check for `READY`, just `RUNNING`.

This fixes it and improves the messages for each status we have.