### PR TITLE
feat: add a troubleshooting section to the root help screen

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,6 +17,7 @@
                 "@crawlee/memory-storage": "^3.5.8",
                 "@oclif/command": "^1.8.36",
                 "@oclif/config": "^1.18.17",
+                "@oclif/core": "^2.15.0",
                 "@oclif/errors": "^1.3.6",
                 "@oclif/plugin-commands": "^2.1.0",
                 "@oclif/plugin-help": "^5.1.12",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@crawlee/memory-storage": "^3.5.8",
         "@oclif/command": "^1.8.36",
         "@oclif/config": "^1.18.17",
+        "@oclif/core": "^2.15.0",
         "@oclif/errors": "^1.3.6",
         "@oclif/plugin-commands": "^2.1.0",
         "@oclif/plugin-help": "^5.1.12",
@@ -109,6 +110,7 @@
             "init": [
                 "./src/hooks/init"
             ]
-        }
+        },
+        "helpClass": "./src/lib/apify-oclif-help"
     }
 }

--- a/src/lib/apify-oclif-help.js
+++ b/src/lib/apify-oclif-help.js
@@ -1,0 +1,23 @@
+const { Help } = require('@oclif/core');
+
+/**
+ * Custom help class that overrides how oclif renders help screens.
+ *
+ * It is registered through package.json.
+ *
+ * Refer to the oclif documentation for more information:
+ * https://oclif.io/docs/help_classes/#custom-help
+ *
+ * Note: The CLI was crashing when printing help with the latest oclif packages. Be careful when upgrading.
+ */
+module.exports = class ApifyOclifHelp extends Help {
+    showRootHelp() {
+        super.showRootHelp();
+
+        this.log(this.section(
+            'TROUBLESHOOTING',
+            this.wrap(
+                'For general support, reach out to us at https://apify.com/contact\n\n'
+                + 'If you believe you are encountering a bug, file it at https://github.com/apify/apify-cli/issues/new')));
+    }
+};


### PR DESCRIPTION
Recently, we deployed a bugged version where apify login would fail ([Slack thread](https://apifier.slack.com/archives/C0L33UM7Z/p1708169059446719)).

We caught this internally but should this be first experienced by an external user, we want to provide them with some basic instructions on what to do.

This adds a new `TROUBLESHOOTING` section to the root help screen with the same content as was added in #484.

![image](https://github.com/apify/apify-cli/assets/5073664/3bd89755-9105-402f-ad38-9d9b4e847536)

Note: The CLI was crashing when printing help with the latest oclif packages. So the original oclif packages were kept and a slightly older version of @oclif/core was installed.
