### PR TITLE
fix: change warn color to yellow instead of red

### DIFF
--- a/src/lib/outputs.ts
+++ b/src/lib/outputs.ts
@@ -34,7 +34,7 @@ export function error(options: SimpleLogOptions) {
 
 export function warning(options: SimpleLogOptions) {
 	internalLog({
-		[options.stdout ? 'stdoutOutput' : 'stderrOutput']: [chalk.rgb(254, 90, 29).bold('Warning:'), options.message],
+		[options.stdout ? 'stdoutOutput' : 'stderrOutput']: [chalk.yellow.bold('Warning:'), options.message],
 	});
 }
 


### PR DESCRIPTION
 The Apify CLI has red color for warning, but it i is standard to have yellow / orange color for these messages. This PR changes it to yellow.