### PR TITLE
fix: print path to invalid `actor.json` when an invalid file is found

### DIFF
--- a/cucumber.json
+++ b/cucumber.json
@@ -1,5 +1,6 @@
 {
 	"default": {
-		"import": ["features/**/*.ts"]
+		"import": ["features/**/*.ts"],
+		"parallel": 4
 	}
 }

--- a/features/invalid-actor-json-output.feature.md
+++ b/features/invalid-actor-json-output.feature.md
@@ -1,0 +1,29 @@
+# Feature: Print out path to invalid `actor.json`
+
+- As an Actor developer or user
+- I want to know the path to the invalid `actor.json`
+- In order to fix it
+- If the file is not valid JSON
+
+## Background:
+
+- Given my `pwd` is a fully initialized Actor project directory
+- And the `actor.json` is invalid
+
+## Rule: Print out path to invalid `actor.json`
+
+### Example: Invalid `actor.json` file
+
+- When I run:
+  ```
+  $ apify run
+  ```
+- Then I can read text on stderr:
+  ```
+  Failed to read local config at path:
+  ```
+- And I can read text on stderr:
+  ```
+  Expected property name or '}'
+  ```
+- And the exit status code is `5`

--- a/features/test-implementations/1.setup.ts
+++ b/features/test-implementations/1.setup.ts
@@ -61,6 +61,15 @@ Given<TestWorld>(/the `actor.json` is valid/i, function () {
 	// Maybe this is something we want to implement >:3
 });
 
