### PR TITLE
fix(push-data): passing the item via stdin works again

### DIFF
--- a/src/commands/actor/push-data.ts
+++ b/src/commands/actor/push-data.ts
@@ -20,24 +20,15 @@ export class PushDataCommand extends ApifyCommand<typeof PushDataCommand> {
 		}),
 	};
 
-	private stdin?: string;
-
-	override async init() {
-		await super.init();
-		// Read data from stdin of the command
-		this.stdin = await this.readStdin(process.stdin);
-	}
-
 	async run() {
 		const { item } = this.args;
 
 		const apifyClient = await getApifyStorageClient();
 		const defaultStoreId = getDefaultStorageId(APIFY_STORAGE_TYPES.DATASET);
-		const data = item || this.stdin;
 
 		let parsedData: Record<string, unknown> | Record<string, unknown>[];
 		try {
-			parsedData = JSON.parse(data!);
+			parsedData = JSON.parse(item!);
 		} catch (err) {
 			throw new Error(`Failed to parse data as JSON string: ${(err as Error).message}`);
 		}

--- a/src/lib/apify_command.ts
+++ b/src/lib/apify_command.ts
@@ -2,7 +2,6 @@ import process from 'node:process';
 
 import { Command, type Interfaces, loadHelpClass } from '@oclif/core';
 
-import { readStdin } from './commands/read-stdin.js';
 import { COMMANDS_WITHIN_ACTOR, LANGUAGE } from './consts.js';
 import { maybeTrackTelemetry } from './telemetry.js';
 import { type KeysToCamelCase, argsToCamelCase, detectLocalActorLanguage } from './utils.js';
@@ -71,13 +70,6 @@ export abstract class ApifyCommand<T extends typeof Command> extends Command {
 		}
 
 		return super.finally(err);
-	}
-
-	/**
-	 * Reads data on standard input as a string.
-	 */
-	async readStdin(stdinStream: typeof process.stdin) {
-		return readStdin(stdinStream);
 	}
 
 	async printHelp(customCommand?: string) {


### PR DESCRIPTION
Previously, doing `apify actor get-input | apify actor push-data` did not work. Now it does again, as oclif supports stdin reading for args by default