### PR TITLE
fix outputJobLog API call with security token

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -505,7 +505,7 @@ export const purgeDefaultKeyValueStore = async () => {
 
 export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
 	const { id: logId, status } = job;
-	const apifyClient = new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
+	const apifyClient = new ApifyClient(getApifyClientOptions());
 
 	// In case job was already done just output log
 	if (ACTOR_JOB_TERMINAL_STATUSES.includes(status as never)) {


### PR DESCRIPTION
If you ask to security team to enable token verification to all API call, this method will fail because doesn't pass token.

This commit add default parameter to Log Client (so token) to follow common token security usage.