### PR TITLE
feat(create, init): create INPUT.json from input_schema prefills

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -23,7 +23,13 @@ const {
     detectNpmVersion,
 } = require('../lib/utils');
 const { EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH, PYTHON_VENV_PATH, SUPPORTED_NODEJS_VERSION } = require('../lib/consts');
-const { httpsGet, ensureValidActorName, getTemplateDefinition, enhanceReadmeWithLocalSuffix, createInputFromSchema } = require('../lib/create-utils');
+const {
+    httpsGet,
+    ensureValidActorName,
+    getTemplateDefinition,
+    enhanceReadmeWithLocalSuffix,
+    createPrefilledInputFileFromInputSchema,
+} = require('../lib/create-utils');
 
 class CreateCommand extends ApifyCommand {
     async run() {
@@ -80,6 +86,8 @@ class CreateCommand extends ApifyCommand {
         const zip = new AdmZip(Buffer.concat(chunks));
         zip.extractAllTo(actFolderDir, true);
 
+        // Create prefilled INPUT.json file from the input schema prefills
+        await createPrefilledInputFileFromInputSchema(actFolderDir);
         // There may be .actor/actor.json file in used template - let's try to load it and change the name prop value to actorName
         const localConfig = await getJsonFileContent(path.join(actFolderDir, LOCAL_CONFIG_PATH));
         await setLocalConfig(Object.assign(localConfig || EMPTY_LOCAL_CONFIG, { name: actorName }), actFolderDir);
@@ -88,7 +96,6 @@ class CreateCommand extends ApifyCommand {
         const packageJsonPath = path.join(actFolderDir, 'package.json');
         const requirementsTxtPath = path.join(actFolderDir, 'requirements.txt');
         const readmePath = path.join(actFolderDir, 'README.md');
-        await createInputFromSchema(actFolderDir);
 
         // Add localReadmeSuffix which is fetched from manifest to README.md
         // The suffix contains local development instructions

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -23,7 +23,7 @@ const {
     detectNpmVersion,
 } = require('../lib/utils');
 const { EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH, PYTHON_VENV_PATH, SUPPORTED_NODEJS_VERSION } = require('../lib/consts');
-const { httpsGet, ensureValidActorName, getTemplateDefinition, enhanceReadmeWithLocalSuffix } = require('../lib/create-utils');
+const { httpsGet, ensureValidActorName, getTemplateDefinition, enhanceReadmeWithLocalSuffix, createInputFromSchema } = require('../lib/create-utils');
 
 class CreateCommand extends ApifyCommand {
     async run() {
@@ -88,6 +88,7 @@ class CreateCommand extends ApifyCommand {
         const packageJsonPath = path.join(actFolderDir, 'package.json');
         const requirementsTxtPath = path.join(actFolderDir, 'requirements.txt');
         const readmePath = path.join(actFolderDir, 'README.md');
+        await createInputFromSchema(actFolderDir);
 
         // Add localReadmeSuffix which is fetched from manifest to README.md
         // The suffix contains local development instructions

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -28,8 +28,8 @@ const {
     ensureValidActorName,
     getTemplateDefinition,
     enhanceReadmeWithLocalSuffix,
-    createPrefilledInputFileFromInputSchema,
 } = require('../lib/create-utils');
+const { createPrefilledInputFileFromInputSchema } = require('../lib/input_schema');
 
 class CreateCommand extends ApifyCommand {
     async run() {
@@ -86,12 +86,13 @@ class CreateCommand extends ApifyCommand {
         const zip = new AdmZip(Buffer.concat(chunks));
         zip.extractAllTo(actFolderDir, true);
 
-        // Create prefilled INPUT.json file from the input schema prefills
-        await createPrefilledInputFileFromInputSchema(actFolderDir);
         // There may be .actor/actor.json file in used template - let's try to load it and change the name prop value to actorName
         const localConfig = await getJsonFileContent(path.join(actFolderDir, LOCAL_CONFIG_PATH));
         await setLocalConfig(Object.assign(localConfig || EMPTY_LOCAL_CONFIG, { name: actorName }), actFolderDir);
         await setLocalEnv(actFolderDir);
+
+        // Create prefilled INPUT.json file from the input schema prefills
+        await createPrefilledInputFileFromInputSchema(actFolderDir);
 
         const packageJsonPath = path.join(actFolderDir, 'package.json');
         const requirementsTxtPath = path.join(actFolderDir, 'requirements.txt');

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -4,6 +4,7 @@ const { ApifyCommand } = require('../lib/apify_command');
 const outputs = require('../lib/outputs');
 const { setLocalConfig, setLocalEnv, getLocalConfig, getLocalConfigOrThrow } = require('../lib/utils');
 const { EMPTY_LOCAL_CONFIG, DEFAULT_LOCAL_STORAGE_DIR, LOCAL_CONFIG_PATH } = require('../lib/consts');
+const { createPrefilledInputFileFromInputSchema } = require('../lib/input_schema');
 
 class InitCommand extends ApifyCommand {
     async run() {
@@ -23,6 +24,8 @@ class InitCommand extends ApifyCommand {
             await setLocalConfig(Object.assign(localConfig, { name: actorName }), cwd);
         }
         await setLocalEnv(cwd);
+        // Create prefilled INPUT.json file from the input schema prefills
+        await createPrefilledInputFileFromInputSchema(cwd);
         outputs.success('The Apify actor has been initialized in the current directory.');
     }
 }

--- a/src/lib/create-utils.js
+++ b/src/lib/create-utils.js
@@ -90,9 +90,10 @@ exports.enhanceReadmeWithLocalSuffix = async (readmePath, manifestPromise) => {
  * Goes to the Actor directory and creates INPUT.json file from the input schema prefills.
  * @param {string} actFolderDir
  */
-exports.createInputFromSchema = async (actFolderDir) => {
+exports.createInputFileFromInputSchema = async (actFolderDir) => {
+    const currentDir = process.cwd();
+
     try {
-        const currentDir = process.cwd();
         process.chdir(actFolderDir);
         const { inputSchema } = await readInputSchema();
 
@@ -103,13 +104,13 @@ exports.createInputFromSchema = async (actFolderDir) => {
                 return acc;
             }, {});
 
-            fs.mkdirSync('./storage/key_value_stores/default', { recursive: true });
-            fs.writeFileSync('./storage/key_value_stores/default/INPUT.json', JSON.stringify(input, null, 2));
+            await fs.mkdir('./storage/key_value_stores/default', { recursive: true });
+            await fs.writeFile('./storage/key_value_stores/default/INPUT.json', JSON.stringify(input, null, 2));
         }
-
-        process.chdir(currentDir);
     } catch (err) {
         warning(`Could not create INPUT.json file. Cause: ${err.message}`);
+    } finally {
+        process.chdir(currentDir);
     }
 };
 

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -97,7 +97,7 @@ const createPrefilledInputFileFromInputSchema = async (actorFolderDir) => {
             ));
         }
     } catch (err) {
-        warning(`Could not create INPUT.json file. Cause: ${err.message}`);
+        warning(`Could not create default input based on input schema, creating empty input instead. Cause: ${err.message}`);
     } finally {
         const keyValueStorePath = getLocalKeyValueStorePath();
         const inputJsonPath = path.join(actorFolderDir, keyValueStorePath, `${KEY_VALUE_STORE_KEYS.INPUT}.json`);

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -77,6 +77,7 @@ const readInputSchema = async (forcePath) => {
  */
 const createPrefilledInputFileFromInputSchema = async (actorFolderDir) => {
     const currentDir = process.cwd();
+    let inputFile = {};
     try {
         process.chdir(actorFolderDir);
         const { inputSchema } = await readInputSchema();
@@ -84,18 +85,17 @@ const createPrefilledInputFileFromInputSchema = async (actorFolderDir) => {
             const validator = new Ajv({ strict: false });
             validateInputSchema(validator, inputSchema);
 
-            const inputFile = _.mapObject(inputSchema.properties, (fieldSchema) => ((fieldSchema.type === 'boolean' || fieldSchema.editor === 'hidden')
+            inputFile = _.mapObject(inputSchema.properties, (fieldSchema) => ((fieldSchema.type === 'boolean' || fieldSchema.editor === 'hidden')
                 ? fieldSchema.default
                 : fieldSchema.prefill
             ));
-
-            const keyValueStorePath = getLocalKeyValueStorePath();
-            const inputJsonPath = path.join(actorFolderDir, keyValueStorePath, `${KEY_VALUE_STORE_KEYS.INPUT}.json`);
-            await writeJsonFile(inputJsonPath, inputFile);
         }
     } catch (err) {
         warning(`Could not create INPUT.json file. Cause: ${err.message}`);
     } finally {
+        const keyValueStorePath = getLocalKeyValueStorePath();
+        const inputJsonPath = path.join(actorFolderDir, keyValueStorePath, `${KEY_VALUE_STORE_KEYS.INPUT}.json`);
+        await writeJsonFile(inputJsonPath, inputFile);
         process.chdir(currentDir);
     }
 };

--- a/src/lib/input_schema.js
+++ b/src/lib/input_schema.js
@@ -81,7 +81,13 @@ const createPrefilledInputFileFromInputSchema = async (actorFolderDir) => {
     try {
         process.chdir(actorFolderDir);
         const { inputSchema } = await readInputSchema();
+
         if (inputSchema) {
+            /**
+             * TODO: The logic is copied from @apify-packages/actor -> getPrefillFromInputSchema
+             * It is not possible to install the package here because it is private
+             * We should move it to @apify/input_schema and use it from there.
+             */
             const validator = new Ajv({ strict: false });
             validateInputSchema(validator, inputSchema);
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -237,7 +237,6 @@ const GITIGNORE_REQUIRED_CONTENTS = [getLocalStorageDir(), 'node_modules', '.ven
 const setLocalEnv = async (actDir) => {
     // Create folders for emulation Apify stores
     const keyValueStorePath = getLocalKeyValueStorePath();
-    const inputJsonPath = path.join(actDir, keyValueStorePath, `${KEY_VALUE_STORE_KEYS.INPUT}.json`);
     ensureFolderExistsSync(actDir, getLocalDatasetPath());
     ensureFolderExistsSync(actDir, getLocalRequestQueuePath());
     ensureFolderExistsSync(actDir, keyValueStorePath);
@@ -263,11 +262,6 @@ const setLocalEnv = async (actDir) => {
         } else {
             fs.writeFileSync(gitignorePath, `${gitignoreAdditions.join('\n')}\n`, { flag: 'w' });
         }
-    }
-
-    // Create an empty INPUT.json file if it does not exist.
-    if (!fs.existsSync(inputJsonPath)) {
-        writeJson.sync(inputJsonPath, {});
     }
 };
 
@@ -365,14 +359,14 @@ const createActZip = async (zipName, pathsToZip) => {
 const getLocalInput = () => {
     const defaultLocalStorePath = getLocalKeyValueStorePath();
     const files = fs.readdirSync(defaultLocalStorePath);
-    const inputFileName = files.find((file) => !!file.match(INPUT_FILE_REG_EXP));
+    const inputName = files.find((file) => !!file.match(INPUT_FILE_REG_EXP));
 
     // No input file
-    if (!inputFileName) return;
+    if (!inputName) return;
 
-    const inputFile = fs.readFileSync(path.join(defaultLocalStorePath, inputFileName));
-    const contentType = mime.getType(inputFileName);
-    return { body: inputFile, contentType };
+    const input = fs.readFileSync(path.join(defaultLocalStorePath, inputName));
+    const contentType = mime.getType(inputName);
+    return { body: input, contentType };
 };
 
 const purgeDefaultQueue = async () => {

--- a/test/commands/call.js
+++ b/test/commands/call.js
@@ -68,7 +68,7 @@ describe('apify call', () => {
             console.log('Done.');
         });
         `;
-        fs.writeFileSync('main.js', actCode, { flag: 'w' });
+        fs.writeFileSync('src/main.js', actCode, { flag: 'w' });
 
         const inputFile = path.join(getLocalKeyValueStorePath(), 'INPUT.json');
 

--- a/test/commands/create.js
+++ b/test/commands/create.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const command = require('@oclif/command');
 const path = require('path');
 const loadJson = require('load-json-file');
+const { KEY_VALUE_STORE_KEYS } = require('@apify/consts');
 const { rimrafPromised } = require('../../src/lib/files');
 const { getLocalKeyValueStorePath } = require('../../src/lib/utils');
 const { LOCAL_CONFIG_PATH } = require('../../src/lib/consts');
@@ -27,7 +28,7 @@ describe('apify create', () => {
         });
     });
 
-    it('basic template structure', async () => {
+    it('basic template structure with prefilled INPUT.json', async () => {
         /* eslint-disable no-unused-expressions */
         await command.run(['create', actName, '--template', ACT_TEMPLATE]);
 
@@ -41,8 +42,7 @@ describe('apify create', () => {
         expect(fs.existsSync(path.join(actName, 'package.json'))).to.be.true;
         expect(fs.existsSync(apifyJsonPath)).to.be.false;
         expect(fs.existsSync(actorJsonPath)).to.be.true;
-        expect(fs.existsSync(path.join(actName, getLocalKeyValueStorePath(), 'INPUT.json'))).to.be.true;
-        expect(JSON.parse(fs.readFileSync(path.join(actName, getLocalKeyValueStorePath(), 'INPUT.json')))).to.be.eql({ url: 'https://www.apify.com' });
+        expect(loadJson.sync(path.join(actName, getLocalKeyValueStorePath(), `${KEY_VALUE_STORE_KEYS.INPUT}.json`))).to.be.eql({ url: 'https://www.apify.com' });
         expect(loadJson.sync(actorJsonPath).name).to.be.eql(actName);
         expect(fs.existsSync('storage')).to.be.false;
     });

--- a/test/commands/create.js
+++ b/test/commands/create.js
@@ -10,7 +10,6 @@ const { getLocalKeyValueStorePath } = require('../../src/lib/utils');
 const { LOCAL_CONFIG_PATH } = require('../../src/lib/consts');
 
 const actName = 'my-act';
-const ACT_TEMPLATE = 'getting_started_typescript';
 
 describe('apify create', () => {
     beforeEach(() => {
@@ -28,9 +27,11 @@ describe('apify create', () => {
         });
     });
 
-    it('basic template structure with prefilled INPUT.json', async () => {
+    it('basic template structure with empty INPUT.json', async () => {
+        const ACT_TEMPLATE = 'project_empty';
+        const expectedInput = {};
         /* eslint-disable no-unused-expressions */
-        await command.run(['create', actName, '--template', ACT_TEMPLATE]);
+        await command.run(['create', actName, '--template', ACT_TEMPLATE, '--skip-dependency-install']);
 
         // Check that create command won't create the deprecated apify.json file
         // TODO: we can remove this later
@@ -42,16 +43,35 @@ describe('apify create', () => {
         expect(fs.existsSync(path.join(actName, 'package.json'))).to.be.true;
         expect(fs.existsSync(apifyJsonPath)).to.be.false;
         expect(fs.existsSync(actorJsonPath)).to.be.true;
-        expect(loadJson.sync(path.join(actName, getLocalKeyValueStorePath(), `${KEY_VALUE_STORE_KEYS.INPUT}.json`))).to.be.eql({ url: 'https://www.apify.com' });
         expect(loadJson.sync(actorJsonPath).name).to.be.eql(actName);
         expect(fs.existsSync('storage')).to.be.false;
+        expect(loadJson.sync(path.join(actName, getLocalKeyValueStorePath(), `${KEY_VALUE_STORE_KEYS.INPUT}.json`))).to.be.eql(expectedInput);
     });
 
-    afterEach(() => {
+    it('basic template structure with prefilled INPUT.json', async () => {
+        const ACT_TEMPLATE = 'getting_started_typescript';
+        const expectedInput = { url: 'https://www.apify.com' };
+
+        /* eslint-disable no-unused-expressions */
+        await command.run(['create', actName, '--template', ACT_TEMPLATE, '--skip-dependency-install']);
+
+        // Check that create command won't create the deprecated apify.json file
+        // TODO: we can remove this later
+        const apifyJsonPath = path.join(actName, 'apify.json');
+        const actorJsonPath = path.join(actName, LOCAL_CONFIG_PATH);
+
+        // check files structure
+        expect(fs.existsSync(actName)).to.be.true;
+        expect(fs.existsSync(path.join(actName, 'package.json'))).to.be.true;
+        expect(fs.existsSync(apifyJsonPath)).to.be.false;
+        expect(fs.existsSync(actorJsonPath)).to.be.true;
+        expect(loadJson.sync(actorJsonPath).name).to.be.eql(actName);
+        expect(fs.existsSync('storage')).to.be.false;
+        expect(loadJson.sync(path.join(actName, getLocalKeyValueStorePath(), `${KEY_VALUE_STORE_KEYS.INPUT}.json`))).to.be.eql(expectedInput);
+    });
+
+    afterEach(async () => {
         console.log.restore();
-    });
-
-    after(async () => {
         if (fs.existsSync(actName)) await rimrafPromised(actName);
     });
 });

--- a/test/commands/create.js
+++ b/test/commands/create.js
@@ -9,7 +9,7 @@ const { getLocalKeyValueStorePath } = require('../../src/lib/utils');
 const { LOCAL_CONFIG_PATH } = require('../../src/lib/consts');
 
 const actName = 'my-act';
-const ACT_TEMPLATE = 'project_empty';
+const ACT_TEMPLATE = 'getting_started_typescript';
 
 describe('apify create', () => {
     beforeEach(() => {
@@ -42,6 +42,7 @@ describe('apify create', () => {
         expect(fs.existsSync(apifyJsonPath)).to.be.false;
         expect(fs.existsSync(actorJsonPath)).to.be.true;
         expect(fs.existsSync(path.join(actName, getLocalKeyValueStorePath(), 'INPUT.json'))).to.be.true;
+        expect(JSON.parse(fs.readFileSync(path.join(actName, getLocalKeyValueStorePath(), 'INPUT.json')))).to.be.eql({ url: 'https://www.apify.com' });
         expect(loadJson.sync(actorJsonPath).name).to.be.eql(actName);
         expect(fs.existsSync('storage')).to.be.false;
     });

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -2,13 +2,17 @@ const { expect } = require('chai');
 const fs = require('fs');
 const command = require('@oclif/command');
 const loadJson = require('load-json-file');
+const path = require('path');
+const { KEY_VALUE_STORE_KEYS } = require('@apify/consts');
+const writeJsonFile = require('write-json-file');
 const { rimrafPromised } = require('../../src/lib/files');
 const { EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH } = require('../../src/lib/consts');
+const { getLocalKeyValueStorePath } = require('../../src/lib/utils');
 
 const actName = 'my-act-init';
 
 describe('apify init', () => {
-    before(() => {
+    beforeEach(() => {
         // create folder for init project
         fs.mkdirSync(actName);
         process.chdir(actName);
@@ -25,7 +29,36 @@ describe('apify init', () => {
         expect(loadJson.sync(LOCAL_CONFIG_PATH)).to.be.eql(Object.assign(EMPTY_LOCAL_CONFIG, { name: actName }));
     });
 
-    after(async () => {
+    it('correctly creates structure with prefilled INPUT.json', async () => {
+        const input = {
+            title: 'Scrape data from a web page',
+            type: 'object',
+            schemaVersion: 1,
+            properties: {
+                url: {
+                    title: 'URL of the page',
+                    type: 'string',
+                    description: 'The URL of website you want to get the data from.',
+                    editor: 'textfield',
+                    prefill: 'https://www.apify.com/',
+                },
+            },
+            required: ['url'],
+        };
+        const defaultActorJson = Object.assign(EMPTY_LOCAL_CONFIG, { name: actName, input });
+
+        await writeJsonFile('.actor/actor.json', defaultActorJson);
+        await command.run(['init', actName]);
+
+        // Check that it won't create deprecated config
+        // TODO: We can remove this later
+        const apifyJsonPath = 'apify.json';
+        expect(fs.existsSync(apifyJsonPath)).to.be.eql(false);
+        expect(loadJson.sync(LOCAL_CONFIG_PATH)).to.be.eql(defaultActorJson);
+        expect(loadJson.sync(path.join(getLocalKeyValueStorePath(), `${KEY_VALUE_STORE_KEYS.INPUT}.json`))).to.be.eql({ url: 'https://www.apify.com/' });
+    });
+
+    afterEach(async () => {
         process.chdir('../');
         if (fs.existsSync(actName)) await rimrafPromised(actName);
     });

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -18,7 +18,7 @@ describe('apify init', () => {
         process.chdir(actName);
     });
 
-    it('correctly creates basic structure', async () => {
+    it('correctly creates basic structure with empty INPUT.json', async () => {
         await command.run(['init', actName]);
 
         // Check that it won't create deprecated config
@@ -27,6 +27,7 @@ describe('apify init', () => {
         expect(fs.existsSync(apifyJsonPath)).to.be.eql(false);
 
         expect(loadJson.sync(LOCAL_CONFIG_PATH)).to.be.eql(Object.assign(EMPTY_LOCAL_CONFIG, { name: actName }));
+        expect(loadJson.sync(path.join(getLocalKeyValueStorePath(), `${KEY_VALUE_STORE_KEYS.INPUT}.json`))).to.be.eql({});
     });
 
     it('correctly creates structure with prefilled INPUT.json', async () => {

--- a/test/commands/run.js
+++ b/test/commands/run.js
@@ -40,7 +40,7 @@ describe('apify run', () => {
             console.log('Done.');
         });
         `;
-        fs.writeFileSync('main.js', actCode, { flag: 'w' });
+        fs.writeFileSync('src/main.js', actCode, { flag: 'w' });
 
         await command.run(['run']);
 
@@ -65,7 +65,7 @@ describe('apify run', () => {
             console.log('Done.');
         });
         `;
-        fs.writeFileSync('main.js', actCode, { flag: 'w' });
+        fs.writeFileSync('src/main.js', actCode, { flag: 'w' });
         const apifyJson = EMPTY_LOCAL_CONFIG;
         apifyJson.environmentVariables = testEnvVars;
         writeJson.sync(LOCAL_CONFIG_PATH, apifyJson);
@@ -104,7 +104,7 @@ describe('apify run', () => {
             await requestQueue.addRequest({ url: 'http://example.com/' });
         });
         `;
-        fs.writeFileSync('main.js', actCode, { flag: 'w' });
+        fs.writeFileSync('src/main.js', actCode, { flag: 'w' });
 
         await command.run(['run']);
 
@@ -118,7 +118,7 @@ describe('apify run', () => {
 
         Actor.main(async () => {});
         `;
-        fs.writeFileSync('main.js', actCode, { flag: 'w' });
+        fs.writeFileSync('src/main.js', actCode, { flag: 'w' });
 
         await command.run(['run', '--purge']);
 


### PR DESCRIPTION
## Example
### From `input_schema.json`:
```
{
    "title": "PlaywrightCrawler Template",
    "type": "object",
    "schemaVersion": 1,
    "properties": {
        "startUrls": {
            "title": "Start URLs",
            "type": "array",
            "description": "URLs to start with.",
            "editor": "requestListSources",
            "prefill": [
                {
                    "url": "https://apify.com"
                }
            ]
        }
    }
}
```

### To `INPUT.json`
```
{
  "startUrls": [
    {
      "url": "https://apify.com"
    }
  ]
}
```