### PR TITLE
feat: add community message

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prepare-release": "npm run commands-md && npm run prod-shrinkwrap",
         "prod-shrinkwrap": "rm -rf node_modules && npm install --production && npm shrinkwrap",
         "manifest": "rm -f oclif.manifest.json && oclif-dev manifest",
-        "postinstall": "node \"./src/bin/run\" check-version"
+        "postinstall": "node \"./src/bin/run\" check-version && node ./src/lib/community"
     },
     "files": [
         "src",

--- a/src/lib/community.js
+++ b/src/lib/community.js
@@ -1,0 +1,3 @@
+console.log('We have an active developer community on Discord. '
+            + 'You can find it on https://discord.gg/crawlee-apify-801163717915574323 or when you write apify -h.',
+);

--- a/src/lib/community.js
+++ b/src/lib/community.js
@@ -1,3 +1,3 @@
 console.log('We have an active developer community on Discord. '
-            + 'You can find it on https://discord.gg/crawlee-apify-801163717915574323 or when you write apify -h.',
+            + 'You can find it on https://discord.gg/crawlee-apify-801163717915574323.',
 );


### PR DESCRIPTION
Closes apify/apify-web#2650

Partially implementing - there's no way to add custom `apify -h` content with older versions of oclif.