### PR TITLE
fix: pass apify client down to output job log wherever possible

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -298,7 +298,7 @@ Skipping push. Use --force to override.`,
 		});
 
 		try {
-			await outputJobLog(build, waitForFinishMillis);
+			await outputJobLog({ job: build, timeout: waitForFinishMillis, apifyClient });
 		} catch (err) {
 			warning({ message: 'Can not get log:' });
 			console.error(err);

--- a/src/commands/builds/create.ts
+++ b/src/commands/builds/create.ts
@@ -146,7 +146,7 @@ export class BuildsCreateCommand extends ApifyCommand<typeof BuildsCreateCommand
 
 		if (log) {
 			try {
-				await outputJobLog(build);
+				await outputJobLog({ job: build, apifyClient: client });
 			} catch (err) {
 				// This should never happen...
 				error({

--- a/src/commands/builds/log.ts
+++ b/src/commands/builds/log.ts
@@ -30,7 +30,7 @@ export class BuildsLogCommand extends ApifyCommand<typeof BuildsLogCommand> {
 		info({ message: `Log for build with ID "${buildId}":\n` });
 
 		try {
-			await outputJobLog(build);
+			await outputJobLog({ job: build, apifyClient });
 		} catch (err) {
 			// This should never happen...
 			error({

--- a/src/commands/runs/log.ts
+++ b/src/commands/runs/log.ts
@@ -30,7 +30,7 @@ export class RunsLogCommand extends ApifyCommand<typeof RunsLogCommand> {
 		info({ message: `Log for run with ID "${runId}":\n`, stdout: true });
 
 		try {
-			await outputJobLog(run);
+			await outputJobLog({ job: run, apifyClient });
 		} catch (err) {
 			// This should never happen...
 			error({ message: `Failed to get log for run with ID "${runId}": ${(err as Error).message}` });

--- a/src/lib/commands/run-on-cloud.ts
+++ b/src/lib/commands/run-on-cloud.ts
@@ -95,7 +95,7 @@ export async function* runActorOrTaskOnCloud(apifyClient: ApifyClient, options: 
 
 	if (!silent && printRunLogs) {
 		try {
-			const res = await outputJobLog(run, waitForFinishMillis);
+			const res = await outputJobLog({ job: run, timeout: waitForFinishMillis, apifyClient });
 
 			if (res === 'timeouts') {
 				console.error(`\n${chalk.gray('Timeout for printing logs was hit, there may be future logs.')}\n`);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -365,9 +365,17 @@ export const purgeDefaultKeyValueStore = async () => {
 	await Promise.all(deletePromises);
 };
 
-export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
+export const outputJobLog = async ({
+	job,
+	timeout,
+	apifyClient,
+}: {
+	job: ActorRun | Build;
+	timeout?: number;
+	apifyClient?: ApifyClient;
+}) => {
 	const { id: logId, status } = job;
-	const apifyClient = new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
+	const client = apifyClient || new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
 
 	// In case job was already done just output log
 	if (ACTOR_JOB_TERMINAL_STATUSES.includes(status as never)) {
@@ -375,7 +383,7 @@ export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
 			return;
 		}
 
-		const log = await apifyClient.log(logId).get();
+		const log = await client.log(logId).get();
 		process.stderr.write(log!);
 		return;
 	}
@@ -383,7 +391,7 @@ export const outputJobLog = async (job: ActorRun | Build, timeout?: number) => {
 	// In other case stream it to stderr
 	// eslint-disable-next-line no-async-promise-executor
 	return new Promise<'no-logs' | 'finished' | 'timeouts'>(async (resolve) => {
-		const stream = await apifyClient.log(logId).stream();
+		const stream = await client.log(logId).stream();
 
 		if (!stream) {
 			resolve('no-logs');


### PR DESCRIPTION
Should solve the issue for now until we do a full auth cleanup

Supersedes #718 
Context: https://apify.slack.com/archives/CD0SF6KD4/p1750672446729949