### PR TITLE
chore: Use new workflow secrets

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,7 +40,7 @@ jobs:
             -
                 name: Run Tests
                 env:
-                    TEST_USER_TOKEN: ${{ secrets.USER_TOKEN }}
+                    TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
                 run: npm test
 
     test_python_support:
@@ -76,7 +76,7 @@ jobs:
             -
                 name: Run Python tests
                 env:
-                    TEST_USER_TOKEN: ${{ secrets.USER_TOKEN }}
+                    TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
                 run: npm run test-python
 
     lint:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
                 with:
-                    token: ${{ secrets.GH_TOKEN }}
+                    token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             -   name: Use Node.js 16
                 uses: actions/setup-node@v3
                 with:
@@ -23,8 +23,8 @@ jobs:
 
             -   name: Set git identity
                 run: |
-                    git config --global user.name "Martin Adámek"
-                    git config --global user.email "martin@apify.com"
+                    git config --global user.name 'GitHub Actions'
+                    git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
             #    - name: Cache node_modules
             #      uses: actions/cache@v2
@@ -45,8 +45,8 @@ jobs:
                     # build and deploy the docs
                     npm run deploy
                 env:
-                    GIT_USER: "B4nan:${{ secrets.GH_TOKEN }}"
-                    GH_TOKEN: ${{ secrets.GH_TOKEN }}
+                    GIT_USER: "GitHub Actions:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
+                    GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             -   name: Commit the updated package(-lock).json
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       -
         name: Run Tests
         env:
-            TEST_USER_TOKEN: ${{ secrets.USER_TOKEN }}
+            TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
         run: npm test
 
   test_python_support:
@@ -80,7 +80,7 @@ jobs:
       -
         name: Run Python tests
         env:
-          TEST_USER_TOKEN: ${{ secrets.USER_TOKEN }}
+          TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
         run: npm run test-python
 
   lint:
@@ -141,7 +141,7 @@ jobs:
         run: node ./.github/scripts/before-beta-release.js
       -
         name: Publish to NPM
-        run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag ${{ env.RELEASE_TAG }} --access public
+        run: NODE_AUTH_TOKEN=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }} npm publish --tag ${{ env.RELEASE_TAG }} --access public
       -
         # Latest version is tagged by the release process so we only tag beta here.
         name: Tag Version
@@ -157,4 +157,4 @@ jobs:
           PACKAGE_VERSION=`node -p "require('./package.json').version"`
           gh workflow run update_formula.yaml --repo apify/homebrew-tap --field package=apify-cli --field version=$PACKAGE_VERSION
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_WORKFLOW_CALL_GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
This uses new secrets set on organization level instead of the repo-level secrets.