### PR TITLE
chore: support new crawlee purge logic

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -16,7 +16,7 @@ const { replaceSecretsValue } = require('../lib/secrets');
 const {
     getLocalUserInfo, purgeDefaultQueue, purgeDefaultKeyValueStore,
     purgeDefaultDataset, getLocalConfigOrThrow, getNpmCmd, checkIfStorageIsEmpty,
-    detectLocalActorLanguage, isPythonVersionSupported, getPythonCommand, isNodeVersionSupported,
+    detectLocalActorLanguage, isPythonVersionSupported, getPythonCommand, isNodeVersionSupported, getLocalStorageDir,
 } = require('../lib/utils');
 
 class RunCommand extends ApifyCommand {
@@ -30,7 +30,7 @@ class RunCommand extends ApifyCommand {
         const mainPyPath = path.join(cwd, 'src/__main__.py');
 
         const projectType = ProjectAnalyzer.getProjectType(cwd);
-        const actualStoragePath = process.env.APIFY_LOCAL_STORAGE_DIR || process.env.CRAWLEE_STORAGE_DIR || DEFAULT_LOCAL_STORAGE_DIR;
+        const actualStoragePath = getLocalStorageDir();
 
         const packageJsonExists = fs.existsSync(packageJsonPath);
         const mainPyExists = fs.existsSync(mainPyPath);

--- a/src/lib/consts.js
+++ b/src/lib/consts.js
@@ -25,6 +25,8 @@ exports.LANGUAGE = {
 
 exports.PROJECT_TYPES = {
     SCRAPY: 'scrapy',
+    CRAWLEE: 'crawlee',
+    PRE_CRAWLEE_APIFY_SDK: 'apify',
     UNKNOWN: 'unknown',
 };
 

--- a/src/lib/project_analyzer.js
+++ b/src/lib/project_analyzer.js
@@ -1,10 +1,20 @@
 const { PROJECT_TYPES } = require('./consts');
+const { CrawleeAnalyzer } = require('./projects/CrawleeAnalyzer');
+const { OldApifySDKAnalyzer } = require('./projects/OldApifySDKAnalyzer');
 const { ScrapyProjectAnalyzer } = require('./scrapy-wrapper/ScrapyProjectAnalyzer');
 
 const analyzers = [
     {
         type: PROJECT_TYPES.SCRAPY,
         analyzer: ScrapyProjectAnalyzer,
+    },
+    {
+        type: PROJECT_TYPES.CRAWLEE,
+        analyzer: CrawleeAnalyzer,
+    },
+    {
+        type: PROJECT_TYPES.PRE_CRAWLEE_APIFY_SDK,
+        analyzer: OldApifySDKAnalyzer,
     },
 ];
 
@@ -17,6 +27,7 @@ class ProjectAnalyzer {
 
             return a.analyzer.isApplicable(pathname);
         });
+
         return analyzer?.type || PROJECT_TYPES.UNKNOWN;
     }
 }

--- a/src/lib/projects/CrawleeAnalyzer.js
+++ b/src/lib/projects/CrawleeAnalyzer.js
@@ -1,6 +1,19 @@
 const { existsSync, readFileSync } = require('fs');
 const { join } = require('path');
 
