### PR TITLE
fix: prevent running `apify push` from non-actor-looking folders

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -11,7 +11,7 @@ import isCI from 'is-ci';
 import open from 'open';
 
 import { ApifyCommand } from '../lib/apify_command.js';
-import { CommandExitCodes, LOCAL_CONFIG_PATH, UPLOADS_STORE_NAME } from '../lib/consts.js';
+import { CommandExitCodes, DEPRECATED_LOCAL_CONFIG_NAME, LOCAL_CONFIG_PATH, UPLOADS_STORE_NAME } from '../lib/consts.js';
 import { sumFilesSizeInBytes } from '../lib/files.js';
 import { error, info, link, run, success, warning } from '../lib/outputs.js';
 import { transformEnvToEnvVars } from '../lib/secrets.js';
@@ -108,14 +108,10 @@ export class PushCommand extends ApifyCommand<typeof PushCommand> {
         if (
             // Check that some of these files exist, cuz otherwise we cannot do much
             ![
-                // node project that will probably work with the default template
-                'package.json',
                 // old apify project
+                DEPRECATED_LOCAL_CONFIG_NAME,
+                // new apify project
                 'actor.json',
-                // Any project with a Dockerfile, be it custom or default
-                'Dockerfile',
-                // New apify project
-                '.actor/Dockerfile',
                 '.actor/actor.json',
                 // The .actor folder existing in general
                 '.actor',

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -89,7 +89,11 @@ export const MIXPANEL_TOKEN = 'ea75e434d4b4d2405d79ed9d14bfc93b';
 export enum CommandExitCodes {
     BuildFailed = 1,
     RunFailed = 1,
+
     BuildTimedOut = 2,
+
     BuildAborted = 3,
     RunAborted = 3,
+
+    NoFilesToPush = 4,
 }

--- a/test/__setup__/hooks/useConsoleSpy.ts
+++ b/test/__setup__/hooks/useConsoleSpy.ts
@@ -1,0 +1,33 @@
+import { MockInstance } from 'vitest';
+
+export function useConsoleSpy() {
+    let logSpy!: MockInstance<Parameters<typeof console['log']>, void>;
+    let errorSpy!: MockInstance<Parameters<typeof console['error']>, void>;
+
+    const logMessages = {
+        log: [] as string[],
+        error: [] as string[],
+    };
+
+    vitest.setConfig({ restoreMocks: false });
+
+    beforeEach(() => {
+        logSpy = vitest.spyOn(console, 'log').mockImplementation((...args) => {
+            logMessages.log.push(args.map(String).join(' '));
+        });
+
+        errorSpy = vitest.spyOn(console, 'error').mockImplementation((...args) => {
+            logMessages.error.push(args.map(String).join(' '));
+        });
+    });
+
+    return {
+        get logSpy() {
+            return logSpy;
+        },
+        get errorSpy() {
+            return errorSpy;
+        },
+        logMessages,
+    };
+}

--- a/test/__setup__/hooks/useTempPath.ts
+++ b/test/__setup__/hooks/useTempPath.ts
@@ -49,6 +49,7 @@ export function useTempPath(
     return {
         tmpPath,
         joinPath: (...paths: string[]) => join(tmpPath, ...paths),
+        joinCwdPath: (...paths: string[]) => join(usedCwd, ...paths),
         beforeAllCalls: async () => {
             if (create) {
                 if (cwdParent) {
@@ -69,6 +70,10 @@ export function useTempPath(
 
         toggleCwdBetweenFullAndParentPath: () => {
             usedCwd = usedCwd === cwdPath ? tmpPath : cwdPath;
+        },
+
+        forceNewCwd: (newCwd: string) => {
+            usedCwd = join(cwdPath, newCwd);
         },
     };
 }


### PR DESCRIPTION
Closes #317 

Do we want to maybe make the checks stricter? Should we only allow `push` from a directory that has a `.actor` folder / `actor.json` in it?