### PR TITLE
feat: validate the Actor name during init

### DIFF
--- a/src/lib/scrapy-wrapper/index.js
+++ b/src/lib/scrapy-wrapper/index.js
@@ -9,7 +9,7 @@ const inquirer = require('inquirer');
 
 const { ScrapyProjectAnalyzer } = require('./ScrapyProjectAnalyzer');
 const outputs = require('../outputs');
-const { downloadAndUnzip } = require('../utils');
+const { downloadAndUnzip, sanitizeActorName } = require('../utils');
 
 /**
  * Files that should be concatenated instead of copied (and overwritten).
@@ -86,6 +86,7 @@ async function wrapScrapyProject({ projectPath }) {
     }
 
     const templateBindings = {
+        actorName: sanitizeActorName(analyzer.settings.BOT_NAME),
         botName: analyzer.settings.BOT_NAME,
         scrapy_settings_module: analyzer.configuration.get('settings', 'default'),
         apify_module_path: `${analyzer.settings.BOT_NAME}.apify`,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -536,6 +536,19 @@ const validateActorName = (actorName) => {
     }
 };
 
+const sanitizeActorName = (actorName) => {
+    let sanitizedName = actorName
+        .replaceAll(/[^a-zA-Z0-9-]/g, '-');
+
+    if (sanitizedName.length < ACTOR_NAME.MIN_LENGTH) {
+        sanitizedName = `${sanitizedName}-apify-actor`;
+    }
+
+    sanitizedName = sanitizedName.replaceAll(/^-+/g, '').replaceAll(/-+$/g, '');
+
+    return sanitizedName.slice(0, ACTOR_NAME.MAX_LENGTH);
+};
+
 const getPythonCommand = (directory) => {
     const pythonVenvPath = /^win/.test(process.platform)
         ? 'Scripts/python.exe'
@@ -665,4 +678,5 @@ module.exports = {
     detectNpmVersion,
     detectLocalActorLanguage,
     downloadAndUnzip,
+    sanitizeActorName,
 };


### PR DESCRIPTION
While we check the actor name for validity during the `apify create` phase, we forget to do so during the `apify init` step. 

Wrapped Scrapy projects are even more susceptible to this, as the actor name is taken from the Scrapy `BOTNAME` by default. This PR introduces a sanitization step, which transforms the (potentially invalid) name into a valid Apify Actor name.

Closes #446 