### PR TITLE
feat(app): Open actor detail after successful apify push

### DIFF
--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -3,6 +3,8 @@ const { flags: flagsHelper } = require('@oclif/command');
 const actorTemplates = require('@apify/actor-templates');
 const { ACT_JOB_STATUSES, ACT_SOURCE_TYPES,
     MAX_MULTIFILE_BYTES } = require('@apify/consts');
+const open = require('open');
+const inquirer = require('inquirer');
 const { ApifyCommand } = require('../lib/apify_command');
 const { createActZip, getLoggedClientOrThrow,
     outputJobLog, getLocalUserInfo, getActorLocalFilePaths,
@@ -153,6 +155,14 @@ class PushCommand extends ApifyCommand {
         build = await apifyClient.build(build.id).get();
 
         outputs.link('Actor build detail', `https://console.apify.com/actors/${build.actId}#/builds/${build.buildNumber}`);
+
+        const shouldOpenBrowser = await inquirer.prompt([
+            { type: 'confirm', name: 'continue', message: 'Do you want to open build detail in your browser?', default: true },
+        ]);
+
+        if (shouldOpenBrowser.continue) {
+            open(`https://console.apify.com/actors/${build.actId}`);
+        }
 
         if (build.status === ACT_JOB_STATUSES.SUCCEEDED) {
             outputs.success('Actor was deployed to Apify cloud and built there.');

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -157,7 +157,7 @@ class PushCommand extends ApifyCommand {
         outputs.link('Actor build detail', `https://console.apify.com/actors/${build.actId}#/builds/${build.buildNumber}`);
 
         const shouldOpenBrowser = await inquirer.prompt([
-            { type: 'confirm', name: 'continue', message: 'Do you want to open build detail in your browser?', default: true },
+            { type: 'confirm', name: 'continue', message: 'Do you want to open the actor detail in your browser?', default: true },
         ]);
 
         if (shouldOpenBrowser.continue) {

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -34,6 +34,8 @@ class PushCommand extends ApifyCommand {
         const apifyClient = await getLoggedClientOrThrow();
         const localConfig = await getLocalConfigOrThrow();
         const userInfo = await getLocalUserInfo();
+        const isOrganizationLoggedIn = !!userInfo.organizationOwnerUserId;
+        const redirectUrlPart = isOrganizationLoggedIn ? `/organization/${userInfo.id}` : '';
 
         let actorId;
         let actor;
@@ -154,14 +156,14 @@ class PushCommand extends ApifyCommand {
 
         build = await apifyClient.build(build.id).get();
 
-        outputs.link('Actor build detail', `https://console.apify.com/actors/${build.actId}#/builds/${build.buildNumber}`);
+        outputs.link('Actor build detail', `https://console.apify.com${redirectUrlPart}/actors/${build.actId}#/builds/${build.buildNumber}`);
 
         const shouldOpenBrowser = await inquirer.prompt([
             { type: 'confirm', name: 'continue', message: 'Do you want to open the actor detail in your browser?', default: true },
         ]);
 
         if (shouldOpenBrowser.continue) {
-            open(`https://console.apify.com/actors/${build.actId}`);
+            open(`https://console.apify.com${redirectUrlPart}/actors/${build.actId}`);
         }
 
         if (build.status === ACT_JOB_STATUSES.SUCCEEDED) {


### PR DESCRIPTION
Prompting user if want to open actor detail in browser after push

@dodaniel Feel free to update/suggest copy. Also, it can't be redirected to `actor source` as there's possibility to redirect to already created actor (which may be connected to git repository).