### PR TITLE
chore: don't print stdout at all when running tests

### DIFF
--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -9,7 +9,7 @@ const spawnPromised = async (cmd: string, args: string[], opts: SpawnOptionsWith
     // NOTE: Pipes stderr, stdout to main process
     const childProcess = spawn(cmd, args, {
         ...opts,
-        stdio: 'inherit',
+        stdio: process.env.APIFY_NO_LOGS_IN_TESTS ? 'ignore' : 'inherit',
     });
 
     // Catch ctrl-c (SIGINT) and kills child process

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -452,11 +452,6 @@ export const purgeDefaultKeyValueStore = async () => {
 };
 
 export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
-    // In tests, writing to process.stdout directly messes with vitest's output
-    if (process.env.APIFY_NO_LOGS_IN_TESTS) {
-        return;
-    }
-
     const { id: logId, status } = job;
     const apifyClient = new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
 
@@ -480,6 +475,12 @@ export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
         let nodeTimeout: NodeJS.Timeout | null = null;
 
         stream.on('data', (chunk) => {
+            // In tests, writing to process.stdout directly messes with vitest's output
+            // With that said, we still NEED to wait for this stream to end, as otherwise tests become flaky.
+            if (process.env.APIFY_NO_LOGS_IN_TESTS) {
+                return;
+            }
+
             process.stdout.write(chunk.toString());
         });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -452,6 +452,11 @@ export const purgeDefaultKeyValueStore = async () => {
 };
 
 export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
+    // In tests, writing to process.stdout directly messes with vitest's output
+    if (process.env.APIFY_NO_LOGS_IN_TESTS) {
+        return;
+    }
+
     const { id: logId, status } = job;
     const apifyClient = new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vitest/config';
 
+const isWindows = process.platform === 'win32';
+
 export default defineConfig({
     esbuild: {
         target: 'es2022',
@@ -8,8 +10,8 @@ export default defineConfig({
     test: {
         globals: true,
         restoreMocks: true,
-        testTimeout: 60_000,
-        hookTimeout: 60_000,
+        testTimeout: 60_000 * (isWindows ? 2 : 1),
+        hookTimeout: 60_000 * (isWindows ? 2 : 1),
         include: [
             '**/*.{test,spec}.?(c|m)[jt]s?(x)',
         ],
@@ -18,7 +20,8 @@ export default defineConfig({
         env: {
             APIFY_CLI_DISABLE_TELEMETRY: '1',
             APIFY_CLI_SKIP_UPDATE_CHECK: '1',
+            APIFY_NO_LOGS_IN_TESTS: '1',
         },
-        retry: 2,
+        retry: 3,
     },
 });


### PR DESCRIPTION
Also gives windows higher timeouts and increases retries, since.. Windows is once again our unreliable entity