### PR TITLE
chore: make opening the actor build results in push opt-in

### DIFF
--- a/features/test-implementations/1.setup.ts
+++ b/features/test-implementations/1.setup.ts
@@ -234,7 +234,7 @@ Given<TestWorld>(/the local actor is pushed to the Apify platform/i, { timeout: 
 	}
 
 	const result = await executeCommand({
-		rawCommand: 'apify push --no-prompt',
+		rawCommand: 'apify push',
 		cwd: this.testActor.pwd,
 		env: extraEnv,
 	});

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -3,7 +3,6 @@ import { join, resolve } from 'node:path';
 import process from 'node:process';
 
 import type { Actor, ActorCollectionCreateOptions, ActorDefaultRunOptions } from 'apify-client';
-import isCI from 'is-ci';
 import open from 'open';
 
 import { fetchManifest } from '@apify/actor-templates';
@@ -15,7 +14,6 @@ import { Flags } from '../../lib/command-framework/flags.js';
 import { CommandExitCodes, DEPRECATED_LOCAL_CONFIG_NAME, LOCAL_CONFIG_PATH } from '../../lib/consts.js';
 import { sumFilesSizeInBytes } from '../../lib/files.js';
 import { useActorConfig } from '../../lib/hooks/useActorConfig.js';
-import { useYesNoConfirm } from '../../lib/hooks/user-confirmations/useYesNoConfirm.js';
 import { error, info, link, run, success, warning } from '../../lib/outputs.js';
 import { transformEnvToEnvVars } from '../../lib/secrets.js';
 import {
@@ -66,9 +64,8 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 			description: 'Seconds for waiting to build to finish, if no value passed, it waits forever.',
 			required: false,
 		}),
-		'no-prompt': Flags.boolean({
-			description:
-				'Do not prompt for opening the Actor details in a browser. This will also not open the browser automatically.',
+		'open': Flags.boolean({
+			description: 'Whether to open the browser automatically to the Actor build details.',
 			default: false,
 			required: false,
 		}),
@@ -311,15 +308,8 @@ Skipping push. Use --force to override.`,
 			url: `https://console.apify.com${redirectUrlPart}/actors/${build.actId}#/builds/${build.buildNumber}`,
 		});
 
-		// Disable open browser on CI, or if user passed --no-prompt flag
-		if (!isCI && !this.flags.noPrompt) {
-			const shouldOpenBrowser = await useYesNoConfirm({
-				message: 'Do you want to open the Actor detail in your browser?',
-			});
-
-			if (shouldOpenBrowser) {
-				await open(`https://console.apify.com${redirectUrlPart}/actors/${build.actId}`);
-			}
+		if (this.flags.open) {
+			await open(`https://console.apify.com${redirectUrlPart}/actors/${build.actId}`);
 		}
 
 		if (build.status === ACTOR_JOB_STATUSES.SUCCEEDED) {

--- a/src/lib/hooks/user-confirmations/useMaskedInput.ts
+++ b/src/lib/hooks/user-confirmations/useMaskedInput.ts
@@ -8,7 +8,7 @@ interface UseMaskedInputInput {
 }
 
 export const useMaskedInput = stdinCheckWrapper(async ({ message, mask }: UseMaskedInputInput) => {
-	const result = await password({ message, mask });
+	const result = await password({ message, mask: mask ?? '*' });
 
 	return result;
 });


### PR DESCRIPTION
BREAKING CHANGE: the `--no-prompt` flag in `apify push` has been replaced with `--open`. Provide this flag if you want the CLI to automatically open the Actor build details.