### PR TITLE
fix: Fix unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "Apify command-line interface helps you create, develop, build and run Apify actors, and manage the Apify cloud platform.",
     "main": "index.js",
     "scripts": {
-        "test": "mocha --timeout 180000 --recursive",
-        "test-python": "mocha --timeout 180000 --recursive --grep '\\[python\\]'",
+        "test": "APIFY_CLI_SKIP_UPDATE_CHECK=1 mocha --timeout 180000 --recursive",
+        "test-python": "npm run test -- --grep '\\[python\\]'",
         "lint": "eslint src test",
         "lint:fix": "eslint src test --fix",
         "commands-md": "npm run manifest && oclif-dev readme",

--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -1,4 +1,4 @@
-const { checkLatestVersion } = require('../lib/version_check');
+const { checkLatestVersion, SKIP_UPDATE_CHECK } = require('../lib/version_check');
 
 /**
  * This code'll be call before each commmand run
@@ -7,6 +7,9 @@ const { checkLatestVersion } = require('../lib/version_check');
 exports.default = async (params) => {
     // This is not nessesary when you call the `--check-version` as the same command is called there.
     if (['cv', 'check-version'].includes(params.id)) return;
+
+    // If the user has configured the `APIFY_CLI_SKIP_UPDATE_CHECK` env variable then skip the check.
+    if (SKIP_UPDATE_CHECK) return;
 
     // Check package latest version
     await checkLatestVersion();

--- a/src/lib/version_check.js
+++ b/src/lib/version_check.js
@@ -25,6 +25,11 @@ const UPDATE_COMMAND = {
     [INSTALLATION_TYPE.NPM]: 'npm install -g apify-cli@latest',
 };
 
+const SKIP_UPDATE_CHECK = (
+    process.env.APIFY_CLI_SKIP_UPDATE_CHECK
+    && !['0', 'false'].includes(process.env.APIFY_CLI_SKIP_UPDATE_CHECK.toLowerCase())
+);
+
 /**
  * Detect through which package manager the Apify CLI was installed.
  * @returns {INSTALLATION_TYPE} The installation type of the CLI.
@@ -115,4 +120,5 @@ const checkLatestVersion = async (enforeUpdate = false) => {
 module.exports = {
     checkLatestVersion,
     getLatestNpmVersion,
+    SKIP_UPDATE_CHECK,
 };

--- a/test/commands/run.js
+++ b/test/commands/run.js
@@ -13,13 +13,14 @@ const { getLocalKeyValueStorePath, getLocalDatasetPath, getLocalRequestQueuePath
 const actName = 'my-act';
 
 describe('apify run', () => {
-    before(async function () {
+    let skipAfterHook = false;
+    before(async () => {
         if (fs.existsSync(GLOBAL_CONFIGS_FOLDER)) {
-            // Skip tests if user used CLI on local, it can break local environment!
-            console.warn(`Test was skipped as directory ${GLOBAL_CONFIGS_FOLDER} exists!`);
-            this.skip();
-            return;
+            // Tests could break local environment if user is already logged in
+            skipAfterHook = true;
+            throw new Error(`Cannot run tests, directory ${GLOBAL_CONFIGS_FOLDER} exists! Run "apify logout" to fix this.`);
         }
+
         await command.run(['create', actName, '--template', 'project_empty']);
         process.chdir(actName);
     });
@@ -137,7 +138,9 @@ describe('apify run', () => {
     });
 
     after(async () => {
+        if (skipAfterHook) return;
         process.chdir('../');
         if (fs.existsSync(actName)) await rimrafPromised(actName);
+        await command.run(['logout']);
     });
 });

--- a/test/commands/secrets/add.js
+++ b/test/commands/secrets/add.js
@@ -9,12 +9,14 @@ const SECRET_KEY = 'mySecret';
 const SECRET_VALUE = 'mySecretValue';
 
 describe('apify secrets:add', () => {
-    before(async function () {
+    let skipAfterHook = false;
+    before(async () => {
         if (fs.existsSync(GLOBAL_CONFIGS_FOLDER)) {
-            // Skip tests if user used CLI on local, it can break local environment!
-            console.warn(`Test was skipped as directory ${GLOBAL_CONFIGS_FOLDER} exists!`);
-            this.skip();
+            // Tests could break local environment if user is already logged in
+            skipAfterHook = true;
+            throw new Error(`Cannot run tests, directory ${GLOBAL_CONFIGS_FOLDER} exists! Run "apify logout" to fix this.`);
         }
+
         await command.run(['login', '--token', TEST_USER_TOKEN]);
         const secrets = getSecretsFile();
         if (secrets[SECRET_KEY]) {
@@ -29,6 +31,7 @@ describe('apify secrets:add', () => {
     });
 
     after(async () => {
+        if (skipAfterHook) return;
         const secrets = getSecretsFile();
         if (secrets[SECRET_KEY]) {
             await command.run(['secrets:rm', SECRET_KEY]);

--- a/test/commands/secrets/rm.js
+++ b/test/commands/secrets/rm.js
@@ -8,12 +8,14 @@ const { TEST_USER_TOKEN } = require('../config');
 const SECRET_KEY = 'mySecret';
 
 describe('apify secrets:rm', () => {
-    before(async function () {
+    let skipAfterHook = false;
+    before(async () => {
         if (fs.existsSync(GLOBAL_CONFIGS_FOLDER)) {
-            // Skip tests if user used CLI on local, it can break local environment!
-            console.warn(`Test was skipped as directory ${GLOBAL_CONFIGS_FOLDER} exists!`);
-            this.skip();
+            // Tests could break local environment if user is already logged in
+            skipAfterHook = true;
+            throw new Error(`Cannot run tests, directory ${GLOBAL_CONFIGS_FOLDER} exists! Run "apify logout" to fix this.`);
         }
+
         await command.run(['login', '--token', TEST_USER_TOKEN]);
         const secrets = getSecretsFile();
         if (!secrets[SECRET_KEY]) {
@@ -28,6 +30,7 @@ describe('apify secrets:rm', () => {
     });
 
     after(async () => {
+        if (skipAfterHook) return;
         await command.run(['logout']);
     });
 });


### PR DESCRIPTION
The CLI unit tests were not running correctly for a while.

The problem was:
- some tests were configured to be skipped when the `~/.apify` directory exists (meaing somebody is already logged in with `apify login`)
- but before each command, the `checkLatestVersion` method was called, which writes the latest version to `~/.apify/state.json`
- this caused all of the tests which checked for `~/.apify` existence to be skipped

I fixed it so that:
- the `checkLatestVersion` is skipped when the `APIFY_CLI_SKIP_UPDATE_CHECK` environment variable is set
- the tests are called with `APIFY_CLI_SKIP_UPDATE_CHECK=1`
- the tests actually fail if the `~/.apify` directory exists at their start (so that we notice these issues immediately next time)
- the `after()` hook is skipped if the `before()` hook throws an error (this was causing some `chdir`s to be called when they shouldn't be)

Fixing the test execution revealed some errors in the `push` test, so I fixed those too - I mostly deleted some tests which didn't really make sense.
