### PR TITLE
fix: deprecate `vis` command in favor of `validate-schema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,9 @@
         "hooks": {
             "init": [
                 "./dist/hooks/init"
+            ],
+            "prerun": [
+                "./dist/hooks/deprecations"
             ]
         },
         "helpClass": "./dist/lib/apify-oclif-help",

--- a/src/commands/validate-schema.ts
+++ b/src/commands/validate-schema.ts
@@ -28,6 +28,8 @@ You can also pass any custom path to your input schema to have it validated inst
         }),
     };
 
+    static override hiddenAliases = ['vis'];
+
     async run() {
         const { inputSchema, inputSchemaPath } = await readInputSchema({ forcePath: this.args.path, cwd: process.cwd() });
 

--- a/src/hooks/deprecations.ts
+++ b/src/hooks/deprecations.ts
@@ -1,0 +1,26 @@
+import process from 'node:process';
+
+import { Hook } from '@oclif/core';
+
+import { warning } from '../lib/outputs.js';
+
+// TODO: this will probably not work for commands that are namespaced, e.g. `actor call`
+const deprecations: Record<string, string> = {
+    vis: 'validate-schema',
+};
+
+const hook: Hook<'prerun'> = async (params) => {
+    const possibleValidCommand = [params.Command.id, ...params.Command.aliases, ...params.Command.hiddenAliases];
+
+    const usedCommand = process.argv.find((arg) => possibleValidCommand.includes(arg));
+
+    if (usedCommand) {
+        const validCommand = deprecations[usedCommand];
+
+        if (validCommand) {
+            warning(`The command "${usedCommand}" is deprecated. Please use "${validCommand}" instead.`);
+        }
+    }
+};
+
+export default hook;

--- a/test/commands/validate-schema.test.ts
+++ b/test/commands/validate-schema.test.ts
@@ -23,4 +23,8 @@ describe('apify validate-schema', () => {
             expect(error.message).to.contain.oneOf(['Unexpected token }', "Expected ',' or ']' after array element"]);
         })
         .it('should correctly validate schema 3');
+
+    test
+        .command(['vis', join(basePath, 'valid.json')])
+        .it('should correctly validate schema 1 with alias');
 });

--- a/test/commands/validate-schema.test.ts
+++ b/test/commands/validate-schema.test.ts
@@ -5,20 +5,20 @@ import { test } from '@oclif/test';
 
 const basePath = join(fileURLToPath(import.meta.url), '../../__setup__/input-schemas/');
 
-describe('apify vis', () => {
+describe('apify validate-schema', () => {
     test
-        .command(['vis', join(basePath, 'valid.json')])
+        .command(['validate-schema', join(basePath, 'valid.json')])
         .it('should correctly validate schema 1');
 
     test
-        .command(['vis', join(basePath, 'invalid.json')])
+        .command(['validate-schema', join(basePath, 'invalid.json')])
         .catch((error) => {
             expect(error.message).to.contain('Field schema.properties.queries.editor must be equal to one of the allowed values');
         })
         .it('should correctly validate schema 2');
 
     test
-        .command(['vis', join(basePath, 'unparsable.json')])
+        .command(['validate-schema', join(basePath, 'unparsable.json')])
         .catch((error) => {
             expect(error.message).to.contain.oneOf(['Unexpected token }', "Expected ',' or ']' after array element"]);
         })


### PR DESCRIPTION
Closes #92 