+const CRAWLEE_PACKAGES = [
+    'crawlee',
+    '@crawlee/core',
+    '@crawlee/puppeteer',
+    '@crawlee/playwright',
+    '@crawlee/cheerio',
+    '@crawlee/jsdom',
+    '@crawlee/linkedom',
+    '@crawlee/http',
+    '@crawlee/browser',
+    '@crawlee/basic',
+];
+
 class CrawleeAnalyzer {
     static isApplicable(pathname) {
         const hasPackageJson = existsSync(join(pathname, 'package.json'));
@@ -14,7 +27,7 @@ class CrawleeAnalyzer {
         try {
             const packageJsonParsed = JSON.parse(packageJson);
 
-            return packageJsonParsed?.dependencies?.crawlee !== undefined;
+            return CRAWLEE_PACKAGES.some((pkg) => packageJsonParsed?.dependencies?.[pkg] !== undefined);
         } catch (err) {
             return false;
         }

--- a/src/lib/projects/CrawleeAnalyzer.js
+++ b/src/lib/projects/CrawleeAnalyzer.js
@@ -1,0 +1,24 @@
+const { existsSync, readFileSync } = require('fs');
+const { join } = require('path');
+
+class CrawleeAnalyzer {
+    static isApplicable(pathname) {
+        const hasPackageJson = existsSync(join(pathname, 'package.json'));
+
+        if (!hasPackageJson) {
+            return false;
+        }
+
+        const packageJson = readFileSync(join(pathname, 'package.json'), 'utf8');
+
+        try {
+            const packageJsonParsed = JSON.parse(packageJson);
+
+            return packageJsonParsed?.dependencies?.crawlee !== undefined;
+        } catch (err) {
+            return false;
+        }
+    }
+}
+
+exports.CrawleeAnalyzer = CrawleeAnalyzer;

--- a/src/lib/projects/OldApifySDKAnalyzer.js
+++ b/src/lib/projects/OldApifySDKAnalyzer.js
@@ -1,0 +1,49 @@
+const { existsSync, readFileSync } = require('fs');
+const { join } = require('path');
+
+const { lt } = require('semver');
+
+const VERSION_WHEN_APIFY_MOVED_TO_CRAWLEE = '3.0.0';
+
+class OldApifySDKAnalyzer {
+    static isApplicable(pathname) {
+        const hasPackageJson = existsSync(join(pathname, 'package.json'));
+
+        if (!hasPackageJson) {
+            return false;
+        }
+
+        const packageJson = readFileSync(join(pathname, 'package.json'), 'utf8');
+
+        try {
+            const packageJsonParsed = JSON.parse(packageJson);
+
+            // If they have crawlee as a dependency, likely to use crawlee
+            if (packageJsonParsed?.dependencies?.crawlee !== undefined) {
+                return false;
+            }
+
+            const apifyVersion = packageJsonParsed?.dependencies?.apify;
+            if (!apifyVersion) {
+                return false;
+            }
+
+            // We cannot infer
+            if (apifyVersion === '*') {
+                return false;
+            }
+
+            let actualVersion = apifyVersion;
+
+            if (apifyVersion.startsWith('~') || apifyVersion.startsWith('^')) {
+                actualVersion = apifyVersion.slice(1);
+            }
+
+            return lt(actualVersion, VERSION_WHEN_APIFY_MOVED_TO_CRAWLEE);
+        } catch (err) {
+            return false;
+        }
+    }
+}
+
+exports.OldApifySDKAnalyzer = OldApifySDKAnalyzer;

--- a/src/lib/projects/OldApifySDKAnalyzer.js
+++ b/src/lib/projects/OldApifySDKAnalyzer.js
@@ -4,6 +4,18 @@ const { join } = require('path');
 const { lt } = require('semver');
 
 const VERSION_WHEN_APIFY_MOVED_TO_CRAWLEE = '3.0.0';
+const CRAWLEE_PACKAGES = [
+    'crawlee',
+    '@crawlee/core',
+    '@crawlee/puppeteer',
+    '@crawlee/playwright',
+    '@crawlee/cheerio',
+    '@crawlee/jsdom',
+    '@crawlee/linkedom',
+    '@crawlee/http',
+    '@crawlee/browser',
+    '@crawlee/basic',
+];
 
 class OldApifySDKAnalyzer {
     static isApplicable(pathname) {
@@ -19,7 +31,7 @@ class OldApifySDKAnalyzer {
             const packageJsonParsed = JSON.parse(packageJson);
 
             // If they have crawlee as a dependency, likely to use crawlee
-            if (packageJsonParsed?.dependencies?.crawlee !== undefined) {
+            if (CRAWLEE_PACKAGES.some((pkg) => packageJsonParsed?.dependencies?.[pkg] !== undefined)) {
                 return false;
             }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -80,7 +80,7 @@ const MIGRATED_APIFY_JSON_PROPERTIES = ['name', 'version', 'buildTag'];
 const getLocalStorageDir = () => {
     const envVar = APIFY_ENV_VARS.LOCAL_STORAGE_DIR;
 
-    return process.env[envVar] || DEFAULT_LOCAL_STORAGE_DIR;
+    return process.env[envVar] || process.env.CRAWLEE_STORAGE_DIR || DEFAULT_LOCAL_STORAGE_DIR;
 };
 const getLocalKeyValueStorePath = (storeId) => {
     const envVar = ACTOR_ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID;


### PR DESCRIPTION
This has been a pain and a half to work in, especially because no TS 😢 but that'll change soon 😏

Also adds in proper migration support to custom folders instead of a hardcoded folder for storages, full redirect of storages based on ENV variables, and a base for detecting old apify-based actors (who knows, maybe it'll be useful in the future)

Closes #373 