### PR TITLE
fix: always try to get a remote storage if IS_AT_HOME is true

### DIFF
--- a/src/lib/actor.ts
+++ b/src/lib/actor.ts
@@ -23,7 +23,7 @@ export const APIFY_STORAGE_TYPES = {
  */
 export const getApifyStorageClient = async (
     options: MemoryStorageOptions | ApifyClientOptions = {},
-    forceCloud = false,
+    forceCloud = Reflect.has(process.env, APIFY_ENV_VARS.IS_AT_HOME),
 ): Promise<StorageClient> => {
     const storageDir = getLocalStorageDir();
 

--- a/test/lib/actor.test.ts
+++ b/test/lib/actor.test.ts
@@ -1,0 +1,19 @@
+import { APIFY_ENV_VARS } from '@apify/consts';
+import { ApifyClient } from 'apify-client';
+
+import { getApifyStorageClient } from '../../src/lib/actor.js';
+
+beforeAll(() => {
+    vitest.stubEnv(APIFY_ENV_VARS.IS_AT_HOME, 'true');
+    vitest.stubEnv(APIFY_ENV_VARS.TOKEN, 'token for sure');
+});
+
+afterAll(() => {
+    vitest.unstubAllEnvs();
+});
+
+describe('getApifyStorageClient should return a cloud instance when APIFY_IS_AT_HOME is set', () => {
+    it('should return a cloud instance', async () => {
+        await expect(getApifyStorageClient()).resolves.toBeInstanceOf(ApifyClient);
+    });
+});


### PR DESCRIPTION
But maybe we should allow users to force it to get local storages too?

Fix tested and adjusted from @netmilk's fork. it does work :pog:

Closes #270 
Closes #553 