### PR TITLE
docs: add a simple troubleshooting page with our contact

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,9 @@
+---
+sidebar_label: Troubleshooting
+title: Troubleshooting
+---
+
+For general support, reach out to us at [apify.com/contact](https://apify.com/contact).
+
+If you believe you are encountering a bug, file it on [GitHub](https://github.com/apify/apify-cli/issues/new).
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -27,6 +27,11 @@ module.exports = [
         },
         {
             type: 'doc',
+            id: 'troubleshooting',
+            label: 'Troubleshooting',
+        },
+        {
+            type: 'doc',
             id: 'changelog',
             label: 'Changelog',
         },


### PR DESCRIPTION
Recently, we deployed a bugged version where apify login would fail ([Slack thread](https://apifier.slack.com/archives/C0L33UM7Z/p1708169059446719)). 

We caught this internally but should this be first experienced by an external user, we want to provide them with some basic instructions on what to do.