### PR TITLE
refactor: track Scrapy wrapper usage using mixpanel

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -19,6 +19,7 @@ class InitCommand extends ApifyCommand {
 
         if (ProjectAnalyzer.getProjectType(cwd) === PROJECT_TYPES.SCRAPY) {
             outputs.info('The current directory looks like a Scrapy project. Using automatic project wrapping.');
+            this.telemetryData.actorWrapper = PROJECT_TYPES.SCRAPY;
 
             return wrapScrapyProject({ projectPath: cwd });
         }


### PR DESCRIPTION
Adds Scrapy-related field to the telemetry data, if the project is wrapped via `apify init`. 

The usage through `apify init-wrap-scrapy` can be tracked through the use of the command.