### PR TITLE
fix: Use the right exit code on error

### DIFF
--- a/src/bin/run
+++ b/src/bin/run
@@ -10,6 +10,7 @@ const outputs = require('../lib/outputs');
         if (exitCode !== 0) {
             outputs.error(err.message);
             if (process.env.DEBUG) console.error(err);
+            process.exit(exitCode);
         }
     }
 })();


### PR DESCRIPTION
Right now, when you run a command (like `apify run`) and the command fails (perhaps because the actor failed), the exit code is still set to 0.

This was probably an oversight in some old version of `oclif`, the current version fixes it and exits with the right exit code now - https://github.com/oclif/core/blob/main/src/errors/handle.ts#L33. 

This changes our behavior to do the same.