### PR TITLE
chore(ci): fix Windows CI for good

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -130,6 +130,12 @@ jobs:
               with:
                   cache: yarn
 
+            - name: Setup Python 3.12 (Windows)
+              if: ${{ matrix.os == 'windows-2025' }}
+              uses: actions/setup-python@v6
+              with:
+                  python-version: 3.12
+
             - name: Install Dependencies
               run: yarn
 


### PR DESCRIPTION
Windows 2025 image coming with Python 3.9 is a joke.