### PR TITLE
feat: make storage purging default, add `--resurrect`

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-11-arm]
+                os: [ubuntu-latest, windows-2025]
                 node-version: [18, 20, 22, 24]
 
         steps:
@@ -60,7 +60,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-11-arm]
+                os: [ubuntu-latest, windows-2025]
                 python-version: ["3.9", "3.10", "3.11", "3.12"]
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest, windows-11-arm]
                 node-version: [18, 20, 22, 24]
 
         steps:
@@ -60,7 +60,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest, windows-11-arm]
                 python-version: ["3.9", "3.10", "3.11", "3.12"]
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cucumber.yaml
+++ b/.github/workflows/cucumber.yaml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-11-arm]
+                os: [ubuntu-latest, windows-2025]
                 # We only test LTS for now
                 node-version: [22]
 

--- a/.github/workflows/cucumber.yaml
+++ b/.github/workflows/cucumber.yaml
@@ -16,9 +16,9 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest, windows-11-arm]
                 # We only test LTS for now
-                node-version: [20]
+                node-version: [22]
 
         runs-on: ${{ matrix.os }}
 

--- a/src/commands/_register.ts
+++ b/src/commands/_register.ts
@@ -66,4 +66,5 @@ export const actorCommands = [
 	ActorGetInputCommand,
 	ActorChargeCommand,
 	HelpCommand,
+	UpgradeCommand,
 ] as const satisfies (typeof BuiltApifyCommand)[];

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -312,6 +312,8 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 					});
 
 					return;
+				} else if (typeof builderData.hasDefault !== 'undefined') {
+					this.flags[camelCasedName] = builderData.hasDefault;
 				}
 			}
 		}
@@ -452,7 +454,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 					// yargs handles "no-" flags by negating the flag, so we need to handle that differently if we register a flag with a "no-" prefix
 					if (flagKey.startsWith('no-')) {
-						finalYargs = internalBuilderData.builder(finalYargs, flagKey.slice(3), [], true);
+						finalYargs = internalBuilderData.builder(finalYargs, flagKey.slice(3));
 					} else {
 						finalYargs = internalBuilderData.builder(finalYargs, flagKey);
 					}

--- a/src/lib/command-framework/flags.ts
+++ b/src/lib/command-framework/flags.ts
@@ -42,7 +42,7 @@ export interface TaggedFlagBuilder<
 	HasDefault = false,
 > {
 	flagTag: Tag;
-	builder: (args: Argv, objectName: string, extraArgs?: string[], invertDefaultIfSet?: boolean) => Argv;
+	builder: (args: Argv, objectName: string, extraArgs?: string[]) => Argv;
 	choicesType: ChoicesType;
 	required: Required;
 	hasDefault: HasDefault;
@@ -67,7 +67,7 @@ function stringFlag<const Choices extends string[], const T extends StringFlagOp
 ): TaggedFlagBuilder<'string', Choices, T['default'] extends string ? true : T['required'], T['default']> {
 	return {
 		flagTag: 'string',
-		builder: (args, objectName, extraAliases, invertDefaultIfSet = false) => {
+		builder: (args, objectName, extraAliases) => {
 			const allAliases = new Set([...(options.aliases ?? []), ...(extraAliases ?? [])]);
 
 			if (options.char) {
@@ -82,7 +82,6 @@ function stringFlag<const Choices extends string[], const T extends StringFlagOp
 				alias: [...allAliases].map((alias) => kebabCaseString(camelCaseToKebabCase(alias))),
 				hidden: options.hidden ?? false,
 				conflicts: options.exclusive,
-				default: invertDefaultIfSet ? !options.default : options.default,
 				choices: options.choices,
 				string: true,
 				// we only require something be passed in if we don't have a default or read from stdin
@@ -107,7 +106,7 @@ function booleanFlag<const T extends BooleanFlagOptions>(
 ): TaggedFlagBuilder<'boolean', never, T['default'] extends boolean ? true : T['required'], T['default']> {
 	return {
 		flagTag: 'boolean',
-		builder: (args, objectName, extraAliases, invertDefaultIfSet = false) => {
+		builder: (args, objectName, extraAliases) => {
 			const allAliases = new Set([...(options.aliases ?? []), ...(extraAliases ?? [])]);
 
 			if (options.char) {
@@ -122,7 +121,6 @@ function booleanFlag<const T extends BooleanFlagOptions>(
 				alias: [...allAliases].map((alias) => kebabCaseString(camelCaseToKebabCase(alias))),
 				hidden: options.hidden ?? false,
 				conflicts: options.exclusive,
-				default: invertDefaultIfSet ? !options.default : options.default,
 				boolean: true,
 			});
 		},
@@ -144,7 +142,7 @@ function integerFlag<const T extends IntegerFlagOptions>(
 ): TaggedFlagBuilder<'integer', never, T['default'] extends number ? true : T['required'], T['default']> {
 	return {
 		flagTag: 'integer',
-		builder: (args, objectName, extraAliases, invertDefaultIfSet = false) => {
+		builder: (args, objectName, extraAliases) => {
 			const allAliases = new Set([...(options.aliases ?? []), ...(extraAliases ?? [])]);
 
 			if (options.char) {
@@ -159,7 +157,6 @@ function integerFlag<const T extends IntegerFlagOptions>(
 				alias: [...allAliases].map((alias) => kebabCaseString(camelCaseToKebabCase(alias))),
 				hidden: options.hidden ?? false,
 				conflicts: options.exclusive,
-				default: invertDefaultIfSet ? !options.default : options.default,
 				choices: options.choices,
 				string: true,
 				nargs: 1,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
+// eslint-disable-next-line import/extensions
 import { defineConfig } from 'vitest/config';
 
 const isWindows = process.platform === 'win32';
+const multiplierFactor = isWindows ? 4 : 1;
 
 export default defineConfig({
 	esbuild: {
@@ -10,8 +12,8 @@ export default defineConfig({
 	test: {
 		globals: true,
 		restoreMocks: true,
-		testTimeout: 60_000 * (isWindows ? 2 : 1),
-		hookTimeout: 60_000 * (isWindows ? 2 : 1),
+		testTimeout: 60_000 * multiplierFactor,
+		hookTimeout: 60_000 * multiplierFactor,
 		include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
 		passWithNoTests: true,
 		silent: !process.env.NO_SILENT_TESTS,


### PR DESCRIPTION
Closes #590 

BREAKING CHANGE:

Purging in projects using Crawlee for SDK v3+ now purge by default, so using `--purge` flag is no longer necessary. Use `--no-purge` to keep the storage folder intact.
The `purge-queue`, `purge-dataset` and `purge-key-value-store` flags have been removed, and the logic of all three was combined into the `purge` flag.