### PR TITLE
fix: use new library for extracting archives

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,6 +20,7 @@
                 "@oclif/errors": "^1.3.5",
                 "@oclif/plugin-commands": "^2.1.0",
                 "@oclif/plugin-help": "^5.1.12",
+                "adm-zip": "^0.5.10",
                 "ajv": "^8.10.0",
                 "apify-client": "^2.2.0",
                 "archiver-promise": "^1.0.0",
@@ -41,7 +42,6 @@
                 "rimraf": "^3.0.2",
                 "semver": "^7.3.5",
                 "underscore": "^1.13.2",
-                "unzipper": "^0.10.11",
                 "write-json-file": "^4.3.0"
             },
             "bin": {
@@ -1393,26 +1393,6 @@
                 }
             ]
         },
-        "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/binary": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dependencies": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1441,11 +1421,6 @@
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "node_modules/bluebird": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
         },
         "node_modules/body-parser": {
             "version": "1.20.1",
@@ -1599,22 +1574,6 @@
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
         },
-        "node_modules/buffer-indexof-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "engines": {
-                "node": ">=0.2.0"
-            }
-        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1744,17 +1703,6 @@
             "resolved": "https://registry.npmjs.org/chai-match/-/chai-match-1.1.1.tgz",
             "integrity": "sha512-gea2rl5SgzF11CopH4yCmFTmPCXSN+e2GSJL33SfM+/WPP/cDk1tmrc0GDU2JRiFVJUJel/2zaNkNfyJKN7CtA==",
             "dev": true
-        },
-        "node_modules/chainsaw": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dependencies": {
-                "traverse": ">=0.3.0 <0.4"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2464,14 +2412,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-        },
-        "node_modules/duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dependencies": {
-                "readable-stream": "^2.0.2"
-            }
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -3699,31 +3639,6 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            },
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/fstream/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
             }
         },
         "node_modules/function-bind": {
@@ -5115,11 +5030,6 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
         },
-        "node_modules/listenercount": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
-        },
         "node_modules/load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -5367,19 +5277,9 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
             "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
             }
         },
         "node_modules/mkdirp-classic": {
@@ -7026,11 +6926,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/setimmediate": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-        },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -7519,14 +7414,6 @@
                 "node": ">=0.6"
             }
         },
-        "node_modules/traverse": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -7677,23 +7564,6 @@
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dependencies": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
-                "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
-                "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -9077,20 +8947,6 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
-        "big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
-        },
-        "binary": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "requires": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
-            }
-        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -9110,11 +8966,6 @@
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "bluebird": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
         },
         "body-parser": {
             "version": "1.20.1",
@@ -9227,16 +9078,6 @@
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
         },
-        "buffer-indexof-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
-        },
-        "buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
-        },
         "bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -9325,14 +9166,6 @@
             "resolved": "https://registry.npmjs.org/chai-match/-/chai-match-1.1.1.tgz",
             "integrity": "sha512-gea2rl5SgzF11CopH4yCmFTmPCXSN+e2GSJL33SfM+/WPP/cDk1tmrc0GDU2JRiFVJUJel/2zaNkNfyJKN7CtA==",
             "dev": true
-        },
-        "chainsaw": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "requires": {
-                "traverse": ">=0.3.0 <0.4"
-            }
         },
         "chalk": {
             "version": "4.1.2",
@@ -9861,14 +9694,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-        },
-        "duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "requires": {
-                "readable-stream": "^2.0.2"
-            }
         },
         "ee-first": {
             "version": "1.1.1",
@@ -10831,27 +10656,6 @@
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "dev": true,
             "optional": true
-        },
-        "fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
-            }
         },
         "function-bind": {
             "version": "1.1.1",
@@ -11829,11 +11633,6 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
         },
-        "listenercount": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
-        },
         "load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -12012,15 +11811,8 @@
         "minimist": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
-        },
-        "mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "requires": {
-                "minimist": "^1.2.6"
-            }
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true
         },
         "mkdirp-classic": {
             "version": "0.5.3",
@@ -13243,11 +13035,6 @@
                 "send": "0.18.0"
             }
         },
-        "setimmediate": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-        },
         "setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -13637,11 +13424,6 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
         },
-        "traverse": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
-        },
         "tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -13759,23 +13541,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-        },
-        "unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "requires": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
-                "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
-                "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
-            }
         },
         "update-browserslist-db": {
             "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "@oclif/errors": "^1.3.5",
         "@oclif/plugin-commands": "^2.1.0",
         "@oclif/plugin-help": "^5.1.12",
+        "adm-zip": "^0.5.10",
         "ajv": "^8.10.0",
         "apify-client": "^2.2.0",
         "archiver-promise": "^1.0.0",
@@ -84,7 +85,6 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "underscore": "^1.13.2",
-        "unzipper": "^0.10.11",
         "write-json-file": "^4.3.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Fixes #356 

Consulted with @barjin, the adm-zip library is also used in fingerprint suite. This library doesn't support streaming decoding, but templates are small, so that shouldn't matter I hope.

(Switching from streaming to decoding one large blob would fix the bug with the original library as well, but let's switch anyways - we already use it on another project, and it seems to be maintained more recently.)