+Given<TestWorld>(/the `actor.json` is invalid/i, async function () {
+	assertWorldIsValid(this);
+
+	const actorJsonFile = new URL('./.actor/actor.json', this.testActor.pwd);
+
+	// We'll just overwrite the file with some invalid JSON
+	await writeFile(actorJsonFile, `{ wow "name": "my-invalid-actor" }`);
+});
+
 Given<TestWorld>(/the actor implementation doesn't throw itself/i, { timeout: 120_000 }, async function () {
 	assertWorldIsValid(this);
 

--- a/features/test-implementations/1.setup.ts
+++ b/features/test-implementations/1.setup.ts
@@ -11,7 +11,7 @@ const createdActors: URL[] = [];
 
 if (!process.env.DO_NOT_DELETE_CUCUMBER_TEST_ACTORS) {
 	AfterAll(async () => {
-		console.log('\n  Cleaning up actors...');
+		console.log(`\n  Cleaning up actors for worker ${process.env.CUCUMBER_WORKER_ID}...`);
 
 		for (const path of createdActors) {
 			await rm(path, { recursive: true, force: true });

--- a/features/test-implementations/README.md
+++ b/features/test-implementations/README.md
@@ -26,6 +26,7 @@ Currently, the following phrases are implemented:
 
 - ``given my `pwd` is a fully initialized actor project directory``
 - ``given the `actor.json` is valid``
+- ``given the `actor.json` is invalid``
 - `given the actor implementation doesn't throw itself`
 - `given the following input provided via standard input`
   - Example:

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,7 @@ import inquirer from 'inquirer';
 
 import { ApifyCommand } from '../lib/apify_command.js';
 import {
+	CommandExitCodes,
 	DEFAULT_LOCAL_STORAGE_DIR,
 	EMPTY_LOCAL_CONFIG,
 	LANGUAGE,
@@ -98,6 +99,7 @@ export class InitCommand extends ApifyCommand<typeof InitCommand> {
 				const cause = casted.cause as Error;
 
 				error({ message: `${casted.message}\n  ${cause.message}` });
+				process.exitCode = CommandExitCodes.InvalidActorJson;
 				return;
 			}
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -88,8 +88,21 @@ export class InitCommand extends ApifyCommand<typeof InitCommand> {
 
 				({ actName: actorName } = response);
 			}
+
+			let existingLocalConfig: Record<string, unknown> | undefined;
+
+			try {
+				existingLocalConfig = await getLocalConfigOrThrow(cwd);
+			} catch (_error) {
+				const casted = _error as Error;
+				const cause = casted.cause as Error;
+
+				error({ message: `${casted.message}\n  ${cause.message}` });
+				return;
+			}
+
 			// Migrate apify.json to .actor/actor.json
-			const localConfig = { ...EMPTY_LOCAL_CONFIG, ...(await getLocalConfigOrThrow(cwd)) };
+			const localConfig = { ...EMPTY_LOCAL_CONFIG, ...existingLocalConfig };
 			await setLocalConfig(Object.assign(localConfig, { name: actorName }), cwd);
 		}
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -10,7 +10,7 @@ import { gt } from 'semver';
 import tiged from 'tiged';
 
 import { ApifyCommand } from '../lib/apify_command.js';
-import { LOCAL_CONFIG_PATH } from '../lib/consts.js';
+import { CommandExitCodes, LOCAL_CONFIG_PATH } from '../lib/consts.js';
 import { error, success } from '../lib/outputs.js';
 import { getLocalConfigOrThrow, getLocalUserInfo, getLoggedClientOrThrow } from '../lib/utils.js';
 
@@ -56,6 +56,7 @@ export class PullCommand extends ApifyCommand<typeof PullCommand> {
 			const cause = casted.cause as Error;
 
 			error({ message: `${casted.message}\n  ${cause.message}` });
+			process.exitCode = CommandExitCodes.InvalidActorJson;
 			return;
 		}
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -46,7 +46,19 @@ export class PullCommand extends ApifyCommand<typeof PullCommand> {
 
 	async run() {
 		const cwd = process.cwd();
-		const localConfig = await getLocalConfigOrThrow(cwd);
+
+		let localConfig: Record<string, unknown>;
+
+		try {
+			localConfig = (await getLocalConfigOrThrow(cwd))!;
+		} catch (_error) {
+			const casted = _error as Error;
+			const cause = casted.cause as Error;
+
+			error({ message: `${casted.message}\n  ${cause.message}` });
+			return;
+		}
+
 		const userInfo = await getLocalUserInfo();
 		const apifyClient = await getLoggedClientOrThrow();
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -5,7 +5,7 @@ import process from 'node:process';
 import { fetchManifest } from '@apify/actor-templates';
 import { ACTOR_JOB_STATUSES, ACTOR_SOURCE_TYPES, MAX_MULTIFILE_BYTES } from '@apify/consts';
 import { Args, Flags } from '@oclif/core';
-import { Actor, ActorCollectionCreateOptions, ActorDefaultRunOptions } from 'apify-client';
+import type { Actor, ActorCollectionCreateOptions, ActorDefaultRunOptions } from 'apify-client';
 import inquirer from 'inquirer';
 import isCI from 'is-ci';
 import open from 'open';
@@ -135,7 +135,19 @@ export class PushCommand extends ApifyCommand<typeof PushCommand> {
 		}
 
 		const apifyClient = await getLoggedClientOrThrow();
-		const localConfig = await getLocalConfigOrThrow(cwd);
+
+		let localConfig: Record<string, unknown>;
+
+		try {
+			localConfig = (await getLocalConfigOrThrow(cwd))!;
+		} catch (_error) {
+			const casted = _error as Error;
+			const cause = casted.cause as Error;
+
+			error({ message: `${casted.message}\n  ${cause.message}` });
+			return;
+		}
+
 		const userInfo = await getLocalUserInfo();
 		const isOrganizationLoggedIn = !!userInfo.organizationOwnerUserId;
 		const redirectUrlPart = isOrganizationLoggedIn ? `/organization/${userInfo.id}` : '';

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -145,6 +145,7 @@ export class PushCommand extends ApifyCommand<typeof PushCommand> {
 			const cause = casted.cause as Error;
 
 			error({ message: `${casted.message}\n  ${cause.message}` });
+			process.exitCode = CommandExitCodes.InvalidActorJson;
 			return;
 		}
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -107,7 +107,18 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 		const cwd = process.cwd();
 
 		const { proxy, id: userId, token } = await getLocalUserInfo();
-		const localConfig = await getLocalConfigOrThrow(cwd);
+
+		let localConfig: Record<string, unknown>;
+
+		try {
+			localConfig = (await getLocalConfigOrThrow(cwd))!;
+		} catch (_error) {
+			const casted = _error as Error;
+			const cause = casted.cause as Error;
+
+			error({ message: `${casted.message}\n  ${cause.message}` });
+			return;
+		}
 
 		const packageJsonPath = join(cwd, 'package.json');
 		const mainPyPath = join(cwd, 'src/__main__.py');

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -13,6 +13,7 @@ import { minVersion } from 'semver';
 import { ApifyCommand } from '../lib/apify_command.js';
 import { getInputOverride } from '../lib/commands/resolve-input.js';
 import {
+	CommandExitCodes,
 	DEFAULT_LOCAL_STORAGE_DIR,
 	LANGUAGE,
 	LEGACY_LOCAL_STORAGE_DIR,
@@ -117,6 +118,7 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 			const cause = casted.cause as Error;
 
 			error({ message: `${casted.message}\n  ${cause.message}` });
+			process.exitCode = CommandExitCodes.InvalidActorJson;
 			return;
 		}
 

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -96,4 +96,5 @@ export enum CommandExitCodes {
 	NoFilesToPush = 4,
 
 	InvalidInput = 5,
+	InvalidActorJson = 5,
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -221,8 +221,21 @@ export const getLocalConfig = (cwd: string) => getJsonFileContent(getLocalConfig
 const getDeprecatedLocalConfig = (cwd: string) => getJsonFileContent(getDeprecatedLocalConfigPath(cwd));
 
 export const getLocalConfigOrThrow = async (cwd: string) => {
-	let localConfig = getLocalConfig(cwd);
-	let deprecatedLocalConfig = getDeprecatedLocalConfig(cwd);
+	let localConfig: Record<string, unknown> | undefined;
+
+	try {
+		localConfig = getLocalConfig(cwd);
+	} catch (error) {
+		throw new Error(`Failed to read local config at path: '${LOCAL_CONFIG_PATH}':`, { cause: error });
+	}
+
+	let deprecatedLocalConfig: Record<string, unknown> | undefined;
+
+	try {
+		deprecatedLocalConfig = getDeprecatedLocalConfig(cwd);
+	} catch (error) {
+		throw new Error(`Failed to read local config at path: '${DEPRECATED_LOCAL_CONFIG_NAME}':`, { cause: error });
+	}
 
 	if (localConfig && deprecatedLocalConfig) {
 		const answer = await inquirer.prompt([


### PR DESCRIPTION
Invalid actor.jsons will have their path printed out now

![iTerm2 - 2024-08-27 at 18 03 20](https://github.com/user-attachments/assets/5c015f4c-1e80-4704-bc4c-b9ae71bf56fc)


Closes #561