### PR TITLE
chore: several tweaks 

### DIFF
--- a/src/commands/actors/call.ts
+++ b/src/commands/actors/call.ts
@@ -119,6 +119,9 @@ export class ActorsCallCommand extends ApifyCommand<typeof ActorsCallCommand> {
 		let runStarted = false;
 		let run: ActorRun;
 
+		let url: string;
+		let datasetUrl: string;
+
 		const iterator = runActorOrTaskOnCloud(apifyClient, {
 			actorOrTaskData: {
 				id: actorId,
@@ -141,7 +144,8 @@ export class ActorsCallCommand extends ApifyCommand<typeof ActorsCallCommand> {
 
 				// A *lot* is copied from `runs info`
 				if (!this.flags.silent) {
-					const url = `https://console.apify.com/actors/${actorId}/runs/${yieldedRun.id}`;
+					url = `https://console.apify.com/actors/${actorId}/runs/${yieldedRun.id}`;
+					datasetUrl = `https://console.apify.com/storage/datasets/${yieldedRun.defaultDatasetId}`;
 
 					const message: string[] = [
 						`${chalk.yellow('Started')}: ${TimestampFormatter.display(yieldedRun.startedAt)}`,
@@ -187,15 +191,26 @@ export class ActorsCallCommand extends ApifyCommand<typeof ActorsCallCommand> {
 					message.push(`${chalk.yellow('Memory')}: ${run.options.memoryMbytes} MB`);
 
 					// url
-					message.push('', `${chalk.blue('View on Apify Console')}: ${url}`, '');
+					message.push(`${chalk.blue('View on Apify Console')}: ${url}`, '');
 
-					simpleLog({ message: message.join('\n') });
+					simpleLog({ message: message.join('\n'), stdout: true });
 				}
 			}
 		}
 
 		if (this.flags.json) {
 			return run!;
+		}
+
+		if (!this.flags.silent) {
+			simpleLog({
+				message: [
+					'',
+					`${chalk.blue('Export results')}: ${datasetUrl!}`,
+					`${chalk.blue('View on Apify Console')}: ${url!}`,
+				].join('\n'),
+				stdout: true,
+			});
 		}
 
 		if (this.flags.outputDataset) {

--- a/src/commands/actors/call.ts
+++ b/src/commands/actors/call.ts
@@ -93,10 +93,6 @@ export class ActorsCallCommand extends ApifyCommand<typeof ActorsCallCommand> {
 			waitForFinish: 2, // NOTE: We need to wait some time to Apify open stream and we can create connection
 		};
 
-		const waitForFinishMillis = Number.isNaN(this.flags.waitForFinish)
-			? undefined
-			: Number.parseInt(this.flags.waitForFinish!, 10) * 1000;
-
 		if (this.flags.build) {
 			runOpts.build = this.flags.build;
 		}
@@ -129,7 +125,6 @@ export class ActorsCallCommand extends ApifyCommand<typeof ActorsCallCommand> {
 			},
 			runOptions: runOpts,
 			type: 'Actor',
-			waitForFinishMillis,
 			inputOverride: inputOverride?.input,
 			silent: this.flags.silent,
 			waitForRunToFinish: true,

--- a/src/commands/builds/create.ts
+++ b/src/commands/builds/create.ts
@@ -24,7 +24,7 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 	};
 
 	static override args = {
-		actor: Args.string({
+		actorId: Args.string({
 			description:
 				'Optional Actor ID or Name to trigger a build for. By default, it will use the Actor from the current directory.',
 		}),
@@ -34,11 +34,11 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 
 	async run() {
 		const { tag, version, json, log } = this.flags;
-		const { actor } = this.args;
+		const { actorId } = this.args;
 
 		const client = await getLoggedClientOrThrow();
 
-		const ctx = await resolveActorContext({ providedActorNameOrId: actor, client });
+		const ctx = await resolveActorContext({ providedActorNameOrId: actorId, client });
 
 		if (!ctx.valid) {
 			error({
@@ -74,6 +74,7 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 			if (tag && (!taggedVersions || !taggedVersions.some((v) => v.versionNumber === version))) {
 				error({
 					message: `The Actor Version "${version}" does not have the tag "${tag}".`,
+					stdout: true,
 				});
 
 				return;
@@ -89,6 +90,7 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 				if (!version) {
 					error({
 						message: `Multiple Actor versions with the tag "${tag}" found. Please specify the version number using the "--version" flag.\n  Available versions for this tag: ${taggedVersions.map((v) => chalk.yellow(v.versionNumber)).join(', ')}`,
+						stdout: true,
 					});
 
 					return;
@@ -101,6 +103,7 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 		if (!selectedVersion) {
 			error({
 				message: `No Actor versions with the tag "${tag}" found. You can push a new version with this tag by using "apify push --build-tag=${tag}".`,
+				stdout: true,
 			});
 
 			return;
@@ -127,6 +130,7 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 
 		simpleLog({
 			message: message.join('\n'),
+			stdout: true,
 		});
 
 		if (log) {
@@ -142,11 +146,13 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 			// Print out an empty line
 			simpleLog({
 				message: '',
+				stdout: true,
 			});
 		}
 
 		simpleLog({
 			message: viewMessage,
+			stdout: true,
 		});
 
 		return undefined;

--- a/src/commands/builds/ls.ts
+++ b/src/commands/builds/ls.ts
@@ -59,6 +59,7 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 		if (!ctx.valid) {
 			error({
 				message: `${ctx.reason}. Please run this command in an Actor directory, or specify the Actor ID by running this command with "--actor=<id>".`,
+				stdout: true,
 			});
 
 			return;
@@ -102,6 +103,7 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 
 		simpleLog({
 			message: `${chalk.reset('Showing')} ${chalk.yellow(allBuilds.items.length)} out of ${chalk.yellow(allBuilds.total)} builds for Actor ${chalk.yellow(ctx.userFriendlyId)} (${chalk.gray(ctx.id)})\n`,
+			stdout: true,
 		});
 
 		const sortedActorVersions = Object.entries(buildsByActorVersion).sort((a, b) => a[0].localeCompare(b[0]));
@@ -110,6 +112,7 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 			if (!buildsForVersion?.length) {
 				simpleLog({
 					message: `No builds for version ${actorVersion}`,
+					stdout: true,
 				});
 
 				continue;
@@ -133,6 +136,7 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 
 			simpleLog({
 				message: message.join('\n'),
+				stdout: true,
 			});
 		}
 

--- a/src/commands/builds/ls.ts
+++ b/src/commands/builds/ls.ts
@@ -58,7 +58,7 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 
 		if (!ctx.valid) {
 			error({
-				message: `${ctx.reason}. Please run this command in an Actor directory, or specify the Actor ID by running this command with "--actor=<id>".`,
+				message: `${ctx.reason}. Please run this command in an Actor directory, or specify the Actor ID.`,
 				stdout: true,
 			});
 

--- a/src/commands/builds/ls.ts
+++ b/src/commands/builds/ls.ts
@@ -1,4 +1,4 @@
-import { Flags } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import type { BuildCollectionClientListItem } from 'apify-client';
 import chalk from 'chalk';
 
@@ -19,10 +19,6 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 	static override description = 'Lists all builds of the Actor.';
 
 	static override flags = {
-		actor: Flags.string({
-			description:
-				'Optional Actor ID or Name to list builds for. By default, it will use the Actor from the current directory.',
-		}),
 		offset: Flags.integer({
 			description: 'Number of builds that will be skipped.',
 			default: 0,
@@ -42,15 +38,23 @@ export class BuildLsCommand extends ApifyCommand<typeof BuildLsCommand> {
 		}),
 	};
 
+	static override args = {
+		actorId: Args.string({
+			description:
+				'Optional Actor ID or Name to list runs for. By default, it will use the Actor from the current directory.',
+		}),
+	};
+
 	static override enableJsonFlag = true;
 
 	async run() {
-		const { actor, desc, limit, offset, compact, json } = this.flags;
+		const { desc, limit, offset, compact, json } = this.flags;
+		const { actorId } = this.args;
 
 		const client = await getLoggedClientOrThrow();
 
 		// TODO: technically speaking, we don't *need* an actor id to list builds. But it makes more sense to have a table of builds for a specific actor.
-		const ctx = await resolveActorContext({ providedActorNameOrId: actor, client });
+		const ctx = await resolveActorContext({ providedActorNameOrId: actorId, client });
 
 		if (!ctx.valid) {
 			error({

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -156,13 +156,16 @@ export class PushCommand extends ApifyCommand<typeof PushCommand> {
 		let actorId: string;
 		let actor: Actor;
 		let isActorCreatedNow = false;
+
 		// User can override Actor version and build tag, attributes in localConfig will remain same.
 		const version =
 			this.flags.version ||
 			this.flags.versionNumber ||
 			(localConfig?.version as string | undefined) ||
 			DEFAULT_ACTOR_VERSION_NUMBER;
+
 		let buildTag = this.flags.buildTag || (localConfig!.buildTag as string | undefined);
+
 		// We can't add the default build tag to everything. If a user creates a new
 		// version, e.g. for testing, but forgets to add a tag, it would use the default
 		// tag and their production runs might be affected ❌
@@ -170,9 +173,11 @@ export class PushCommand extends ApifyCommand<typeof PushCommand> {
 		if (!buildTag && version === DEFAULT_ACTOR_VERSION_NUMBER) {
 			buildTag = DEFAULT_BUILD_TAG;
 		}
+
 		const waitForFinishMillis = Number.isNaN(this.flags.waitForFinish)
 			? undefined
 			: Number.parseInt(this.flags.waitForFinish!, 10) * 1000;
+
 		// User can override actorId of pushing Actor.
 		// It causes that we push Actor to this id but attributes in localConfig will remain same.
 		const forceActorId = this.args.actorId;
@@ -274,6 +279,7 @@ Skipping push. Use --force to override.`,
 		const envVars = localConfig!.environmentVariables
 			? transformEnvToEnvVars(localConfig!.environmentVariables as Record<string, string>)
 			: undefined;
+
 		if (actorCurrentVersion) {
 			const actorVersionModifier = { tarballUrl, sourceFiles, buildTag, sourceType, envVars };
 			// TODO: fix this type too -.-

--- a/src/commands/runs/abort.ts
+++ b/src/commands/runs/abort.ts
@@ -38,15 +38,15 @@ export class RunsAbortCommand extends ApifyCommand<typeof RunsAbortCommand> {
 		const run = await apifyClient.run(runId).get();
 
 		if (!run) {
-			error({ message: `Run with ID "${runId}" was not found on your account.` });
+			error({ message: `Run with ID "${runId}" was not found on your account.`, stdout: true });
 			return;
 		}
 
 		if (!runningStatuses.includes(run.status as never)) {
 			if (abortingStatuses.includes(run.status as never)) {
-				error({ message: `Run with ID "${runId}" is already aborting.` });
+				error({ message: `Run with ID "${runId}" is already aborting.`, stdout: true });
 			} else {
-				error({ message: `Run with ID "${runId}" is already aborted.` });
+				error({ message: `Run with ID "${runId}" is already aborted.`, stdout: true });
 			}
 
 			return;
@@ -60,10 +60,11 @@ export class RunsAbortCommand extends ApifyCommand<typeof RunsAbortCommand> {
 			}
 
 			if (this.flags.force) {
-				success({ message: `Triggered the immediate abort of run "${runId}".` });
+				success({ message: `Triggered the immediate abort of run "${runId}".`, stdout: true });
 			} else {
 				success({
 					message: `Triggered the abort of run "${runId}", it should finish aborting in up to 30 seconds.`,
+					stdout: true,
 				});
 			}
 		} catch (err) {
@@ -71,6 +72,7 @@ export class RunsAbortCommand extends ApifyCommand<typeof RunsAbortCommand> {
 
 			error({
 				message: `Failed to abort run "${runId}".\n  ${casted.message || casted}`,
+				stdout: true,
 			});
 		}
 

--- a/src/commands/runs/info.ts
+++ b/src/commands/runs/info.ts
@@ -241,7 +241,7 @@ export class RunsInfoCommand extends ApifyCommand<typeof RunsInfoCommand> {
 		message.push(`${chalk.blue('View saved items')}: ${keyValueStoreUrl}`);
 		message.push(`${chalk.blue('View in Apify Console')}: ${url}`);
 
-		simpleLog({ message: message.join('\n') });
+		simpleLog({ message: message.join('\n'), stdout: true });
 
 		return undefined;
 	}

--- a/src/commands/runs/log.ts
+++ b/src/commands/runs/log.ts
@@ -22,11 +22,11 @@ export class RunsLogCommand extends ApifyCommand<typeof RunsLogCommand> {
 		const run = await apifyClient.run(runId).get();
 
 		if (!run) {
-			error({ message: `Run with ID "${runId}" was not found on your account.` });
+			error({ message: `Run with ID "${runId}" was not found on your account.`, stdout: true });
 			return;
 		}
 
-		info({ message: `Log for run with ID "${runId}":\n` });
+		info({ message: `Log for run with ID "${runId}":\n`, stdout: true });
 
 		try {
 			await outputJobLog(run);

--- a/src/commands/runs/ls.ts
+++ b/src/commands/runs/ls.ts
@@ -65,7 +65,7 @@ export class RunsLsCommand extends ApifyCommand<typeof RunsLsCommand> {
 
 		if (!ctx.valid) {
 			error({
-				message: `${ctx.reason}. Please run this command in an Actor directory, or specify the Actor ID by running this command with "--actor=<id>".`,
+				message: `${ctx.reason}. Please run this command in an Actor directory, or specify the Actor ID.`,
 			});
 
 			return;

--- a/src/commands/runs/ls.ts
+++ b/src/commands/runs/ls.ts
@@ -1,4 +1,4 @@
-import { Flags } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { Timestamp } from '@sapphire/timestamp';
 import chalk from 'chalk';
 
@@ -26,10 +26,6 @@ export class RunsLsCommand extends ApifyCommand<typeof RunsLsCommand> {
 	static override description = 'Lists all runs of the Actor.';
 
 	static override flags = {
-		actor: Flags.string({
-			description:
-				'Optional Actor ID or Name to list runs for. By default, it will use the Actor from the current directory.',
-		}),
 		offset: Flags.integer({
 			description: 'Number of runs that will be skipped.',
 			default: 0,
@@ -49,15 +45,23 @@ export class RunsLsCommand extends ApifyCommand<typeof RunsLsCommand> {
 		}),
 	};
 
+	static override args = {
+		actorId: Args.string({
+			description:
+				'Optional Actor ID or Name to list runs for. By default, it will use the Actor from the current directory.',
+		}),
+	};
+
 	static override enableJsonFlag = true;
 
 	async run() {
-		const { actor, desc, limit, offset, compact, json } = this.flags;
+		const { desc, limit, offset, compact, json } = this.flags;
+		const { actorId } = this.args;
 
 		const client = await getLoggedClientOrThrow();
 
 		// Should we allow users to list any runs, not just actor-specific runs? Right now it works like `builds ls`, requiring an actor
-		const ctx = await resolveActorContext({ providedActorNameOrId: actor, client });
+		const ctx = await resolveActorContext({ providedActorNameOrId: actorId, client });
 
 		if (!ctx.valid) {
 			error({

--- a/src/commands/runs/ls.ts
+++ b/src/commands/runs/ls.ts
@@ -128,6 +128,7 @@ export class RunsLsCommand extends ApifyCommand<typeof RunsLsCommand> {
 
 		simpleLog({
 			message: message.join('\n'),
+			stdout: true,
 		});
 
 		return undefined;

--- a/src/commands/runs/resurrect.ts
+++ b/src/commands/runs/resurrect.ts
@@ -33,13 +33,14 @@ export class RunsResurrectCommand extends ApifyCommand<typeof RunsResurrectComma
 		const run = await apifyClient.run(runId).get();
 
 		if (!run) {
-			error({ message: `Run with ID "${runId}" was not found on your account.` });
+			error({ message: `Run with ID "${runId}" was not found on your account.`, stdout: true });
 			return;
 		}
 
 		if (!resurrectStatuses.includes(run.status as never)) {
 			error({
 				message: `Run with ID "${runId}" cannot be resurrected, as it is still running or in the process of aborting.`,
+				stdout: true,
 			});
 
 			return;
@@ -52,12 +53,13 @@ export class RunsResurrectCommand extends ApifyCommand<typeof RunsResurrectComma
 				return result;
 			}
 
-			success({ message: `Run with ID "${runId}" was resurrected successfully.` });
+			success({ message: `Run with ID "${runId}" was resurrected successfully.`, stdout: true });
 		} catch (err) {
 			const casted = err as ApifyApiError;
 
 			error({
 				message: `Failed to resurrect run "${runId}".\n  ${casted.message || casted}`,
+				stdout: true,
 			});
 		}
 

--- a/src/commands/task/run.ts
+++ b/src/commands/task/run.ts
@@ -33,10 +33,6 @@ export class TaskRunCommand extends ApifyCommand<typeof TaskRunCommand> {
 			waitForFinish: 2, // NOTE: We need to wait some time to Apify open stream and we can create connection
 		};
 
-		const waitForFinishMillis = Number.isNaN(this.flags.waitForFinish)
-			? undefined
-			: Number.parseInt(this.flags.waitForFinish!, 10) * 1000;
-
 		if (this.flags.build) {
 			runOpts.build = this.flags.build;
 		}
@@ -60,7 +56,6 @@ export class TaskRunCommand extends ApifyCommand<typeof TaskRunCommand> {
 			},
 			runOptions: runOpts,
 			type: 'Task',
-			waitForFinishMillis,
 			printRunLogs: true,
 		});
 

--- a/src/lib/commands/run-on-cloud.ts
+++ b/src/lib/commands/run-on-cloud.ts
@@ -157,9 +157,4 @@ export const SharedRunOnCloudFlags = (type: 'Actor' | 'Task') => ({
 		description: `Amount of memory allocated for the ${type} run, in megabytes.`,
 		required: false,
 	}),
-	'wait-for-finish': Flags.string({
-		char: 'w',
-		description: 'Seconds for waiting to run to finish, if no value passed, it waits forever.',
-		required: false,
-	}),
 });


### PR DESCRIPTION
- adds in a direct link to exporting the dataset url for `actors call` / `actors start` when it happens / `tasks run`
- moves most outputs to stdout for commands, keeping stderr mostly for actor run logs
- moves all `--actor=` to arguments instead
- remove `wait-for-finish` from `actors call`, as it now always waits for the run to finish (and `actors start` will immediately return the run)