### PR TITLE
chore(ci): cache npm cache for tests

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,7 +37,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ env.LATEST_NODE_VERSION }}
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -71,7 +71,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ env.LATEST_NODE_VERSION }}
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -117,7 +117,12 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ matrix.node-version }}
+            - name: Activate cache for npm
+              uses: actions/setup-node@v4
+              with:
+                  cache: npm
+
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -154,7 +159,12 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ env.LATEST_NODE_VERSION }}
+            - name: Activate cache for npm
+              uses: actions/setup-node@v4
+              with:
+                  cache: npm
+
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -199,7 +209,12 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ env.LATEST_NODE_VERSION }}
+            - name: Activate cache for npm
+              uses: actions/setup-node@v4
+              with:
+                  cache: npm
+
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -237,7 +252,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ env.LATEST_NODE_VERSION }}
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -284,7 +299,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ env.LATEST_NODE_VERSION }}
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn

--- a/.github/workflows/cucumber.yaml
+++ b/.github/workflows/cucumber.yaml
@@ -39,7 +39,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js ${{ matrix.node-version }}
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,12 +9,15 @@ on:
 jobs:
     build:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+
         environment:
             name: github-pages
+
         permissions:
             contents: write
             pages: write
             id-token: write
+
         runs-on: ubuntu-latest
 
         steps:
@@ -22,17 +25,17 @@ jobs:
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-            - name: Use Node.js 20
+            - name: Use Node.js 22
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Enable corepack
               run: |
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js 20
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -133,7 +133,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js 22
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -238,7 +238,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js 22
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js 22
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -156,7 +156,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js 22
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -259,7 +259,7 @@ jobs:
                   corepack enable
                   corepack prepare yarn@stable --activate
 
-            - name: Activate cache for Node.js 22
+            - name: Activate cache for yarn
               uses: actions/setup-node@v4
               with:
                   cache: yarn
@@ -275,7 +275,7 @@ jobs:
 
             - name: Publish to NPM
               run: |
-                  yarn npm publish --provenance --access public --tag beta
+                  yarn npm publish --provenance --access public
               env:
                   YARN_NPM_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
 


### PR DESCRIPTION
Should hopefully speed up template tests (since that seems to be the longest part of the CI). 
Also fixes the release flow tagging releases as `beta` - thankfully caught before we did an actual release