### PR TITLE
chore: Setup cli app for Mixpanel

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -72,7 +72,7 @@ export const maybeTrackTelemetry = async ({
 		const distinctId = getOrCreateLocalDistinctId();
 		await promisifiedTrack(eventName, {
 			distinct_id: distinctId,
-            app: 'cli',
+			app: 'cli',
 			...eventData,
 		});
 	} catch (e) {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -72,6 +72,7 @@ export const maybeTrackTelemetry = async ({
 		const distinctId = getOrCreateLocalDistinctId();
 		await promisifiedTrack(eventName, {
 			distinct_id: distinctId,
+            app: 'cli',
 			...eventData,
 		});
 	} catch (e) {


### PR DESCRIPTION
Part of apify/apify-web#4066

Similarly to the console, we want to distinguish among multiple sources of data for Mixpanel, thus setting `app` property to every tracking call.