### PR TITLE
chore: Update local dev script to allow running from anywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Dev mode
 
-You can call `./bin/dev.js` to run the CLI in development mode. This will use the local version of the CLI instead of the one installed globally.
+You can call `./bin/dev.sh` to run the CLI in development mode. This will use the local version of the CLI instead of the one installed globally.
 
 ## Tests
 

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node_modules/.bin/tsx
-
 import { execute } from '@oclif/core';
 
 import { error } from '../src/lib/outputs.ts';

--- a/bin/dev.sh
+++ b/bin/dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${DIR}"/../node_modules/.bin/tsx "${DIR}"/dev.js "$@"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "types": "./dist/index.d.ts",
     "type": "module",
     "scripts": {
+        "dev": "tsx ./bin/dev.js",
         "test": "vitest run",
         "test-python": "vitest run -t '.*\\[python\\]'",
         "lint": "eslint src test",


### PR DESCRIPTION
I was trying to run the local copy of the CLI from a different folder, like `../apify-cli/bin/dev.js`, but unfortunately it didn't work, because the shebang in the `dev.js` file was resolved relative to the current working directory, instead of relative to the `apify-cli` folder.

This adds a `dev.sh` script, which will work when called from anywhere, and run `apify-cli/node_modules/.bin/tsx`. This allows you to test stuff like `apify create`, `apify pull` etc. easier.