### PR TITLE
feat: Improve `apify login-new` command

### DIFF
--- a/src/commands/login-new.js
+++ b/src/commands/login-new.js
@@ -100,7 +100,6 @@ class LoginNewCommand extends ApifyCommand {
             apiRouter.post('/login-token', async (req, res) => {
                 try {
                     if (req.body.apiToken) {
-                        // outputs.info('Got token from console...');
                         await tryToLogin(req.body.apiToken);
                     } else {
                         throw new Error('Request did not contain API token');
@@ -131,7 +130,6 @@ class LoginNewCommand extends ApifyCommand {
             // Listening on port 0 will assign a random available port
             server = app.listen(0);
             const { port } = server.address();
-            // outputs.info(`Waiting for token from Apify console (on port ${port})...`);
 
             const consoleUrl = new URL(CONSOLE_BASE_URL);
             consoleUrl.searchParams.set('localCliCommand', 'login');
@@ -140,7 +138,7 @@ class LoginNewCommand extends ApifyCommand {
             consoleUrl.searchParams.set('localCliApiVersion', API_VERSION);
             try {
                 consoleUrl.searchParams.set('localCliComputerName', encodeURIComponent(computerName()));
-            } catch (err) {
+            } catch {
                 // Ignore errors from fetching computer name as it's not critical
             }
 

--- a/src/commands/login-new.js
+++ b/src/commands/login-new.js
@@ -47,7 +47,7 @@ class LoginNewCommand extends ApifyCommand {
             name: 'loginMethod',
             message: 'Choose how you want to log in to Apify',
             choices: [
-                { value: 'console', name: 'Log in through Apify Console in your default browser', short: 'Through Apify Console' },
+                { value: 'console', name: 'Through Apify Console in your default browser', short: 'Through Apify Console' },
                 { value: 'manual', name: 'Enter API token manually', short: 'Manually' },
             ],
             loop: false,


### PR DESCRIPTION
I made a few small improvements to the `apify login-new` command:
- you can now choose right away whether you want to login through Console or by pasting the token
	- this was based on internal feedback that people don't like browsers opening out of the blue
	- it makes the prompt a bit more readable
	- it works better if you use the CLI in Docker for example, where you don't have a browser installed
- I wrapped the `computerName()` call in a try/catch
	- so that the CLI doesn't crash when you don't have `/usr/sbin` in $PATH on `macOS` (happens sometimes)
- I removed some debug logs to clean up the output

<img width="672" alt="Screenshot 2023-04-17 at 16 02 08" src="https://user-images.githubusercontent.com/2934111/232507470-9a532a18-a0e5-4fbf-a3ea-a06c288bb70a.png">
 CC @mvolfik 