### PR TITLE
chore: fix login/logout test + make vitest wait longer for api tests

### DIFF
--- a/test/api/commands/log_in_out.test.ts
+++ b/test/api/commands/log_in_out.test.ts
@@ -36,7 +36,6 @@ describe('[api] apify login and logout', () => {
 		}) as unknown as Record<string, string>;
 		const userInfoFromConfig = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
 
-		expect(errorSpy()).toHaveBeenCalledTimes(1);
 		expect(lastErrorMessage()).to.include('Success:');
 
 		// Omit currentBillingPeriod, It can change during tests

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'vitest/config';
 
 const isWindows = process.platform === 'win32';
-const multiplierFactor = isWindows ? 3 : 1;
+const multiplierFactor = isWindows ? 3 : 2;
 
 export default defineConfig({
 	esbuild: {


### PR DESCRIPTION
Quick fix for login test that broke post telemetry change and increase unix timeouts too (which affects API tests specifically since creating and building actors takes annoyingly long)