### PR TITLE
feat: Auto-update `apify-cli` Homebrew formula in `homebrew-core`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,11 +160,56 @@ jobs:
           git_tag=v`node -p "require('./package.json').version"`
           git tag $git_tag
           git push origin $git_tag
+
+  update_homebrew_formula:
+    name: Update Homebrew Formula
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    steps:
       -
-        name: Update Homebrew formula in homebrew-tap repo
-        if: env.RELEASE_TAG == 'latest'
+        name: Checkout repository
+        uses: actions/checkout@v3
+      -
+        name: Set git identity
+        run: |
+          git config --global user.name 'Apify Service Account'
+          git config --global user.email 'apify-service-account@users.noreply.github.com'
+      -
+        name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      -
+        # It can happen that the updated package version is not available right after the `npm publish` command finishes
+        # Try waiting 3 minutes until the updated package version is available
+        name: Wait for updated package to be available on NPM
+        run: |
+          PACKAGE_VERSION=`node -p "require('./package.json').version"`
+          PACKAGE_DEFINITION_URL="https://registry.npmjs.org/apify-cli/${PACKAGE_VERSION}"
+
+          for _i in {1..30}; do
+              curl -sf "${PACKAGE_DEFINITION_URL}" &> /dev/null && exit 0;
+              echo "Package 'apify-cli' version '${PACKAGE_VERSION}' is not available yet, will retry in 10 seconds."
+              sleep 10;
+          done
+          curl -sf "${PACKAGE_DEFINITION_URL}" &> /dev/null || exit 1;
+      -
+        name: Update Homebrew formula in apify/homebrew-tap repo
         run: |
           PACKAGE_VERSION=`node -p "require('./package.json').version"`
           gh workflow run update_formula.yaml --repo apify/homebrew-tap --field package=apify-cli --field version=$PACKAGE_VERSION
         env:
           GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+      -
+        name: Send PR with formula update to homebrew/homebrew-core repo
+        run: |
+          PACKAGE_VERSION=`node -p "require('./package.json').version"`
+          brew tap --force homebrew/core
+          brew bump-formula-pr apify-cli \
+            --version ${PACKAGE_VERSION} \
+            --no-browse \
+            --fork-org apify \
+            --message "Automatic update of the \`apify-cli\` formula.
+
+            CC @fnesveda @B4nan"
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -207,7 +207,6 @@ jobs:
           brew bump-formula-pr apify-cli \
             --version ${PACKAGE_VERSION} \
             --no-browse \
-            --fork-org apify \
             --message "Automatic update of the \`apify-cli\` formula.
 
             CC @fnesveda @B4nan"


### PR DESCRIPTION
This sets up automatic updating of the `apify-cli` formula in the `homebrew/homebrew-core` repository.

It uses [`brew bump-formula-pr`](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request) to create the update, the result looks like this: https://github.com/Homebrew/homebrew-core/pull/141010

@B4nan I've made it so that you and I are tagged in the PR with the update, so that we get notifications for replies from Homebrew maintainers.