### PR TITLE
docs: pseudo-automated new reference markdown file

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,9 +8,6 @@ on:
         branches: [master, renovate/**]
     pull_request:
         branches: [master]
-    # A release via GitHub releases will deploy a latest version
-    release:
-        types: [published]
 
 jobs:
     build_and_test:
@@ -50,6 +47,9 @@ jobs:
                   TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
                   APIFY_CLI_DISABLE_TELEMETRY: 1
               run: yarn test
+
+            - name: Ensure the reference documentation builds
+              run: yarn build-docs
 
     test_python_support:
         name: Test Python template support

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ package.tgz
 test/tmp
 oclif.manifest.json
 tmp
+
+scripts/temporary-reference.md

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,550 +2,159 @@
 title: Command reference
 ---
 
-This section contains printouts of `apify help` for all commands.
+# Reference
+
+# Apify CLI Reference Documentation
+
+The Apify CLI provides tools for managing your Apify projects and resources from the command line. Use these commands to develop Actors locally, deploy them to the Apify platform, manage storage, orchestrate runs, and handle account configuration.
+
+This reference guide documents available commands, their options, and common usage patterns, to efficiently work with the Apify platform.
+
+## General
+
+The general commands provide basic functionality for getting help and information about the Apify CLI.
 
 <!-- prettier-ignore-start -->
-<!-- commands -->
-* [`apify actor`](#apify-actor)
-* [`apify actor get-input`](#apify-actor-get-input)
-* [`apify actor get-value KEY`](#apify-actor-get-value-key)
-* [`apify actor push-data [ITEM]`](#apify-actor-push-data-item)
-* [`apify actor set-value KEY [VALUE]`](#apify-actor-set-value-key-value)
-* [`apify actors`](#apify-actors)
-* [`apify actors build [ACTORID]`](#apify-actors-build-actorid)
-* [`apify actors call [ACTORID]`](#apify-actors-call-actorid)
-* [`apify actors info ACTORID`](#apify-actors-info-actorid)
-* [`apify actors ls`](#apify-actors-ls)
-* [`apify actors pull [ACTORID]`](#apify-actors-pull-actorid)
-* [`apify actors push [ACTORID]`](#apify-actors-push-actorid)
-* [`apify actors rm ACTORID`](#apify-actors-rm-actorid)
-* [`apify actors start [ACTORID]`](#apify-actors-start-actorid)
-* [`apify builds`](#apify-builds)
-* [`apify builds create [ACTORID]`](#apify-builds-create-actorid)
-* [`apify builds info BUILDID`](#apify-builds-info-buildid)
-* [`apify builds log BUILDID`](#apify-builds-log-buildid)
-* [`apify builds ls [ACTORID]`](#apify-builds-ls-actorid)
-* [`apify builds rm BUILDID`](#apify-builds-rm-buildid)
-* [`apify call [ACTORID]`](#apify-call-actorid)
-* [`apify create [ACTORNAME]`](#apify-create-actorname)
-* [`apify datasets`](#apify-datasets)
-* [`apify datasets create [DATASETNAME]`](#apify-datasets-create-datasetname)
-* [`apify datasets get-items DATASETID`](#apify-datasets-get-items-datasetid)
-* [`apify datasets info STOREID`](#apify-datasets-info-storeid)
-* [`apify datasets ls`](#apify-datasets-ls)
-* [`apify datasets push-items NAMEORID [ITEM]`](#apify-datasets-push-items-nameorid-item)
-* [`apify datasets rename NAMEORID [NEWNAME]`](#apify-datasets-rename-nameorid-newname)
-* [`apify datasets rm DATASETNAMEORID`](#apify-datasets-rm-datasetnameorid)
-* [`apify help [COMMAND]`](#apify-help-command)
-* [`apify info`](#apify-info)
-* [`apify init [ACTORNAME]`](#apify-init-actorname)
-* [`apify key-value-stores`](#apify-key-value-stores)
-* [`apify key-value-stores create [KEYVALUESTORENAME]`](#apify-key-value-stores-create-keyvaluestorename)
-* [`apify key-value-stores delete-value STOREID ITEMKEY`](#apify-key-value-stores-delete-value-storeid-itemkey)
-* [`apify key-value-stores get-value KEYVALUESTOREID ITEMKEY`](#apify-key-value-stores-get-value-keyvaluestoreid-itemkey)
-* [`apify key-value-stores info STOREID`](#apify-key-value-stores-info-storeid)
-* [`apify key-value-stores keys STOREID`](#apify-key-value-stores-keys-storeid)
-* [`apify key-value-stores ls`](#apify-key-value-stores-ls)
-* [`apify key-value-stores rename KEYVALUESTORENAMEORID [NEWNAME]`](#apify-key-value-stores-rename-keyvaluestorenameorid-newname)
-* [`apify key-value-stores rm KEYVALUESTORENAMEORID`](#apify-key-value-stores-rm-keyvaluestorenameorid)
-* [`apify key-value-stores set-value STOREID ITEMKEY [VALUE]`](#apify-key-value-stores-set-value-storeid-itemkey-value)
-* [`apify login`](#apify-login)
-* [`apify logout`](#apify-logout)
-* [`apify pull [ACTORID]`](#apify-pull-actorid)
-* [`apify push [ACTORID]`](#apify-push-actorid)
-* [`apify request-queues`](#apify-request-queues)
-* [`apify run`](#apify-run)
-* [`apify runs`](#apify-runs)
-* [`apify runs abort RUNID`](#apify-runs-abort-runid)
-* [`apify runs info RUNID`](#apify-runs-info-runid)
-* [`apify runs log RUNID`](#apify-runs-log-runid)
-* [`apify runs ls [ACTORID]`](#apify-runs-ls-actorid)
-* [`apify runs resurrect RUNID`](#apify-runs-resurrect-runid)
-* [`apify runs rm RUNID`](#apify-runs-rm-runid)
-* [`apify secrets`](#apify-secrets)
-* [`apify secrets add NAME VALUE`](#apify-secrets-add-name-value)
-* [`apify secrets rm NAME`](#apify-secrets-rm-name)
-* [`apify task`](#apify-task)
-* [`apify task run TASKID`](#apify-task-run-taskid)
-* [`apify validate-schema [PATH]`](#apify-validate-schema-path)
+<!-- general-commands-start -->
+### `apify help [COMMAND]`
 
-## `apify actor`
-
-Manages runtime data operations inside of a running Actor.
+Display help for apify.
 
 ```
 USAGE
-  $ apify actor
-
-DESCRIPTION
-  Manages runtime data operations inside of a running Actor.
-```
-
-_See code: [src/commands/actor/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actor/index.ts)_
-
-## `apify actor get-input`
-
-Gets the Actor input value from the default key-value store associated with the Actor run.
-
-```
-USAGE
-  $ apify actor get-input
-
-DESCRIPTION
-  Gets the Actor input value from the default key-value store associated with the Actor run.
-```
-
-_See code: [src/commands/actor/get-input.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actor/get-input.ts)_
-
-## `apify actor get-value KEY`
-
-Gets a value from the default key-value store associated with the Actor run.
-
-```
-USAGE
-  $ apify actor get-value KEY
+  $ apify help [COMMAND...] [-n]
 
 ARGUMENTS
-  KEY  Key of the record in key-value store
-
-DESCRIPTION
-  Gets a value from the default key-value store associated with the Actor run.
-```
-
-_See code: [src/commands/actor/get-value.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actor/get-value.ts)_
-
-## `apify actor push-data [ITEM]`
-
-Saves data to Actor's run default dataset.
-
-```
-USAGE
-  $ apify actor push-data [ITEM]
-
-ARGUMENTS
-  ITEM  JSON string with one object or array of objects containing data to be stored in the default dataset.
-
-DESCRIPTION
-  Saves data to Actor's run default dataset.
-
-  Accept input as:
-  - JSON argument:
-  $ apify actor push-data {"key": "value"}
-  - Piped stdin:
-  $ cat ./test.json | apify actor push-data
-```
-
-_See code: [src/commands/actor/push-data.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actor/push-data.ts)_
-
-## `apify actor set-value KEY [VALUE]`
-
-Sets or removes record into the default key-value store associated with the Actor run.
-
-```
-USAGE
-  $ apify actor set-value KEY [VALUE] [-c <value>]
-
-ARGUMENTS
-  KEY    Key of the record in key-value store.
-  VALUE  Record data, which can be one of the following values:
-         - If empty, the record in the key-value store is deleted.
-         - If no `contentType` flag is specified, value is expected to be any JSON string value.
-         - If options.contentType is set, value is taken as is.
+  COMMAND...  Command to show help for.
 
 FLAGS
-  -c, --contentType=<value>  Specifies a custom MIME content type of the record. By default "application/json" is used.
+  -n, --nested-commands  Include all nested commands in the output.
 
 DESCRIPTION
-  Sets or removes record into the default key-value store associated with the Actor run.
-
-  It is possible to pass data using argument or stdin.
-
-  Passing data using argument:
-  $ apify actor set-value KEY my-value
-
-  Passing data using stdin with pipe:
-  $ cat ./my-text-file.txt | apify actor set-value KEY --contentType text/plain
+  Display help for apify.
 ```
+<!-- general-commands-end -->
+<!-- prettier-ignore-end -->
 
-_See code: [src/commands/actor/set-value.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actor/set-value.ts)_
+## Authentication & Account Management
 
-## `apify actors`
+Use these commands to manage your Apify account authentication, access tokens, and configuration settings. These commands control how you interact with the Apify platform and manage sensitive information.
 
-Manages Actor creation, deployment, and execution on the Apify platform.
+<!-- prettier-ignore-start -->
+<!-- auth-commands-start -->
+### `apify login`
+
+Authenticates your Apify account and saves credentials to '~/.apify'.
 
 ```
 USAGE
-  $ apify actors
-
-DESCRIPTION
-  Manages Actor creation, deployment, and execution on the Apify platform.
-```
-
-_See code: [src/commands/actors/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/index.ts)_
-
-## `apify actors build [ACTORID]`
-
-Creates a new build of the Actor.
-
-```
-USAGE
-  $ apify actors build [ACTORID] [--json] [--tag <value>] [--version <value>] [--log]
-
-ARGUMENTS
-  ACTORID  Optional Actor ID or Name to trigger a build for. By default, it will use the Actor from the current
-           directory.
+  $ apify login [-t <value>] [-m console|manual]
 
 FLAGS
-  --log              Whether to print out the build log after the build is triggered.
-  --tag=<value>      Build tag to be applied to the successful Actor build. By default, this is "latest".
-  --version=<value>  Optional Actor Version to build. By default, this will be inferred from the tag, but this flag is
-                     required when multiple versions have the same tag.
-
-GLOBAL FLAGS
-  --json  Format output as json.
+  -m, --method=<option>  [Optional] Method of logging in to Apify
+                         <options: console|manual>
+  -t, --token=<value>    [Optional] Apify API token
 
 DESCRIPTION
-  Creates a new build of the Actor.
+  Authenticates your Apify account and saves credentials to '~/.apify'.
+  All other commands use these stored credentials.
+
+  Run 'apify logout' to remove authentication.
 ```
 
-_See code: [src/commands/actors/build.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/build.ts)_
+### `apify logout`
 
-## `apify actors call [ACTORID]`
-
-Executes Actor remotely using your authenticated account.
+Removes authentication by deleting your API token and account information from '~/.apify'.
 
 ```
 USAGE
-  $ apify actors call [ACTORID] [--json] [-b <value>] [-t <value>] [-m <value>] [-i <value> | --input-file
-    <value>] [-s] [-o]
+  $ apify logout
+
+DESCRIPTION
+  Removes authentication by deleting your API token and account information from '~/.apify'.
+  Run 'apify login' to authenticate again.
+```
+
+### `apify info`
+
+Prints details about your currently authenticated Apify account.
+
+```
+USAGE
+  $ apify info
+
+DESCRIPTION
+  Prints details about your currently authenticated Apify account.
+```
+
+### `apify secrets`
+
+Manages secure environment variables for Actors.
+
+```
+USAGE
+  $ apify secrets
+
+DESCRIPTION
+  Manages secure environment variables for Actors.
+
+  Example:
+  $ apify secrets add mySecret TopSecretValue123
+
+  The "mySecret" value can be used in an environment variable defined in '.actor/actor.json' file by adding the "@"
+  prefix:
+
+  {
+  "actorSpecification": 1,
+  "name": "my_actor",
+  "environmentVariables": { "SECRET_ENV_VAR": "@mySecret" },
+  "version": "0.1"
+  }
+
+  When the Actor is pushed to Apify cloud, the "SECRET_ENV_VAR" and its value is stored as a secret environment variable
+  of the Actor.
+```
+
+### `apify secrets add NAME VALUE`
+
+Adds a new secret to '~/.apify' for use in Actor environment variables.
+
+```
+USAGE
+  $ apify secrets add NAME VALUE
 
 ARGUMENTS
-  ACTORID  Name or ID of the Actor to run (e.g. "my-actor", "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not
-           provided, the command runs the remote Actor specified in the '.actor/actor.json' file.
-
-FLAGS
-  -b, --build=<value>       Tag or number of the build to run (e.g. "latest" or "1.2.34").
-  -i, --input=<value>       Optional JSON input to be given to the Actor.
-  -m, --memory=<value>      Amount of memory allocated for the Actor run, in megabytes.
-  -o, --output-dataset      Prints out the entire default dataset on successful run of the Actor.
-  -s, --silent              Prevents printing the logs of the Actor run to the console.
-  -t, --timeout=<value>     Timeout for the Actor run in seconds. Zero value means there is no timeout.
-      --input-file=<value>  Optional path to a file with JSON input to be given to the Actor. The file must be a valid
-                            JSON file. You can also specify `-` to read from standard input.
-
-GLOBAL FLAGS
-  --json  Format output as json.
+  NAME   Name of the secret
+  VALUE  Value of the secret
 
 DESCRIPTION
-  Executes Actor remotely using your authenticated account.
-  Reads input from local key-value store by default.
+  Adds a new secret to '~/.apify' for use in Actor environment variables.
 ```
 
-_See code: [src/commands/actors/call.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/call.ts)_
+### `apify secrets rm NAME`
 
-## `apify actors info ACTORID`
-
-Get information about an Actor.
+Permanently deletes a secret from your stored credentials.
 
 ```
 USAGE
-  $ apify actors info ACTORID [--json] [--readme | --input]
+  $ apify secrets rm NAME
 
 ARGUMENTS
-  ACTORID  The ID of the Actor to return information about.
-
-FLAGS
-  --input   Return the Actor input schema.
-  --readme  Return the Actor README.
-
-GLOBAL FLAGS
-  --json  Format output as json.
+  NAME  Name of the secret
 
 DESCRIPTION
-  Get information about an Actor.
+  Permanently deletes a secret from your stored credentials.
 ```
+<!-- auth-commands-end -->
+<!-- prettier-ignore-end -->
 
-_See code: [src/commands/actors/info.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/info.ts)_
+## Actor Development
 
-## `apify actors ls`
+These commands help you develop actors locally. Use them to create new actor projects, initialize configurations, run actors in development mode, and validate input schemas.
 
-Prints a list of recently executed Actors or Actors you own.
-
-```
-USAGE
-  $ apify actors ls [--json] [--my] [--offset <value>] [--limit <value>] [--desc]
-
-FLAGS
-  --desc            Sort Actors in descending order.
-  --limit=<value>   [default: 20] Number of Actors that will be listed.
-  --my              Whether to list Actors made by the logged in user.
-  --offset=<value>  Number of Actors that will be skipped.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Prints a list of recently executed Actors or Actors you own.
-```
-
-_See code: [src/commands/actors/ls.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/ls.ts)_
-
-## `apify actors pull [ACTORID]`
-
-Download Actor code to current directory. Clones Git repositories or fetches Actor files based on the source type.
-
-```
-USAGE
-  $ apify actors pull [ACTORID] [-v <value>] [--dir <value>]
-
-ARGUMENTS
-  ACTORID  Name or ID of the Actor to run (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the
-           command will update the Actor in the current directory based on its name in ".actor/actor.json" file.
-
-FLAGS
-  -v, --version=<value>  Actor version number which will be pulled, e.g. 1.2. Default: the highest version
-      --dir=<value>      Directory where the Actor should be pulled to
-
-DESCRIPTION
-  Download Actor code to current directory. Clones Git repositories or fetches Actor files based on the source type.
-```
-
-_See code: [src/commands/actors/pull.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/pull.ts)_
-
-## `apify actors push [ACTORID]`
-
-Deploys Actor to Apify platform using settings from '.actor/actor.json'.
-
-```
-USAGE
-  $ apify actors push [ACTORID] [-v <value>] [-b <value>] [-w <value>] [--no-prompt] [--force] [--dir <value>]
-
-ARGUMENTS
-  ACTORID  Name or ID of the Actor to push (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the
-           command will create or modify the Actor with the name specified in '.actor/actor.json' file.
-
-FLAGS
-  -b, --build-tag=<value>        Build tag to be applied to the successful Actor build. By default, it is taken from the
-                                 '.actor/actor.json' file
-  -v, --version=<value>          Actor version number to which the files should be pushed. By default, it is taken from
-                                 the '.actor/actor.json' file.
-  -w, --wait-for-finish=<value>  Seconds for waiting to build to finish, if no value passed, it waits forever.
-      --dir=<value>              Directory where the Actor is located
-      --force                    Push an Actor even when the local files are older than the Actor on the platform.
-      --no-prompt                Do not prompt for opening the Actor details in a browser. This will also not open the
-                                 browser automatically.
-
-DESCRIPTION
-  Deploys Actor to Apify platform using settings from '.actor/actor.json'.
-  Files under '3' MB upload as "Multiple source files"; larger projects upload as ZIP file.
-  Use --force to override newer remote versions.
-```
-
-_See code: [src/commands/actors/push.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/push.ts)_
-
-## `apify actors rm ACTORID`
-
-Permanently removes an Actor from your account.
-
-```
-USAGE
-  $ apify actors rm ACTORID
-
-ARGUMENTS
-  ACTORID  The Actor ID to delete.
-
-DESCRIPTION
-  Permanently removes an Actor from your account.
-```
-
-_See code: [src/commands/actors/rm.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/rm.ts)_
-
-## `apify actors start [ACTORID]`
-
-Starts Actor remotely and returns run details immediately.
-
-```
-USAGE
-  $ apify actors start [ACTORID] [--json] [-b <value>] [-t <value>] [-m <value>] [-i <value> | --input-file
-    <value>]
-
-ARGUMENTS
-  ACTORID  Name or ID of the Actor to run (e.g. "my-actor", "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not
-           provided, the command runs the remote Actor specified in the '.actor/actor.json' file.
-
-FLAGS
-  -b, --build=<value>       Tag or number of the build to run (e.g. "latest" or "1.2.34").
-  -i, --input=<value>       Optional JSON input to be given to the Actor.
-  -m, --memory=<value>      Amount of memory allocated for the Actor run, in megabytes.
-  -t, --timeout=<value>     Timeout for the Actor run in seconds. Zero value means there is no timeout.
-      --input-file=<value>  Optional path to a file with JSON input to be given to the Actor. The file must be a valid
-                            JSON file. You can also specify `-` to read from standard input.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Starts Actor remotely and returns run details immediately.
-  Uses authenticated account and local key-value store for input.
-```
-
-_See code: [src/commands/actors/start.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/actors/start.ts)_
-
-## `apify builds`
-
-Manages Actor build processes and versioning.
-
-```
-USAGE
-  $ apify builds
-
-DESCRIPTION
-  Manages Actor build processes and versioning.
-```
-
-_See code: [src/commands/builds/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/builds/index.ts)_
-
-## `apify builds create [ACTORID]`
-
-Creates a new build of the Actor.
-
-```
-USAGE
-  $ apify builds create [ACTORID] [--json] [--tag <value>] [--version <value>] [--log]
-
-ARGUMENTS
-  ACTORID  Optional Actor ID or Name to trigger a build for. By default, it will use the Actor from the current
-           directory.
-
-FLAGS
-  --log              Whether to print out the build log after the build is triggered.
-  --tag=<value>      Build tag to be applied to the successful Actor build. By default, this is "latest".
-  --version=<value>  Optional Actor Version to build. By default, this will be inferred from the tag, but this flag is
-                     required when multiple versions have the same tag.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Creates a new build of the Actor.
-```
-
-_See code: [src/commands/builds/create.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/builds/create.ts)_
-
-## `apify builds info BUILDID`
-
-Prints information about a specific build.
-
-```
-USAGE
-  $ apify builds info BUILDID [--json]
-
-ARGUMENTS
-  BUILDID  The build ID to get information about.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Prints information about a specific build.
-```
-
-_See code: [src/commands/builds/info.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/builds/info.ts)_
-
-## `apify builds log BUILDID`
-
-Prints the log of a specific build.
-
-```
-USAGE
-  $ apify builds log BUILDID
-
-ARGUMENTS
-  BUILDID  The build ID to get the log from.
-
-DESCRIPTION
-  Prints the log of a specific build.
-```
-
-_See code: [src/commands/builds/log.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/builds/log.ts)_
-
-## `apify builds ls [ACTORID]`
-
-Lists all builds of the Actor.
-
-```
-USAGE
-  $ apify builds ls [ACTORID] [--json] [--offset <value>] [--limit <value>] [--desc] [-c]
-
-ARGUMENTS
-  ACTORID  Optional Actor ID or Name to list runs for. By default, it will use the Actor from the current directory.
-
-FLAGS
-  -c, --compact         Display a compact table.
-      --desc            Sort builds in descending order.
-      --limit=<value>   [default: 10] Number of builds that will be listed.
-      --offset=<value>  Number of builds that will be skipped.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Lists all builds of the Actor.
-```
-
-_See code: [src/commands/builds/ls.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/builds/ls.ts)_
-
-## `apify builds rm BUILDID`
-
-Permanently removes an Actor build from the Apify platform.
-
-```
-USAGE
-  $ apify builds rm BUILDID
-
-ARGUMENTS
-  BUILDID  The build ID to delete.
-
-DESCRIPTION
-  Permanently removes an Actor build from the Apify platform.
-```
-
-_See code: [src/commands/builds/rm.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/builds/rm.ts)_
-
-## `apify call [ACTORID]`
-
-Executes Actor remotely using your authenticated account.
-
-```
-USAGE
-  $ apify call [ACTORID] [--json] [-b <value>] [-t <value>] [-m <value>] [-i <value> | --input-file
-    <value>] [-s] [-o]
-
-ARGUMENTS
-  ACTORID  Name or ID of the Actor to run (e.g. "my-actor", "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not
-           provided, the command runs the remote Actor specified in the '.actor/actor.json' file.
-
-FLAGS
-  -b, --build=<value>       Tag or number of the build to run (e.g. "latest" or "1.2.34").
-  -i, --input=<value>       Optional JSON input to be given to the Actor.
-  -m, --memory=<value>      Amount of memory allocated for the Actor run, in megabytes.
-  -o, --output-dataset      Prints out the entire default dataset on successful run of the Actor.
-  -s, --silent              Prevents printing the logs of the Actor run to the console.
-  -t, --timeout=<value>     Timeout for the Actor run in seconds. Zero value means there is no timeout.
-      --input-file=<value>  Optional path to a file with JSON input to be given to the Actor. The file must be a valid
-                            JSON file. You can also specify `-` to read from standard input.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Executes Actor remotely using your authenticated account.
-  Reads input from local key-value store by default.
-```
-
-_See code: [src/commands/call.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/call.ts)_
-
-## `apify create [ACTORNAME]`
+<!-- prettier-ignore-start -->
+<!-- actor-dev-commands-start -->
+### `apify create [ACTORNAME]`
 
 Creates an Actor project from a template in a new directory.
 
@@ -568,199 +177,7 @@ DESCRIPTION
   Creates an Actor project from a template in a new directory.
 ```
 
-_See code: [src/commands/create.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/create.ts)_
-
-## `apify datasets`
-
-Manages structured data storage and retrieval.
-
-```
-USAGE
-  $ apify datasets
-
-DESCRIPTION
-  Manages structured data storage and retrieval.
-```
-
-_See code: [src/commands/datasets/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/index.ts)_
-
-## `apify datasets create [DATASETNAME]`
-
-Creates a new dataset for storing structured data on your account.
-
-```
-USAGE
-  $ apify datasets create [DATASETNAME] [--json]
-
-ARGUMENTS
-  DATASETNAME  Optional name for the Dataset
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Creates a new dataset for storing structured data on your account.
-```
-
-_See code: [src/commands/datasets/create.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/create.ts)_
-
-## `apify datasets get-items DATASETID`
-
-Retrieves dataset items in specified format (JSON, CSV, etc).
-
-```
-USAGE
-  $ apify datasets get-items DATASETID [--limit <value>] [--offset <value>] [--format json|jsonl|csv|html|rss|xml|xlsx]
-
-ARGUMENTS
-  DATASETID  The ID of the Dataset to export the items for
-
-FLAGS
-  --format=<option>  [default: json] The format of the returned output. By default, it is set to 'json'
-                     <options: json|jsonl|csv|html|rss|xml|xlsx>
-  --limit=<value>    The amount of elements to get from the dataset. By default, it will return all available items.
-  --offset=<value>   The offset in the dataset where to start getting items.
-
-DESCRIPTION
-  Retrieves dataset items in specified format (JSON, CSV, etc).
-```
-
-_See code: [src/commands/datasets/get-items.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/get-items.ts)_
-
-## `apify datasets info STOREID`
-
-Prints information about a specific dataset.
-
-```
-USAGE
-  $ apify datasets info STOREID [--json]
-
-ARGUMENTS
-  STOREID  The dataset store ID to print information about.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Prints information about a specific dataset.
-```
-
-_See code: [src/commands/datasets/info.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/info.ts)_
-
-## `apify datasets ls`
-
-Prints all datasets on your account.
-
-```
-USAGE
-  $ apify datasets ls [--json] [--offset <value>] [--limit <value>] [--desc] [--unnamed]
-
-FLAGS
-  --desc            Sorts datasets in descending order.
-  --limit=<value>   [default: 20] Number of datasets that will be listed.
-  --offset=<value>  Number of datasets that will be skipped.
-  --unnamed         Lists datasets that don't have a name set.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Prints all datasets on your account.
-```
-
-_See code: [src/commands/datasets/ls.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/ls.ts)_
-
-## `apify datasets push-items NAMEORID [ITEM]`
-
-Adds data items to specified dataset. Accepts single object or array of objects.
-
-```
-USAGE
-  $ apify datasets push-items NAMEORID [ITEM]
-
-ARGUMENTS
-  NAMEORID  The dataset ID or name to push the objects to
-  ITEM      The object or array of objects to be pushed.
-
-DESCRIPTION
-  Adds data items to specified dataset. Accepts single object or array of objects.
-```
-
-_See code: [src/commands/datasets/push-items.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/push-items.ts)_
-
-## `apify datasets rename NAMEORID [NEWNAME]`
-
-Change dataset name or removes name with --unname flag.
-
-```
-USAGE
-  $ apify datasets rename NAMEORID [NEWNAME] [--unname]
-
-ARGUMENTS
-  NAMEORID  The dataset ID or name to delete.
-  NEWNAME   The new name for the dataset.
-
-FLAGS
-  --unname  Removes the unique name of the dataset.
-
-DESCRIPTION
-  Change dataset name or removes name with --unname flag.
-```
-
-_See code: [src/commands/datasets/rename.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/rename.ts)_
-
-## `apify datasets rm DATASETNAMEORID`
-
-Permanently removes a dataset.
-
-```
-USAGE
-  $ apify datasets rm DATASETNAMEORID
-
-ARGUMENTS
-  DATASETNAMEORID  The dataset ID or name to delete
-
-DESCRIPTION
-  Permanently removes a dataset.
-```
-
-_See code: [src/commands/datasets/rm.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/datasets/rm.ts)_
-
-## `apify help [COMMAND]`
-
-Display help for apify.
-
-```
-USAGE
-  $ apify help [COMMAND...] [-n]
-
-ARGUMENTS
-  COMMAND...  Command to show help for.
-
-FLAGS
-  -n, --nested-commands  Include all nested commands in the output.
-
-DESCRIPTION
-  Display help for apify.
-```
-
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.23/src/commands/help.ts)_
-
-## `apify info`
-
-Prints details about your currently authenticated Apify account.
-
-```
-USAGE
-  $ apify info
-
-DESCRIPTION
-  Prints details about your currently authenticated Apify account.
-```
-
-_See code: [src/commands/info.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/info.ts)_
-
-## `apify init [ACTORNAME]`
+### `apify init [ACTORNAME]`
 
 Sets up an Actor project in your current directory by creating actor.json and storage files.
 
@@ -785,316 +202,7 @@ DESCRIPTION
   WARNING: Overwrites existing 'storage' directory.
 ```
 
-_See code: [src/commands/init.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/init.ts)_
-
-## `apify key-value-stores`
-
-Manages persistent key-value storage.
-
-```
-USAGE
-  $ apify key-value-stores
-
-DESCRIPTION
-  Manages persistent key-value storage.
-
-  Alias: kvs
-```
-
-_See code: [src/commands/key-value-stores/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/index.ts)_
-
-## `apify key-value-stores create [KEYVALUESTORENAME]`
-
-Creates a new key-value store on your account.
-
-```
-USAGE
-  $ apify key-value-stores create [KEYVALUESTORENAME] [--json]
-
-ARGUMENTS
-  KEYVALUESTORENAME  Optional name for the key-value store
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Creates a new key-value store on your account.
-```
-
-_See code: [src/commands/key-value-stores/create.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/create.ts)_
-
-## `apify key-value-stores delete-value STOREID ITEMKEY`
-
-Delete a value from a key-value store.
-
-```
-USAGE
-  $ apify key-value-stores delete-value STOREID ITEMKEY
-
-ARGUMENTS
-  STOREID  The key-value store ID to delete the value from.
-  ITEMKEY  The key of the item in the key-value store.
-
-DESCRIPTION
-  Delete a value from a key-value store.
-```
-
-_See code: [src/commands/key-value-stores/delete-value.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/delete-value.ts)_
-
-## `apify key-value-stores get-value KEYVALUESTOREID ITEMKEY`
-
-Retrieves stored value for specified key. Use --only-content-type to check MIME type.
-
-```
-USAGE
-  $ apify key-value-stores get-value KEYVALUESTOREID ITEMKEY [--only-content-type]
-
-ARGUMENTS
-  KEYVALUESTOREID  The key-value store ID to get the value from.
-  ITEMKEY          The key of the item in the key-value store.
-
-FLAGS
-  --only-content-type  Only return the content type of the specified key
-
-DESCRIPTION
-  Retrieves stored value for specified key. Use --only-content-type to check MIME type.
-```
-
-_See code: [src/commands/key-value-stores/get-value.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/get-value.ts)_
-
-## `apify key-value-stores info STOREID`
-
-Shows information about a key-value store.
-
-```
-USAGE
-  $ apify key-value-stores info STOREID [--json]
-
-ARGUMENTS
-  STOREID  The key-value store ID to print information about.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Shows information about a key-value store.
-```
-
-_See code: [src/commands/key-value-stores/info.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/info.ts)_
-
-## `apify key-value-stores keys STOREID`
-
-Lists all keys in a key-value store.
-
-```
-USAGE
-  $ apify key-value-stores keys STOREID [--json] [--limit <value>] [--exclusive-start-key <value>]
-
-ARGUMENTS
-  STOREID  The key-value store ID to list keys for.
-
-FLAGS
-  --exclusive-start-key=<value>  The key to start the list from.
-  --limit=<value>                [default: 20] The maximum number of keys to return.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Lists all keys in a key-value store.
-```
-
-_See code: [src/commands/key-value-stores/keys.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/keys.ts)_
-
-## `apify key-value-stores ls`
-
-Lists all key-value stores on your account.
-
-```
-USAGE
-  $ apify key-value-stores ls [--json] [--offset <value>] [--limit <value>] [--desc] [--unnamed]
-
-FLAGS
-  --desc            Sorts key-value stores in descending order.
-  --limit=<value>   [default: 20] Number of key-value stores that will be listed.
-  --offset=<value>  Number of key-value stores that will be skipped.
-  --unnamed         Lists key-value stores that don't have a name set.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Lists all key-value stores on your account.
-```
-
-_See code: [src/commands/key-value-stores/ls.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/ls.ts)_
-
-## `apify key-value-stores rename KEYVALUESTORENAMEORID [NEWNAME]`
-
-Renames a key-value store, or removes its unique name.
-
-```
-USAGE
-  $ apify key-value-stores rename KEYVALUESTORENAMEORID [NEWNAME] [--unname]
-
-ARGUMENTS
-  KEYVALUESTORENAMEORID  The key-value store ID or name to delete
-  NEWNAME                The new name for the key-value store
-
-FLAGS
-  --unname  Removes the unique name of the key-value store
-
-DESCRIPTION
-  Renames a key-value store, or removes its unique name.
-```
-
-_See code: [src/commands/key-value-stores/rename.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/rename.ts)_
-
-## `apify key-value-stores rm KEYVALUESTORENAMEORID`
-
-Permanently removes a key-value store.
-
-```
-USAGE
-  $ apify key-value-stores rm KEYVALUESTORENAMEORID
-
-ARGUMENTS
-  KEYVALUESTORENAMEORID  The key-value store ID or name to delete
-
-DESCRIPTION
-  Permanently removes a key-value store.
-```
-
-_See code: [src/commands/key-value-stores/rm.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/rm.ts)_
-
-## `apify key-value-stores set-value STOREID ITEMKEY [VALUE]`
-
-Stores value with specified key. Set content-type with --content-type flag.
-
-```
-USAGE
-  $ apify key-value-stores set-value STOREID ITEMKEY [VALUE] [--content-type <value>]
-
-ARGUMENTS
-  STOREID  The key-value store ID to set the value in.
-  ITEMKEY  The key of the item in the key-value store.
-  VALUE    The value to set.
-
-FLAGS
-  --content-type=<value>  [default: application/json] The MIME content type of the value. By default, "application/json"
-                          is assumed.
-
-DESCRIPTION
-  Stores value with specified key. Set content-type with --content-type flag.
-```
-
-_See code: [src/commands/key-value-stores/set-value.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/key-value-stores/set-value.ts)_
-
-## `apify login`
-
-Authenticates your Apify account and saves credentials to '~/.apify'.
-
-```
-USAGE
-  $ apify login [-t <value>] [-m console|manual]
-
-FLAGS
-  -m, --method=<option>  [Optional] Method of logging in to Apify
-                         <options: console|manual>
-  -t, --token=<value>    [Optional] Apify API token
-
-DESCRIPTION
-  Authenticates your Apify account and saves credentials to '~/.apify'.
-  All other commands use these stored credentials.
-
-  Run 'apify logout' to remove authentication.
-```
-
-_See code: [src/commands/login.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/login.ts)_
-
-## `apify logout`
-
-Removes authentication by deleting your API token and account information from '~/.apify'.
-
-```
-USAGE
-  $ apify logout
-
-DESCRIPTION
-  Removes authentication by deleting your API token and account information from '~/.apify'.
-  Run 'apify login' to authenticate again.
-```
-
-_See code: [src/commands/logout.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/logout.ts)_
-
-## `apify pull [ACTORID]`
-
-Download Actor code to current directory. Clones Git repositories or fetches Actor files based on the source type.
-
-```
-USAGE
-  $ apify pull [ACTORID] [-v <value>] [--dir <value>]
-
-ARGUMENTS
-  ACTORID  Name or ID of the Actor to run (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the
-           command will update the Actor in the current directory based on its name in ".actor/actor.json" file.
-
-FLAGS
-  -v, --version=<value>  Actor version number which will be pulled, e.g. 1.2. Default: the highest version
-      --dir=<value>      Directory where the Actor should be pulled to
-
-DESCRIPTION
-  Download Actor code to current directory. Clones Git repositories or fetches Actor files based on the source type.
-```
-
-_See code: [src/commands/pull.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/pull.ts)_
-
-## `apify push [ACTORID]`
-
-Deploys Actor to Apify platform using settings from '.actor/actor.json'.
-
-```
-USAGE
-  $ apify push [ACTORID] [-v <value>] [-b <value>] [-w <value>] [--no-prompt] [--force] [--dir <value>]
-
-ARGUMENTS
-  ACTORID  Name or ID of the Actor to push (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the
-           command will create or modify the Actor with the name specified in '.actor/actor.json' file.
-
-FLAGS
-  -b, --build-tag=<value>        Build tag to be applied to the successful Actor build. By default, it is taken from the
-                                 '.actor/actor.json' file
-  -v, --version=<value>          Actor version number to which the files should be pushed. By default, it is taken from
-                                 the '.actor/actor.json' file.
-  -w, --wait-for-finish=<value>  Seconds for waiting to build to finish, if no value passed, it waits forever.
-      --dir=<value>              Directory where the Actor is located
-      --force                    Push an Actor even when the local files are older than the Actor on the platform.
-      --no-prompt                Do not prompt for opening the Actor details in a browser. This will also not open the
-                                 browser automatically.
-
-DESCRIPTION
-  Deploys Actor to Apify platform using settings from '.actor/actor.json'.
-  Files under '3' MB upload as "Multiple source files"; larger projects upload as ZIP file.
-  Use --force to override newer remote versions.
-```
-
-_See code: [src/commands/push.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/push.ts)_
-
-## `apify request-queues`
-
-Manages URL queues for web scraping and automation tasks.
-
-```
-USAGE
-  $ apify request-queues
-
-DESCRIPTION
-  Manages URL queues for web scraping and automation tasks.
-```
-
-_See code: [src/commands/request-queues/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/request-queues/index.ts)_
-
-## `apify run`
+### `apify run`
 
 Executes Actor locally with simulated Apify environment variables.
 
@@ -1125,9 +233,473 @@ DESCRIPTION
   NOTE: For Node.js Actors, customize behavior by modifying the 'start' script in package.json file.
 ```
 
-_See code: [src/commands/run.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/run.ts)_
+### `apify validate-schema [PATH]`
 
-## `apify runs`
+Validates Actor input schema from one of these locations (in priority order):
+
+```
+USAGE
+  $ apify validate-schema [PATH]
+
+ARGUMENTS
+  PATH  Optional path to your INPUT_SCHEMA.json file. If not provided ./INPUT_SCHEMA.json is used.
+
+DESCRIPTION
+  Validates Actor input schema from one of these locations (in priority order):
+  1. Object in '.actor/actor.json' under "input" key
+  2. JSON file path in '.actor/actor.json' "input" key
+  3. .actor/INPUT_SCHEMA.json
+  4. INPUT_SCHEMA.json
+
+  Optionally specify custom schema path to validate.
+```
+<!-- actor-dev-commands-end -->
+<!-- prettier-ignore-end -->
+
+## Actor Management
+
+These commands let you manage actors on the Apify platform. They provide functionality for deployment, execution, monitoring, and maintenance of your actors in the cloud environment.
+
+### Basic Actor Operations
+
+Use these commands to handle core actor operations like creation, listing, deletion, and basic runtime management. These are the essential commands for working with actors on the Apify platform.
+
+<!-- prettier-ignore-start -->
+<!-- actor-basic-commands-start -->
+### `apify actors`
+
+Manages Actor creation, deployment, and execution on the Apify platform.
+
+```
+USAGE
+  $ apify actors
+
+DESCRIPTION
+  Manages Actor creation, deployment, and execution on the Apify platform.
+```
+
+### `apify actors ls`
+
+Prints a list of recently executed Actors or Actors you own.
+
+```
+USAGE
+  $ apify actors ls [--json] [--my] [--offset <value>] [--limit <value>] [--desc]
+
+FLAGS
+  --desc            Sort Actors in descending order.
+  --limit=<value>   [default: 20] Number of Actors that will be listed.
+  --my              Whether to list Actors made by the logged in user.
+  --offset=<value>  Number of Actors that will be skipped.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Prints a list of recently executed Actors or Actors you own.
+```
+
+### `apify actors rm ACTORID`
+
+Permanently removes an Actor from your account.
+
+```
+USAGE
+  $ apify actors rm ACTORID
+
+ARGUMENTS
+  ACTORID  The Actor ID to delete.
+
+DESCRIPTION
+  Permanently removes an Actor from your account.
+```
+
+### `apify actor`
+
+Manages runtime data operations inside of a running Actor.
+
+```
+USAGE
+  $ apify actor
+
+DESCRIPTION
+  Manages runtime data operations inside of a running Actor.
+```
+
+### `apify actor get-input`
+
+Gets the Actor input value from the default key-value store associated with the Actor run.
+
+```
+USAGE
+  $ apify actor get-input
+
+DESCRIPTION
+  Gets the Actor input value from the default key-value store associated with the Actor run.
+```
+
+### `apify actor get-value KEY`
+
+Gets a value from the default key-value store associated with the Actor run.
+
+```
+USAGE
+  $ apify actor get-value KEY
+
+ARGUMENTS
+  KEY  Key of the record in key-value store
+
+DESCRIPTION
+  Gets a value from the default key-value store associated with the Actor run.
+```
+
+### `apify actor push-data [ITEM]`
+
+Saves data to Actor's run default dataset.
+
+```
+USAGE
+  $ apify actor push-data [ITEM]
+
+ARGUMENTS
+  ITEM  JSON string with one object or array of objects containing data to be stored in the default dataset.
+
+DESCRIPTION
+  Saves data to Actor's run default dataset.
+
+  Accept input as:
+  - JSON argument:
+  $ apify actor push-data {"key": "value"}
+  - Piped stdin:
+  $ cat ./test.json | apify actor push-data
+```
+
+### `apify actor set-value KEY [VALUE]`
+
+Sets or removes record into the default key-value store associated with the Actor run.
+
+```
+USAGE
+  $ apify actor set-value KEY [VALUE] [-c <value>]
+
+ARGUMENTS
+  KEY    Key of the record in key-value store.
+  VALUE  Record data, which can be one of the following values:
+         - If empty, the record in the key-value store is deleted.
+         - If no `contentType` flag is specified, value is expected to be any JSON string value.
+         - If options.contentType is set, value is taken as is.
+
+FLAGS
+  -c, --contentType=<value>  Specifies a custom MIME content type of the record. By default "application/json" is used.
+
+DESCRIPTION
+  Sets or removes record into the default key-value store associated with the Actor run.
+
+  It is possible to pass data using argument or stdin.
+
+  Passing data using argument:
+  $ apify actor set-value KEY my-value
+
+  Passing data using stdin with pipe:
+  $ cat ./my-text-file.txt | apify actor set-value KEY --contentType text/plain
+```
+<!-- actor-basic-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Actor Deployment
+
+These commands handle the deployment workflow of actors to the Apify platform. Use them to push local changes, pull remote actors, and manage actor versions and builds.
+
+<!-- prettier-ignore-start -->
+<!-- actor-deploy-commands-start -->
+### `apify push [ACTORID]`
+
+### `apify actors push [ACTORID]`
+
+Deploys Actor to Apify platform using settings from '.actor/actor.json'.
+
+```
+USAGE
+  $ apify actors push [ACTORID] [-v <value>] [-b <value>] [-w <value>] [--no-prompt] [--force] [--dir <value>]
+
+ARGUMENTS
+  ACTORID  Name or ID of the Actor to push (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the
+           command will create or modify the Actor with the name specified in '.actor/actor.json' file.
+
+FLAGS
+  -b, --build-tag=<value>        Build tag to be applied to the successful Actor build. By default, it is taken from the
+                                 '.actor/actor.json' file
+  -v, --version=<value>          Actor version number to which the files should be pushed. By default, it is taken from
+                                 the '.actor/actor.json' file.
+  -w, --wait-for-finish=<value>  Seconds for waiting to build to finish, if no value passed, it waits forever.
+      --dir=<value>              Directory where the Actor is located
+      --force                    Push an Actor even when the local files are older than the Actor on the platform.
+      --no-prompt                Do not prompt for opening the Actor details in a browser. This will also not open the
+                                 browser automatically.
+
+DESCRIPTION
+  Deploys Actor to Apify platform using settings from '.actor/actor.json'.
+  Files under '3' MB upload as "Multiple source files"; larger projects upload as ZIP file.
+  Use --force to override newer remote versions.
+```
+
+### `apify pull [ACTORID]`
+
+### `apify actors pull [ACTORID]`
+
+Download Actor code to current directory. Clones Git repositories or fetches Actor files based on the source type.
+
+```
+USAGE
+  $ apify actors pull [ACTORID] [-v <value>] [--dir <value>]
+
+ARGUMENTS
+  ACTORID  Name or ID of the Actor to run (e.g. "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not provided, the
+           command will update the Actor in the current directory based on its name in ".actor/actor.json" file.
+
+FLAGS
+  -v, --version=<value>  Actor version number which will be pulled, e.g. 1.2. Default: the highest version
+      --dir=<value>      Directory where the Actor should be pulled to
+
+DESCRIPTION
+  Download Actor code to current directory. Clones Git repositories or fetches Actor files based on the source type.
+```
+
+### `apify call [ACTORID]`
+
+### `apify actors call [ACTORID]`
+
+Executes Actor remotely using your authenticated account.
+
+```
+USAGE
+  $ apify actors call [ACTORID] [--json] [-b <value>] [-t <value>] [-m <value>] [-i <value> | --input-file
+    <value>] [-s] [-o]
+
+ARGUMENTS
+  ACTORID  Name or ID of the Actor to run (e.g. "my-actor", "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not
+           provided, the command runs the remote Actor specified in the '.actor/actor.json' file.
+
+FLAGS
+  -b, --build=<value>       Tag or number of the build to run (e.g. "latest" or "1.2.34").
+  -i, --input=<value>       Optional JSON input to be given to the Actor.
+  -m, --memory=<value>      Amount of memory allocated for the Actor run, in megabytes.
+  -o, --output-dataset      Prints out the entire default dataset on successful run of the Actor.
+  -s, --silent              Prevents printing the logs of the Actor run to the console.
+  -t, --timeout=<value>     Timeout for the Actor run in seconds. Zero value means there is no timeout.
+      --input-file=<value>  Optional path to a file with JSON input to be given to the Actor. The file must be a valid
+                            JSON file. You can also specify `-` to read from standard input.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Executes Actor remotely using your authenticated account.
+  Reads input from local key-value store by default.
+```
+
+### `apify actors start [ACTORID]`
+
+Starts Actor remotely and returns run details immediately.
+
+```
+USAGE
+  $ apify actors start [ACTORID] [--json] [-b <value>] [-t <value>] [-m <value>] [-i <value> | --input-file
+    <value>]
+
+ARGUMENTS
+  ACTORID  Name or ID of the Actor to run (e.g. "my-actor", "apify/hello-world" or "E2jjCZBezvAZnX8Rb"). If not
+           provided, the command runs the remote Actor specified in the '.actor/actor.json' file.
+
+FLAGS
+  -b, --build=<value>       Tag or number of the build to run (e.g. "latest" or "1.2.34").
+  -i, --input=<value>       Optional JSON input to be given to the Actor.
+  -m, --memory=<value>      Amount of memory allocated for the Actor run, in megabytes.
+  -t, --timeout=<value>     Timeout for the Actor run in seconds. Zero value means there is no timeout.
+      --input-file=<value>  Optional path to a file with JSON input to be given to the Actor. The file must be a valid
+                            JSON file. You can also specify `-` to read from standard input.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Starts Actor remotely and returns run details immediately.
+  Uses authenticated account and local key-value store for input.
+```
+
+### `apify actors info ACTORID`
+
+Get information about an Actor.
+
+```
+USAGE
+  $ apify actors info ACTORID [--json] [--readme | --input]
+
+ARGUMENTS
+  ACTORID  The ID of the Actor to return information about.
+
+FLAGS
+  --input   Return the Actor input schema.
+  --readme  Return the Actor README.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Get information about an Actor.
+```
+<!-- actor-deploy-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Actor Builds
+
+Use these commands to manage actor build processes. They help you create, monitor, and maintain versioned snapshots of your actors that can be executed on the Apify platform.
+
+<!-- prettier-ignore-start -->
+<!-- actor-build-commands-start -->
+### `apify builds`
+
+Manages Actor build processes and versioning.
+
+```
+USAGE
+  $ apify builds
+
+DESCRIPTION
+  Manages Actor build processes and versioning.
+```
+
+### `apify builds create [ACTORID]`
+
+Creates a new build of the Actor.
+
+```
+USAGE
+  $ apify builds create [ACTORID] [--json] [--tag <value>] [--version <value>] [--log]
+
+ARGUMENTS
+  ACTORID  Optional Actor ID or Name to trigger a build for. By default, it will use the Actor from the current
+           directory.
+
+FLAGS
+  --log              Whether to print out the build log after the build is triggered.
+  --tag=<value>      Build tag to be applied to the successful Actor build. By default, this is "latest".
+  --version=<value>  Optional Actor Version to build. By default, this will be inferred from the tag, but this flag is
+                     required when multiple versions have the same tag.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Creates a new build of the Actor.
+```
+
+### `apify actors build [ACTORID]`
+
+Creates a new build of the Actor.
+
+```
+USAGE
+  $ apify actors build [ACTORID] [--json] [--tag <value>] [--version <value>] [--log]
+
+ARGUMENTS
+  ACTORID  Optional Actor ID or Name to trigger a build for. By default, it will use the Actor from the current
+           directory.
+
+FLAGS
+  --log              Whether to print out the build log after the build is triggered.
+  --tag=<value>      Build tag to be applied to the successful Actor build. By default, this is "latest".
+  --version=<value>  Optional Actor Version to build. By default, this will be inferred from the tag, but this flag is
+                     required when multiple versions have the same tag.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Creates a new build of the Actor.
+```
+
+### `apify builds info BUILDID`
+
+Prints information about a specific build.
+
+```
+USAGE
+  $ apify builds info BUILDID [--json]
+
+ARGUMENTS
+  BUILDID  The build ID to get information about.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Prints information about a specific build.
+```
+
+### `apify builds log BUILDID`
+
+Prints the log of a specific build.
+
+```
+USAGE
+  $ apify builds log BUILDID
+
+ARGUMENTS
+  BUILDID  The build ID to get the log from.
+
+DESCRIPTION
+  Prints the log of a specific build.
+```
+
+### `apify builds ls [ACTORID]`
+
+Lists all builds of the Actor.
+
+```
+USAGE
+  $ apify builds ls [ACTORID] [--json] [--offset <value>] [--limit <value>] [--desc] [-c]
+
+ARGUMENTS
+  ACTORID  Optional Actor ID or Name to list runs for. By default, it will use the Actor from the current directory.
+
+FLAGS
+  -c, --compact         Display a compact table.
+      --desc            Sort builds in descending order.
+      --limit=<value>   [default: 10] Number of builds that will be listed.
+      --offset=<value>  Number of builds that will be skipped.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Lists all builds of the Actor.
+```
+
+### `apify builds rm BUILDID`
+
+Permanently removes an Actor build from the Apify platform.
+
+```
+USAGE
+  $ apify builds rm BUILDID
+
+ARGUMENTS
+  BUILDID  The build ID to delete.
+
+DESCRIPTION
+  Permanently removes an Actor build from the Apify platform.
+```
+<!-- actor-build-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Actor Runs
+
+These commands control actor execution on the Apify platform. Use them to start, monitor, and manage actor runs, including accessing logs and handling execution states.
+
+<!-- prettier-ignore-start -->
+<!-- actor-run-commands-start -->
+### `apify runs`
 
 Manages Actor run operations
 
@@ -1139,9 +711,7 @@ DESCRIPTION
   Manages Actor run operations
 ```
 
-_See code: [src/commands/runs/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/index.ts)_
-
-## `apify runs abort RUNID`
+### `apify runs abort RUNID`
 
 Aborts an Actor run.
 
@@ -1162,9 +732,7 @@ DESCRIPTION
   Aborts an Actor run.
 ```
 
-_See code: [src/commands/runs/abort.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/abort.ts)_
-
-## `apify runs info RUNID`
+### `apify runs info RUNID`
 
 Prints information about an Actor run.
 
@@ -1185,9 +753,7 @@ DESCRIPTION
   Prints information about an Actor run.
 ```
 
-_See code: [src/commands/runs/info.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/info.ts)_
-
-## `apify runs log RUNID`
+### `apify runs log RUNID`
 
 Prints the log of a specific run.
 
@@ -1202,9 +768,7 @@ DESCRIPTION
   Prints the log of a specific run.
 ```
 
-_See code: [src/commands/runs/log.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/log.ts)_
-
-## `apify runs ls [ACTORID]`
+### `apify runs ls [ACTORID]`
 
 Lists all runs of the Actor.
 
@@ -1228,9 +792,7 @@ DESCRIPTION
   Lists all runs of the Actor.
 ```
 
-_See code: [src/commands/runs/ls.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/ls.ts)_
-
-## `apify runs resurrect RUNID`
+### `apify runs resurrect RUNID`
 
 Resurrects an aborted or finished Actor Run.
 
@@ -1248,9 +810,7 @@ DESCRIPTION
   Resurrects an aborted or finished Actor Run.
 ```
 
-_See code: [src/commands/runs/resurrect.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/resurrect.ts)_
-
-## `apify runs rm RUNID`
+### `apify runs rm RUNID`
 
 Deletes an Actor Run.
 
@@ -1264,75 +824,379 @@ ARGUMENTS
 DESCRIPTION
   Deletes an Actor Run.
 ```
+<!-- actor-run-commands-end -->
+<!-- prettier-ignore-end -->
 
-_See code: [src/commands/runs/rm.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/runs/rm.ts)_
+## Storage
 
-## `apify secrets`
+These commands manage data storage on the Apify platform. Use them to work with datasets, key-value stores, and request queues for persistent data storage and retrieval.
 
-Manages secure environment variables for Actors.
+### Datasets
+
+Use these commands to manage datasets, which provide structured storage for tabular data. They enable creation, modification, and data manipulation within datasets.
+
+<!-- prettier-ignore-start -->
+<!-- dataset-commands-start -->
+### `apify datasets`
+
+Manages structured data storage and retrieval.
 
 ```
 USAGE
-  $ apify secrets
+  $ apify datasets
 
 DESCRIPTION
-  Manages secure environment variables for Actors.
-
-  Example:
-  $ apify secrets add mySecret TopSecretValue123
-
-  The "mySecret" value can be used in an environment variable defined in '.actor/actor.json' file by adding the "@"
-  prefix:
-
-  {
-  "actorSpecification": 1,
-  "name": "my_actor",
-  "environmentVariables": { "SECRET_ENV_VAR": "@mySecret" },
-  "version": "0.1"
-  }
-
-  When the Actor is pushed to Apify cloud, the "SECRET_ENV_VAR" and its value is stored as a secret environment variable
-  of the Actor.
+  Manages structured data storage and retrieval.
 ```
 
-_See code: [src/commands/secrets/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/secrets/index.ts)_
+### `apify datasets create [DATASETNAME]`
 
-## `apify secrets add NAME VALUE`
-
-Adds a new secret to '~/.apify' for use in Actor environment variables.
+Creates a new dataset for storing structured data on your account.
 
 ```
 USAGE
-  $ apify secrets add NAME VALUE
+  $ apify datasets create [DATASETNAME] [--json]
 
 ARGUMENTS
-  NAME   Name of the secret
-  VALUE  Value of the secret
+  DATASETNAME  Optional name for the Dataset
+
+GLOBAL FLAGS
+  --json  Format output as json.
 
 DESCRIPTION
-  Adds a new secret to '~/.apify' for use in Actor environment variables.
+  Creates a new dataset for storing structured data on your account.
 ```
 
-_See code: [src/commands/secrets/add.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/secrets/add.ts)_
+### `apify datasets get-items DATASETID`
 
-## `apify secrets rm NAME`
-
-Permanently deletes a secret from your stored credentials.
+Retrieves dataset items in specified format (JSON, CSV, etc).
 
 ```
 USAGE
-  $ apify secrets rm NAME
+  $ apify datasets get-items DATASETID [--limit <value>] [--offset <value>] [--format json|jsonl|csv|html|rss|xml|xlsx]
 
 ARGUMENTS
-  NAME  Name of the secret
+  DATASETID  The ID of the Dataset to export the items for
+
+FLAGS
+  --format=<option>  [default: json] The format of the returned output. By default, it is set to 'json'
+                     <options: json|jsonl|csv|html|rss|xml|xlsx>
+  --limit=<value>    The amount of elements to get from the dataset. By default, it will return all available items.
+  --offset=<value>   The offset in the dataset where to start getting items.
 
 DESCRIPTION
-  Permanently deletes a secret from your stored credentials.
+  Retrieves dataset items in specified format (JSON, CSV, etc).
 ```
 
-_See code: [src/commands/secrets/rm.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/secrets/rm.ts)_
+### `apify datasets info STOREID`
 
-## `apify task`
+Prints information about a specific dataset.
+
+```
+USAGE
+  $ apify datasets info STOREID [--json]
+
+ARGUMENTS
+  STOREID  The dataset store ID to print information about.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Prints information about a specific dataset.
+```
+
+### `apify datasets ls`
+
+Prints all datasets on your account.
+
+```
+USAGE
+  $ apify datasets ls [--json] [--offset <value>] [--limit <value>] [--desc] [--unnamed]
+
+FLAGS
+  --desc            Sorts datasets in descending order.
+  --limit=<value>   [default: 20] Number of datasets that will be listed.
+  --offset=<value>  Number of datasets that will be skipped.
+  --unnamed         Lists datasets that don't have a name set.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Prints all datasets on your account.
+```
+
+### `apify datasets push-items NAMEORID [ITEM]`
+
+Adds data items to specified dataset. Accepts single object or array of objects.
+
+```
+USAGE
+  $ apify datasets push-items NAMEORID [ITEM]
+
+ARGUMENTS
+  NAMEORID  The dataset ID or name to push the objects to
+  ITEM      The object or array of objects to be pushed.
+
+DESCRIPTION
+  Adds data items to specified dataset. Accepts single object or array of objects.
+```
+
+### `apify datasets rename NAMEORID [NEWNAME]`
+
+Change dataset name or removes name with --unname flag.
+
+```
+USAGE
+  $ apify datasets rename NAMEORID [NEWNAME] [--unname]
+
+ARGUMENTS
+  NAMEORID  The dataset ID or name to delete.
+  NEWNAME   The new name for the dataset.
+
+FLAGS
+  --unname  Removes the unique name of the dataset.
+
+DESCRIPTION
+  Change dataset name or removes name with --unname flag.
+```
+
+### `apify datasets rm DATASETNAMEORID`
+
+Permanently removes a dataset.
+
+```
+USAGE
+  $ apify datasets rm DATASETNAMEORID
+
+ARGUMENTS
+  DATASETNAMEORID  The dataset ID or name to delete
+
+DESCRIPTION
+  Permanently removes a dataset.
+```
+<!-- dataset-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Key-Value Stores
+
+These commands handle key-value store operations. Use them to create stores, manage key-value pairs, and handle persistent storage of arbitrary data types.
+
+<!-- prettier-ignore-start -->
+<!-- keyval-commands-start -->
+### `apify key-value-stores`
+
+Manages persistent key-value storage.
+
+```
+USAGE
+  $ apify key-value-stores
+
+DESCRIPTION
+  Manages persistent key-value storage.
+
+  Alias: kvs
+```
+
+### `apify key-value-stores create [KEYVALUESTORENAME]`
+
+Creates a new key-value store on your account.
+
+```
+USAGE
+  $ apify key-value-stores create [KEYVALUESTORENAME] [--json]
+
+ARGUMENTS
+  KEYVALUESTORENAME  Optional name for the key-value store
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Creates a new key-value store on your account.
+```
+
+### `apify key-value-stores delete-value STOREID ITEMKEY`
+
+Delete a value from a key-value store.
+
+```
+USAGE
+  $ apify key-value-stores delete-value STOREID ITEMKEY
+
+ARGUMENTS
+  STOREID  The key-value store ID to delete the value from.
+  ITEMKEY  The key of the item in the key-value store.
+
+DESCRIPTION
+  Delete a value from a key-value store.
+```
+
+### `apify key-value-stores get-value KEYVALUESTOREID ITEMKEY`
+
+Retrieves stored value for specified key. Use --only-content-type to check MIME type.
+
+```
+USAGE
+  $ apify key-value-stores get-value KEYVALUESTOREID ITEMKEY [--only-content-type]
+
+ARGUMENTS
+  KEYVALUESTOREID  The key-value store ID to get the value from.
+  ITEMKEY          The key of the item in the key-value store.
+
+FLAGS
+  --only-content-type  Only return the content type of the specified key
+
+DESCRIPTION
+  Retrieves stored value for specified key. Use --only-content-type to check MIME type.
+```
+
+### `apify key-value-stores info STOREID`
+
+Shows information about a key-value store.
+
+```
+USAGE
+  $ apify key-value-stores info STOREID [--json]
+
+ARGUMENTS
+  STOREID  The key-value store ID to print information about.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Shows information about a key-value store.
+```
+
+### `apify key-value-stores keys STOREID`
+
+Lists all keys in a key-value store.
+
+```
+USAGE
+  $ apify key-value-stores keys STOREID [--json] [--limit <value>] [--exclusive-start-key <value>]
+
+ARGUMENTS
+  STOREID  The key-value store ID to list keys for.
+
+FLAGS
+  --exclusive-start-key=<value>  The key to start the list from.
+  --limit=<value>                [default: 20] The maximum number of keys to return.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Lists all keys in a key-value store.
+```
+
+### `apify key-value-stores ls`
+
+Lists all key-value stores on your account.
+
+```
+USAGE
+  $ apify key-value-stores ls [--json] [--offset <value>] [--limit <value>] [--desc] [--unnamed]
+
+FLAGS
+  --desc            Sorts key-value stores in descending order.
+  --limit=<value>   [default: 20] Number of key-value stores that will be listed.
+  --offset=<value>  Number of key-value stores that will be skipped.
+  --unnamed         Lists key-value stores that don't have a name set.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Lists all key-value stores on your account.
+```
+
+### `apify key-value-stores rename KEYVALUESTORENAMEORID [NEWNAME]`
+
+Renames a key-value store, or removes its unique name.
+
+```
+USAGE
+  $ apify key-value-stores rename KEYVALUESTORENAMEORID [NEWNAME] [--unname]
+
+ARGUMENTS
+  KEYVALUESTORENAMEORID  The key-value store ID or name to delete
+  NEWNAME                The new name for the key-value store
+
+FLAGS
+  --unname  Removes the unique name of the key-value store
+
+DESCRIPTION
+  Renames a key-value store, or removes its unique name.
+```
+
+### `apify key-value-stores rm KEYVALUESTORENAMEORID`
+
+Permanently removes a key-value store.
+
+```
+USAGE
+  $ apify key-value-stores rm KEYVALUESTORENAMEORID
+
+ARGUMENTS
+  KEYVALUESTORENAMEORID  The key-value store ID or name to delete
+
+DESCRIPTION
+  Permanently removes a key-value store.
+```
+
+### `apify key-value-stores set-value STOREID ITEMKEY [VALUE]`
+
+Stores value with specified key. Set content-type with --content-type flag.
+
+```
+USAGE
+  $ apify key-value-stores set-value STOREID ITEMKEY [VALUE] [--content-type <value>]
+
+ARGUMENTS
+  STOREID  The key-value store ID to set the value in.
+  ITEMKEY  The key of the item in the key-value store.
+  VALUE    The value to set.
+
+FLAGS
+  --content-type=<value>  [default: application/json] The MIME content type of the value. By default, "application/json"
+                          is assumed.
+
+DESCRIPTION
+  Stores value with specified key. Set content-type with --content-type flag.
+```
+<!-- keyval-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Request Queues
+
+These commands manage request queues, which handle URL processing for web scraping and automation tasks. Use them to maintain lists of URLs with automatic retry mechanisms and state management.
+
+<!-- prettier-ignore-start -->
+<!-- reqqueue-commands-start -->
+### `apify request-queues`
+
+Manages URL queues for web scraping and automation tasks.
+
+```
+USAGE
+  $ apify request-queues
+
+DESCRIPTION
+  Manages URL queues for web scraping and automation tasks.
+```
+<!-- reqqueue-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Tasks
+
+These commands help you manage scheduled and configured actor runs. Use them to create, modify, and execute predefined actor configurations as tasks.
+
+<!-- prettier-ignore-start -->
+<!-- task-commands-start -->
+### `apify task`
 
 Manages scheduled and predefined Actor configurations.
 
@@ -1344,9 +1208,7 @@ DESCRIPTION
   Manages scheduled and predefined Actor configurations.
 ```
 
-_See code: [src/commands/task/index.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/task/index.ts)_
-
-## `apify task run TASKID`
+### `apify task run TASKID`
 
 Executes predefined Actor task remotely using local key-value store for input.
 
@@ -1366,30 +1228,5 @@ DESCRIPTION
   Executes predefined Actor task remotely using local key-value store for input.
   Customize with --memory and --timeout flags.
 ```
-
-_See code: [src/commands/task/run.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/task/run.ts)_
-
-## `apify validate-schema [PATH]`
-
-Validates Actor input schema from one of these locations (in priority order):
-
-```
-USAGE
-  $ apify validate-schema [PATH]
-
-ARGUMENTS
-  PATH  Optional path to your INPUT_SCHEMA.json file. If not provided ./INPUT_SCHEMA.json is used.
-
-DESCRIPTION
-  Validates Actor input schema from one of these locations (in priority order):
-  1. Object in '.actor/actor.json' under "input" key
-  2. JSON file path in '.actor/actor.json' "input" key
-  3. .actor/INPUT_SCHEMA.json
-  4. INPUT_SCHEMA.json
-
-  Optionally specify custom schema path to validate.
-```
-
-_See code: [src/commands/validate-schema.ts](https://github.com/apify/apify-cli/blob/v0.21.1/src/commands/validate-schema.ts)_
-<!-- commandsstop -->
+<!-- task-commands-end -->
 <!-- prettier-ignore-end -->

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "build": "yarn clean && tsc && tsc -p tsconfig.typechecking.json",
         "postpack": "rimraf oclif.manifest.json",
         "prepack": "yarn build && oclif manifest && oclif readme && yarn update-docs",
-        "update-docs": "oclif readme --readme-path=docs/reference.md",
+        "update-docs": "tsx scripts/generate-reference.ts",
         "postinstallDev": "yarn build && node ./bin/run.js check-version && node ./dist/lib/community.js"
     },
     "files": [
@@ -133,8 +133,9 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^10.0.0",
-        "execa": "^9.3.0",
+        "execa": "^9.5.2",
         "lint-staged": "^15.2.8",
+        "mdast-util-from-markdown": "^2.0.2",
         "mock-stdin": "^1.0.0",
         "oclif": "^4.14.15",
         "prettier": "^3.3.3",

--- a/scripts/generate-reference.ts
+++ b/scripts/generate-reference.ts
@@ -1,0 +1,323 @@
+// oclif readme --readme-path=docs/reference.md
+
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { execa } from 'execa';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used when / if we want the link to commands
+import type { Code, Link, Paragraph, PhrasingContentMap } from 'mdast';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+
+const finalOutputFile = new URL('../docs/reference.md', import.meta.url);
+const temporaryReferenceFile = fileURLToPath(new URL('./temporary-reference.md', import.meta.url));
+const referenceTemplateFile = new URL('./reference-template.md', import.meta.url);
+
+// Make sure the temporary file is the empty template
+await writeFile(temporaryReferenceFile, '<!-- commands -->\n<!-- commandsstop -->');
+
+// Generate the oclif reference
+await execa`oclif readme --readme-path=${temporaryReferenceFile}`;
+
+// Read the temporary file, reference template
+const temporaryReferenceString = await readFile(temporaryReferenceFile, 'utf-8');
+const referenceTemplateString = await readFile(referenceTemplateFile, 'utf-8');
+
+// Keep in sync with the comments used in the reference template
+// If you have a comment like `<!-- wow-apify-commands-start -->` in the reference-template.md file, you need to add `wow-apify` in this array and handle mappings accordingly
+const CommandCategories = [
+	'general',
+	'auth',
+	'actor-dev',
+	'actor-basic',
+	'actor-deploy',
+	'actor-build',
+	'actor-run',
+	'dataset',
+	'keyval',
+	'reqqueue',
+	'task',
+] as const;
+
+type CommandCategories = (typeof CommandCategories)[number];
+
+const mappedCommands = Object.fromEntries(CommandCategories.map((category) => [category, [] as string[]])) as Record<
+	CommandCategories,
+	string[]
+>;
+
+const commands = new Map<string, Map<string | undefined, string>>([]);
+
+// Get the AST for the temporary file
+const ast = fromMarkdown(temporaryReferenceString).children;
+
+if (ast.length === 0) {
+	throw new Error('No commands found in the temporary reference file! This should not be possible');
+}
+
+for (let idx = 0; idx < ast.length; idx++) {
+	const node = ast[idx];
+
+	// The structure of a command definition is heading -> command description -> usage string -> link to code
+	// So even if we don't increment idx at the end, we will skip invalid nodes
+	if (node.type !== 'heading') {
+		continue;
+	}
+
+	const [headingNodeContent] = node.children as [PhrasingContentMap['inlineCode']];
+
+	// We know that right after the command name we have the command description
+	const [commandDescription] = (ast[idx + 1] as Paragraph).children as [PhrasingContentMap['text']];
+
+	// And then we have the usage code
+	const code = ast[idx + 2] as Code;
+
+	// Last we have the paragraph, code is here if we ever need it (Paragraph with 1 children of type Emphasis with 2 children (Text, Link))
+	// const linkToCode = ((ast[idx + 3] as Paragraph).children as [PhrasingContentMap['emphasis']])[0].children as [
+	// 	Text,
+	// 	Link,
+	// ];
+
+	const commandName = headingNodeContent.value;
+
+	const commandString = [
+		`### \`${commandName}\``,
+		'',
+		commandDescription.value,
+		'',
+		`\`\`\`\n${code.value}\n\`\`\``,
+	].join('\n');
+
+	// Find the category of the command
+	const commandParts = commandName.split(' ');
+
+	if (commandParts.length < 2) {
+		console.error(`Command ${commandName} does not have a category?`, { commandName, commandParts, commandString });
+
+		continue;
+	}
+
+	const [, command, rawSubcommand] = commandParts;
+
+	const existing = commands.get(command);
+
+	const subcommand = /[A-Z]/i.test(rawSubcommand?.[0] || '') ? rawSubcommand : undefined;
+
+	if (!existing) {
+		commands.set(command, new Map([[subcommand, commandString]]));
+	} else {
+		existing.set(subcommand, commandString);
+	}
+}
+
+// console.log(
+// 	Object.fromEntries([...commands.entries()].map(([key, value]) => [key, Object.fromEntries(value.entries())])),
+// );
+
+const actorNamespace = commands.get('actor')!;
+const actorsNamespace = commands.get('actors')!;
+const buildsNamespace = commands.get('builds')!;
+const callCommand = commands.get('call')!.get(undefined)!;
+const createCommand = commands.get('create')!.get(undefined)!;
+const datasetsNamespace = commands.get('datasets')!;
+const helpCommand = commands.get('help')!.get(undefined)!;
+const infoCommand = commands.get('info')!.get(undefined)!;
+const initCommand = commands.get('init')!.get(undefined)!;
+const keyValueStoresNamespace = commands.get('key-value-stores')!;
+const loginCommand = commands.get('login')!.get(undefined)!;
+const logoutCommand = commands.get('logout')!.get(undefined)!;
+const pullCommand = commands.get('pull')!.get(undefined)!;
+const pushCommand = commands.get('push')!.get(undefined)!;
+const requestQueuesNamespace = commands.get('request-queues')!;
+const runCommand = commands.get('run')!.get(undefined)!;
+const runsNamespace = commands.get('runs')!;
+const secretsNamespace = commands.get('secrets')!;
+const taskNamespace = commands.get('task')!;
+const validateSchemaCommand = commands.get('validate-schema')!.get(undefined)!;
+
+// Organize commands in the order thats requested, and remove them from the map
+
+// #region General
+
+mappedCommands.general.push(helpCommand);
+commands.delete('help');
+
+// #endregion
+
+// #region Auth
+
+mappedCommands.auth.push(loginCommand);
+commands.delete('login');
+
+mappedCommands.auth.push(logoutCommand);
+commands.delete('logout');
+
+mappedCommands.auth.push(infoCommand);
+commands.delete('info');
+
+for (const str of secretsNamespace.values()) {
+	mappedCommands.auth.push(str);
+}
+commands.delete('secrets');
+
+// #endregion
+
+// #region Actor Dev
+
+mappedCommands['actor-dev'].push(createCommand);
+commands.delete('create');
+
+mappedCommands['actor-dev'].push(initCommand);
+commands.delete('init');
+
+mappedCommands['actor-dev'].push(runCommand);
+commands.delete('run');
+
+mappedCommands['actor-dev'].push(validateSchemaCommand);
+commands.delete('validate-schema');
+
+// #endregion
+
+// #region Actor Basic
+
+mappedCommands['actor-basic'].push(actorsNamespace.get(undefined)!);
+actorsNamespace.delete(undefined);
+
+mappedCommands['actor-basic'].push(actorsNamespace.get('ls')!);
+actorsNamespace.delete('ls');
+
+mappedCommands['actor-basic'].push(actorsNamespace.get('rm')!);
+actorsNamespace.delete('rm');
+
+for (const str of actorNamespace.values()) {
+	mappedCommands['actor-basic'].push(str);
+}
+commands.delete('actor');
+
+// #endregion
+
+// #region Actor Deploy
+
+mappedCommands['actor-deploy'].push(pushCommand.split('\n')[0]);
+commands.delete('push');
+
+mappedCommands['actor-deploy'].push(actorsNamespace.get('push')!);
+actorsNamespace.delete('push');
+
+mappedCommands['actor-deploy'].push(pullCommand.split('\n')[0]);
+commands.delete('pull');
+
+mappedCommands['actor-deploy'].push(actorsNamespace.get('pull')!);
+actorsNamespace.delete('pull');
+
+mappedCommands['actor-deploy'].push(callCommand.split('\n')[0]);
+commands.delete('call');
+
+mappedCommands['actor-deploy'].push(actorsNamespace.get('call')!);
+actorsNamespace.delete('call');
+
+mappedCommands['actor-deploy'].push(actorsNamespace.get('start')!);
+actorsNamespace.delete('start');
+
+mappedCommands['actor-deploy'].push(actorsNamespace.get('info')!);
+actorsNamespace.delete('info');
+
+// #endregion
+
+// #region Actor Build
+
+mappedCommands['actor-build'].push(buildsNamespace.get(undefined)!);
+buildsNamespace.delete(undefined);
+
+mappedCommands['actor-build'].push(buildsNamespace.get('create')!);
+buildsNamespace.delete('create');
+
+// actors build
+mappedCommands['actor-build'].push(actorsNamespace.get('build')!);
+actorsNamespace.delete('build');
+
+// remainder of builds namespace
+for (const str of buildsNamespace.values()) {
+	mappedCommands['actor-build'].push(str);
+}
+
+commands.delete('builds');
+
+// #endregion
+
+// #region Actor Run
+
+for (const str of runsNamespace.values()) {
+	mappedCommands['actor-run'].push(str);
+}
+commands.delete('runs');
+
+// #endregion
+
+// #region Dataset
+
+for (const str of datasetsNamespace.values()) {
+	mappedCommands.dataset.push(str);
+}
+commands.delete('datasets');
+
+// #endregion
+
+// #region KeyVal
+
+for (const str of keyValueStoresNamespace.values()) {
+	mappedCommands.keyval.push(str);
+}
+commands.delete('key-value-stores');
+
+// #endregion
+
+// #region ReqQueue
+
+for (const str of requestQueuesNamespace.values()) {
+	mappedCommands.reqqueue.push(str);
+}
+commands.delete('request-queues');
+
+// #endregion
+
+// #region Task
+
+for (const str of taskNamespace.values()) {
+	mappedCommands.task.push(str);
+}
+commands.delete('task');
+
+// #endregion
+
+// ------
+
+for (const [namespace, entries] of commands) {
+	if (entries.size) {
+		throw new Error(
+			`Namespace ${namespace} still has entries that are not properly mapped: ${[...entries.keys()].join(', ')}`,
+		);
+	}
+}
+
+// Finally, walk the template, replacing the placeholders with the actual commands
+
+let finalString = referenceTemplateString;
+
+for (const [category, commandList] of Object.entries(mappedCommands)) {
+	const startString = `<!-- ${category}-commands-start -->`;
+	const endString = `<!-- ${category}-commands-end -->`;
+
+	if (referenceTemplateString.includes(startString) && !referenceTemplateString.includes(endString)) {
+		throw new Error(`Category ${category} has a start placeholder but no end placeholder in reference template!`);
+	}
+
+	const categoryCommands = commandList.join('\n\n');
+
+	finalString = finalString.replace(startString, `${startString}\n${categoryCommands}`);
+}
+
+// Write the final reference file
+await writeFile(finalOutputFile, finalString);
+
+// Cleanup the temporary file
+await rm(temporaryReferenceFile);

--- a/scripts/reference-template.md
+++ b/scripts/reference-template.md
@@ -1,0 +1,118 @@
+---
+title: Command reference
+---
+
+# Reference
+
+# Apify CLI Reference Documentation
+
+The Apify CLI provides tools for managing your Apify projects and resources from the command line. Use these commands to develop Actors locally, deploy them to the Apify platform, manage storage, orchestrate runs, and handle account configuration.
+
+This reference guide documents available commands, their options, and common usage patterns, to efficiently work with the Apify platform.
+
+## General
+
+The general commands provide basic functionality for getting help and information about the Apify CLI.
+
+<!-- prettier-ignore-start -->
+<!-- general-commands-start -->
+<!-- general-commands-end -->
+<!-- prettier-ignore-end -->
+
+## Authentication & Account Management
+
+Use these commands to manage your Apify account authentication, access tokens, and configuration settings. These commands control how you interact with the Apify platform and manage sensitive information.
+
+<!-- prettier-ignore-start -->
+<!-- auth-commands-start -->
+<!-- auth-commands-end -->
+<!-- prettier-ignore-end -->
+
+## Actor Development
+
+These commands help you develop actors locally. Use them to create new actor projects, initialize configurations, run actors in development mode, and validate input schemas.
+
+<!-- prettier-ignore-start -->
+<!-- actor-dev-commands-start -->
+<!-- actor-dev-commands-end -->
+<!-- prettier-ignore-end -->
+
+## Actor Management
+
+These commands let you manage actors on the Apify platform. They provide functionality for deployment, execution, monitoring, and maintenance of your actors in the cloud environment.
+
+### Basic Actor Operations
+
+Use these commands to handle core actor operations like creation, listing, deletion, and basic runtime management. These are the essential commands for working with actors on the Apify platform.
+
+<!-- prettier-ignore-start -->
+<!-- actor-basic-commands-start -->
+<!-- actor-basic-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Actor Deployment
+
+These commands handle the deployment workflow of actors to the Apify platform. Use them to push local changes, pull remote actors, and manage actor versions and builds.
+
+<!-- prettier-ignore-start -->
+<!-- actor-deploy-commands-start -->
+<!-- actor-deploy-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Actor Builds
+
+Use these commands to manage actor build processes. They help you create, monitor, and maintain versioned snapshots of your actors that can be executed on the Apify platform.
+
+<!-- prettier-ignore-start -->
+<!-- actor-build-commands-start -->
+<!-- actor-build-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Actor Runs
+
+These commands control actor execution on the Apify platform. Use them to start, monitor, and manage actor runs, including accessing logs and handling execution states.
+
+<!-- prettier-ignore-start -->
+<!-- actor-run-commands-start -->
+<!-- actor-run-commands-end -->
+<!-- prettier-ignore-end -->
+
+## Storage
+
+These commands manage data storage on the Apify platform. Use them to work with datasets, key-value stores, and request queues for persistent data storage and retrieval.
+
+### Datasets
+
+Use these commands to manage datasets, which provide structured storage for tabular data. They enable creation, modification, and data manipulation within datasets.
+
+<!-- prettier-ignore-start -->
+<!-- dataset-commands-start -->
+<!-- dataset-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Key-Value Stores
+
+These commands handle key-value store operations. Use them to create stores, manage key-value pairs, and handle persistent storage of arbitrary data types.
+
+<!-- prettier-ignore-start -->
+<!-- keyval-commands-start -->
+<!-- keyval-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Request Queues
+
+These commands manage request queues, which handle URL processing for web scraping and automation tasks. Use them to maintain lists of URLs with automatic retry mechanisms and state management.
+
+<!-- prettier-ignore-start -->
+<!-- reqqueue-commands-start -->
+<!-- reqqueue-commands-end -->
+<!-- prettier-ignore-end -->
+
+### Tasks
+
+These commands help you manage scheduled and configured actor runs. Use them to create, modify, and execute predefined actor configurations as tasks.
+
+<!-- prettier-ignore-start -->
+<!-- task-commands-start -->
+<!-- task-commands-end -->
+<!-- prettier-ignore-end -->

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -10,6 +10,7 @@
 		"vitest.config.ts",
 		"test",
 		".yarn/plugins/postinstallDev.cjs",
-		"features/**/*.ts"
+		"features/**/*.ts",
+		"scripts"
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,6 +3061,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/debug@npm:^4.0.0":
+  version: 4.1.12
+  resolution: "@types/debug@npm:4.1.12"
+  dependencies:
+    "@types/ms": "npm:*"
+  checksum: 10c0/5dcd465edbb5a7f226e9a5efd1f399c6172407ef5840686b73e3608ce135eeca54ae8037dcd9f16bdb2768ac74925b820a8b9ecc588a58ca09eca6acabe33e2f
+  languageName: node
+  linkType: hard
+
 "@types/emscripten@npm:^1.39.6":
   version: 1.40.0
   resolution: "@types/emscripten@npm:1.40.0"
@@ -3190,6 +3199,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mdast@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "@types/mdast@npm:4.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/84f403dbe582ee508fd9c7643ac781ad8597fcbfc9ccb8d4715a2c92e4545e5772cbd0dbdf18eda65789386d81b009967fdef01b24faf6640f817287f54d9c82
+  languageName: node
+  linkType: hard
+
 "@types/mime@npm:^1":
   version: 1.3.5
   resolution: "@types/mime@npm:1.3.5"
@@ -3203,6 +3221,13 @@ __metadata:
   dependencies:
     mime: "npm:*"
   checksum: 10c0/c544ca670c2cb53b96c7e4a1b4ecfdf3777dad4b74f7bb305680eed82c753a7ccfdf03c8b06c9fba48bb10d2a96ae95c9a4007b6c83bc5fdc9cfa7250c07b85b
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 2.1.0
+  resolution: "@types/ms@npm:2.1.0"
+  checksum: 10c0/5ce692ffe1549e1b827d99ef8ff71187457e0eb44adbae38fdf7b9a74bae8d20642ee963c14516db1d35fa2652e65f47680fdf679dcbde52bbfadd021f497225
   languageName: node
   linkType: hard
 
@@ -3320,6 +3345,13 @@ __metadata:
   version: 1.13.0
   resolution: "@types/underscore@npm:1.13.0"
   checksum: 10c0/240d3f36f694e177b1896c464b1254249e64b51a2afc703a1dda61f0c544d6e3b081ac4d955fb057e873982a62a7ba78e3a0aaa252c9d766f6cbe5e85283bc04
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*, @types/unist@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "@types/unist@npm:3.0.3"
+  checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
   languageName: node
   linkType: hard
 
@@ -3892,7 +3924,7 @@ __metadata:
     escape-string-regexp: "npm:~5.0.0"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^10.0.0"
-    execa: "npm:^9.3.0"
+    execa: "npm:^9.5.2"
     express: "npm:~4.21.0"
     fs-extra: "npm:^11.2.0"
     globby: "npm:~14.1.0"
@@ -3905,6 +3937,7 @@ __metadata:
     lint-staged: "npm:^15.2.8"
     load-json-file: "npm:~7.0.1"
     lodash.clonedeep: "npm:^4.5.0"
+    mdast-util-from-markdown: "npm:^2.0.2"
     mime: "npm:~4.0.4"
     mixpanel: "npm:~0.18.0"
     mock-stdin: "npm:^1.0.0"
@@ -4627,6 +4660,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "character-entities@npm:2.0.2"
+  checksum: 10c0/b0c645a45bcc90ff24f0e0140f4875a8436b8ef13b6bcd31ec02cfb2ca502b680362aa95386f7815bdc04b6464d48cf191210b3840d7c04241a149ede591a308
+  languageName: node
+  linkType: hard
+
 "chardet@npm:^0.7.0":
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
@@ -5130,7 +5170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -5148,6 +5188,15 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
+  languageName: node
+  linkType: hard
+
+"decode-named-character-reference@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "decode-named-character-reference@npm:1.0.2"
+  dependencies:
+    character-entities: "npm:^2.0.0"
+  checksum: 10c0/66a9fc5d9b5385a2b3675c69ba0d8e893393d64057f7dbbb585265bb4fc05ec513d76943b8e5aac7d8016d20eea4499322cbf4cd6d54b466976b78f3a7587a4c
   languageName: node
   linkType: hard
 
@@ -5250,6 +5299,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "destroy@npm:1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
@@ -5268,6 +5324,15 @@ __metadata:
   version: 4.0.1
   resolution: "detect-newline@npm:4.0.1"
   checksum: 10c0/1cc1082e88ad477f30703ae9f23bd3e33816ea2db6a35333057e087d72d466f5a777809b71f560118ecff935d2c712f5b59e1008a8b56a900909d8fd4621c603
+  languageName: node
+  linkType: hard
+
+"devlop@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "devlop@npm:1.1.0"
+  dependencies:
+    dequal: "npm:^2.0.0"
+  checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
   languageName: node
   linkType: hard
 
@@ -6317,7 +6382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^9.3.0":
+"execa@npm:^9.5.2":
   version: 9.5.2
   resolution: "execa@npm:9.5.2"
   dependencies:
@@ -8547,6 +8612,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-from-markdown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "mdast-util-from-markdown@npm:2.0.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark: "npm:^4.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/76eb2bd2c6f7a0318087c73376b8af6d7561c1e16654e7667e640f391341096c56142618fd0ff62f6d39e5ab4895898b9789c84cd7cec2874359a437a0e1ff15
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mdast-util-to-string@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+  checksum: 10c0/2d3c1af29bf3fe9c20f552ee9685af308002488f3b04b12fa66652c9718f66f41a32f8362aa2d770c3ff464c034860b41715902ada2306bb0a055146cef064d7
+  languageName: node
+  linkType: hard
+
 "media-typer@npm:0.3.0":
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
@@ -8579,6 +8673,242 @@ __metadata:
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
   checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
+  languageName: node
+  linkType: hard
+
+"micromark-core-commonmark@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "micromark-core-commonmark@npm:2.0.2"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-factory-destination: "npm:^2.0.0"
+    micromark-factory-label: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-factory-title: "npm:^2.0.0"
+    micromark-factory-whitespace: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-html-tag-name: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/87c7a75cd339189eb6f1d6323037f7d108d1331d953b84fe839b37fd385ee2292b27222327c1ceffda46ba5d5d4dee703482475e5ee8744be40c9e308d8acb77
+  languageName: node
+  linkType: hard
+
+"micromark-factory-destination@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-destination@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bbafcf869cee5bf511161354cb87d61c142592fbecea051000ff116068dc85216e6d48519d147890b9ea5d7e2864a6341c0c09d9948c203bff624a80a476023c
+  languageName: node
+  linkType: hard
+
+"micromark-factory-label@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-label@npm:2.0.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/0137716b4ecb428114165505e94a2f18855c8bbea21b07a8b5ce514b32a595ed789d2b967125718fc44c4197ceaa48f6609d58807a68e778138d2e6b91b824e8
+  languageName: node
+  linkType: hard
+
+"micromark-factory-space@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-space@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/f9ed43f1c0652d8d898de0ac2be3f77f776fffe7dd96bdbba1e02d7ce33d3853c6ff5daa52568fc4fa32cdf3a62d86b85ead9b9189f7211e1d69ff2163c450fb
+  languageName: node
+  linkType: hard
+
+"micromark-factory-title@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-title@npm:2.0.1"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/e72fad8d6e88823514916890099a5af20b6a9178ccf78e7e5e05f4de99bb8797acb756257d7a3a57a53854cb0086bf8aab15b1a9e9db8982500dd2c9ff5948b6
+  languageName: node
+  linkType: hard
+
+"micromark-factory-whitespace@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-whitespace@npm:2.0.1"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/20a1ec58698f24b766510a309b23a10175034fcf1551eaa9da3adcbed3e00cd53d1ebe5f030cf873f76a1cec3c34eb8c50cc227be3344caa9ed25d56cf611224
+  languageName: node
+  linkType: hard
+
+"micromark-util-character@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "micromark-util-character@npm:2.1.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/d3fe7a5e2c4060fc2a076f9ce699c82a2e87190a3946e1e5eea77f563869b504961f5668d9c9c014724db28ac32fa909070ea8b30c3a39bd0483cc6c04cc76a1
+  languageName: node
+  linkType: hard
+
+"micromark-util-chunked@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-chunked@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/b68c0c16fe8106949537bdcfe1be9cf36c0ccd3bc54c4007003cb0984c3750b6cdd0fd77d03f269a3382b85b0de58bde4f6eedbe7ecdf7244759112289b1ab56
+  languageName: node
+  linkType: hard
+
+"micromark-util-classify-character@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-classify-character@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/8a02e59304005c475c332f581697e92e8c585bcd45d5d225a66c1c1b14ab5a8062705188c2ccec33cc998d33502514121478b2091feddbc751887fc9c290ed08
+  languageName: node
+  linkType: hard
+
+"micromark-util-combine-extensions@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-combine-extensions@npm:2.0.1"
+  dependencies:
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/f15e282af24c8372cbb10b9b0b3e2c0aa681fea0ca323a44d6bc537dc1d9382c819c3689f14eaa000118f5a163245358ce6276b2cda9a84439cdb221f5d86ae7
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-numeric-character-reference@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "micromark-util-decode-numeric-character-reference@npm:2.0.2"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/9c8a9f2c790e5593ffe513901c3a110e9ec8882a08f466da014112a25e5059b51551ca0aeb7ff494657d86eceb2f02ee556c6558b8d66aadc61eae4a240da0df
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-string@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-decode-string@npm:2.0.1"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/f24d75b2e5310be6e7b6dee532e0d17d3bf46996841d6295f2a9c87a2046fff4ab603c52ab9d7a7a6430a8b787b1574ae895849c603d262d1b22eef71736b5cb
+  languageName: node
+  linkType: hard
+
+"micromark-util-encode@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-encode@npm:2.0.1"
+  checksum: 10c0/b2b29f901093845da8a1bf997ea8b7f5e061ffdba85070dfe14b0197c48fda64ffcf82bfe53c90cf9dc185e69eef8c5d41cae3ba918b96bc279326921b59008a
+  languageName: node
+  linkType: hard
+
+"micromark-util-html-tag-name@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-html-tag-name@npm:2.0.1"
+  checksum: 10c0/ae80444db786fde908e9295f19a27a4aa304171852c77414516418650097b8afb401961c9edb09d677b06e97e8370cfa65638dde8438ebd41d60c0a8678b85b9
+  languageName: node
+  linkType: hard
+
+"micromark-util-normalize-identifier@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-normalize-identifier@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/5299265fa360769fc499a89f40142f10a9d4a5c3dd8e6eac8a8ef3c2e4a6570e4c009cf75ea46dce5ee31c01f25587bde2f4a5cc0a935584ae86dd857f2babbd
+  languageName: node
+  linkType: hard
+
+"micromark-util-resolve-all@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-resolve-all@npm:2.0.1"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bb6ca28764696bb479dc44a2d5b5fe003e7177aeae1d6b0d43f24cc223bab90234092d9c3ce4a4d2b8df095ccfd820537b10eb96bb7044d635f385d65a4c984a
+  languageName: node
+  linkType: hard
+
+"micromark-util-sanitize-uri@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-sanitize-uri@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/60e92166e1870fd4f1961468c2651013ff760617342918e0e0c3c4e872433aa2e60c1e5a672bfe5d89dc98f742d6b33897585cf86ae002cda23e905a3c02527c
+  languageName: node
+  linkType: hard
+
+"micromark-util-subtokenize@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "micromark-util-subtokenize@npm:2.0.4"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/d1d19c6ede87e5d3778aa7f6c56ad736a48404556757abf71ea87bd2baac71927d18db3c9a1f76c4b3f42f32d6032aea97d1de739b49872daf168c6f8f373f39
+  languageName: node
+  linkType: hard
+
+"micromark-util-symbol@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-symbol@npm:2.0.1"
+  checksum: 10c0/f2d1b207771e573232436618e78c5e46cd4b5c560dd4a6d63863d58018abbf49cb96ec69f7007471e51434c60de3c9268ef2bf46852f26ff4aacd10f9da16fe9
+  languageName: node
+  linkType: hard
+
+"micromark-util-types@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-types@npm:2.0.1"
+  checksum: 10c0/872ec9334bb42afcc91c5bed8b7ee03b75654b36c6f221ab4d2b1bb0299279f00db948bf38ec6bc1ec03d0cf7842c21ab805190bf676157ba587eb0386d38b71
+  languageName: node
+  linkType: hard
+
+"micromark@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "micromark@npm:4.0.1"
+  dependencies:
+    "@types/debug": "npm:^4.0.0"
+    debug: "npm:^4.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/b5d950c84664ce209575e5a54946488f0a1e1240d080544e657b65074c9b08208a5315d9db066b93cbc199ec05f68552ba8b09fd5e716c726f4a4712275a7c5c
   languageName: node
   linkType: hard
 
@@ -11640,6 +11970,15 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/d324c5a44887bd7e105ce800fcf7533d43f29c48757ac410afd42975de82cc38ea2035c0483f4de82d186691bf3208ef35c644f73aa2b1b20b8e651be5afd293
+  languageName: node
+  linkType: hard
+
+"unist-util-stringify-position@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unist-util-stringify-position@npm:4.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/dfe1dbe79ba31f589108cb35e523f14029b6675d741a79dea7e5f3d098785045d556d5650ec6a8338af11e9e78d2a30df12b1ee86529cded1098da3f17ee999e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As requested by @TC-MO, I've pseudo-automated the generation of the reference file that people see on our docs!

I will add in more documentation on how to alter this later (more specifically handling new commands added to the CLI), as its a manual mapping of commands (unfortunately couldn't do it fully automated due to some commands having different positions across the categories)

There probably is a better way to handle this in the future, I just did the speedy way for now. Ideally, we'd use oclif's systems to load all commands, store some specific field on each command class and rely on that to map commands around, but even then we'll need to handle custom ordering which might make it janky. To be determined