### PR TITLE
feat: properly implement the logic to use CLI with multiple backends

### DIFF
--- a/features/test-implementations/1.setup.ts
+++ b/features/test-implementations/1.setup.ts
@@ -193,7 +193,7 @@ Given<TestWorld>(/logged in apify console user/i, async function () {
 	}
 
 	// Try to make the client with the token
-	const client = new ApifyClient(getApifyClientOptions(process.env.TEST_USER_TOKEN));
+	const client = new ApifyClient(await getApifyClientOptions(process.env.TEST_USER_TOKEN));
 
 	try {
 		await client.user('me').get();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -16,19 +16,18 @@ import { updateUserId } from '../lib/hooks/telemetry/useTelemetryState.js';
 import { useMaskedInput } from '../lib/hooks/user-confirmations/useMaskedInput.js';
 import { useSelectFromList } from '../lib/hooks/user-confirmations/useSelectFromList.js';
 import { error, info, success } from '../lib/outputs.js';
-import { getLocalUserInfo, getLoggedClient, tildify } from '../lib/utils.js';
+import { getApifyAPIBaseUrl, getLocalUserInfo, getLoggedClient, tildify } from '../lib/utils.js';
 
-const CONSOLE_BASE_URL = 'https://console.apify.com/settings/integrations';
-// const CONSOLE_BASE_URL = 'http://localhost:3000/settings/integrations';
+const CONSOLE_BASE_URL = getApifyAPIBaseUrl()?.includes('localhost')
+	? 'http://localhost:3000/settings/integrations'
+	: 'https://console.apify.com/settings/integrations';
 const CONSOLE_URL_ORIGIN = new URL(CONSOLE_BASE_URL).origin;
-
-const API_BASE_URL = CONSOLE_BASE_URL.includes('localhost') ? 'http://localhost:3333' : undefined;
 
 // Not really checked right now, but it might come useful if we ever need to do some breaking changes
 const API_VERSION = 'v1';
 
 const tryToLogin = async (token: string) => {
-	const isUserLogged = await getLoggedClient(token, API_BASE_URL);
+	const isUserLogged = await getLoggedClient(token);
 	const userInfo = await getLocalUserInfo();
 
 	if (isUserLogged) {

--- a/src/lib/actor.ts
+++ b/src/lib/actor.ts
@@ -57,7 +57,7 @@ export const getApifyStorageClient = async (
 	const apifyToken = await getApifyTokenFromEnvOrAuthFile();
 
 	return new ApifyClient({
-		...getApifyClientOptions(apifyToken),
+		...(await getApifyClientOptions(apifyToken)),
 		...options,
 	});
 };

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -76,3 +76,5 @@ export enum CommandExitCodes {
 	NotFound = 250,
 	NotImplemented = 255,
 }
+
+export const DEFAULT_APIFY_API_BASE_URL = 'https://api.apify.com';

--- a/src/lib/hooks/telemetry/useTelemetryEnabled.ts
+++ b/src/lib/hooks/telemetry/useTelemetryEnabled.ts
@@ -1,5 +1,5 @@
 import { cliDebugPrint } from '../../utils/cliDebugPrint.js';
-import { useTelemetryState } from './useTelemetryState.js';
+import { isTelemetryDisabledInThisEnv, useTelemetryState } from './useTelemetryState.js';
 
 export async function useTelemetryEnabled() {
 	// Env variable present and not false/0
@@ -13,5 +13,5 @@ export async function useTelemetryEnabled() {
 
 	cliDebugPrint('telemetry state', { telemetryState });
 
-	return telemetryState.enabled;
+	return telemetryState.enabled && !isTelemetryDisabledInThisEnv();
 }

--- a/test/__setup__/config.ts
+++ b/test/__setup__/config.ts
@@ -13,9 +13,9 @@ if (!ENV_TEST_USER_TOKEN) {
 	throw Error('You must configure "TEST_USER_TOKEN" environment variable to run tests!');
 }
 
-export const testUserClient = new ApifyClient(getApifyClientOptions(ENV_TEST_USER_TOKEN));
+export const testUserClient = new ApifyClient(await getApifyClientOptions(ENV_TEST_USER_TOKEN));
 
-export const badUserClient = new ApifyClient(getApifyClientOptions(TEST_USER_BAD_TOKEN));
+export const badUserClient = new ApifyClient(await getApifyClientOptions(TEST_USER_BAD_TOKEN));
 
 export const TEST_USER_TOKEN = ENV_TEST_USER_TOKEN;
 

--- a/test/api/commands/info.test.ts
+++ b/test/api/commands/info.test.ts
@@ -1,8 +1,6 @@
-import { readFileSync } from 'node:fs';
-
 import { InfoCommand } from '../../../src/commands/info.js';
 import { testRunCommand } from '../../../src/lib/command-framework/apify-command.js';
-import { AUTH_FILE_PATH } from '../../../src/lib/consts.js';
+import { getLocalUserInfo } from '../../../src/lib/utils.js';
 import { safeLogin, useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
 import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
 
@@ -21,7 +19,7 @@ describe('[api] apify info', () => {
 		await safeLogin();
 		await testRunCommand(InfoCommand, {});
 
-		const userInfoFromConfig = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
+		const userInfoFromConfig = await getLocalUserInfo();
 
 		const spy = logSpy();
 

--- a/test/api/commands/log_in_out.test.ts
+++ b/test/api/commands/log_in_out.test.ts
@@ -1,9 +1,10 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 
 import axios from 'axios';
 
 import { testRunCommand } from '../../../src/lib/command-framework/apify-command.js';
 import { AUTH_FILE_PATH } from '../../../src/lib/consts.js';
+import { getLocalUserInfo } from '../../../src/lib/utils.js';
 import { TEST_USER_BAD_TOKEN, TEST_USER_TOKEN, testUserClient } from '../../__setup__/config.js';
 import { safeLogin, useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
 import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
@@ -34,7 +35,7 @@ describe('[api] apify login and logout', () => {
 		const expectedUserInfo = Object.assign(await testUserClient.user('me').get(), {
 			token: TEST_USER_TOKEN,
 		}) as unknown as Record<string, string>;
-		const userInfoFromConfig = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
+		const userInfoFromConfig = (await getLocalUserInfo()) as unknown as Record<string, string>;
 
 		expect(lastErrorMessage()).to.include('Success:');
 
@@ -85,7 +86,7 @@ describe('[api] apify login and logout', () => {
 		const expectedUserInfo = Object.assign(await testUserClient.user('me').get(), {
 			token: TEST_USER_TOKEN,
 		}) as unknown as Record<string, string>;
-		const userInfoFromConfig = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
+		const userInfoFromConfig = (await getLocalUserInfo()) as unknown as Record<string, string>;
 
 		expect(lastErrorMessage()).to.include('Success:');
 

--- a/test/local/commands/run.test.ts
+++ b/test/local/commands/run.test.ts
@@ -4,13 +4,14 @@ import { dirname } from 'node:path/win32';
 import { APIFY_ENV_VARS } from '@apify/consts';
 
 import { testRunCommand } from '../../../src/lib/command-framework/apify-command.js';
-import { AUTH_FILE_PATH, EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH } from '../../../src/lib/consts.js';
+import { EMPTY_LOCAL_CONFIG, LOCAL_CONFIG_PATH } from '../../../src/lib/consts.js';
 import { rimrafPromised } from '../../../src/lib/files.js';
 import {
 	getLocalDatasetPath,
 	getLocalKeyValueStorePath,
 	getLocalRequestQueuePath,
 	getLocalStorageDir,
+	getLocalUserInfo,
 } from '../../../src/lib/utils.js';
 import { TEST_TIMEOUT } from '../../__setup__/consts.js';
 import { safeLogin, useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
@@ -123,9 +124,9 @@ describe('apify run', () => {
 		const actOutputPath = joinPath(getLocalKeyValueStorePath(), 'OUTPUT.json');
 
 		const localEnvVars = JSON.parse(readFileSync(actOutputPath, 'utf8'));
-		const auth = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
+		const auth = await getLocalUserInfo();
 
-		expect(localEnvVars[APIFY_ENV_VARS.PROXY_PASSWORD]).toStrictEqual(auth.proxy.password);
+		expect(localEnvVars[APIFY_ENV_VARS.PROXY_PASSWORD]).toStrictEqual(auth.proxy!.password);
 		expect(localEnvVars[APIFY_ENV_VARS.USER_ID]).toStrictEqual(auth.id);
 		expect(localEnvVars[APIFY_ENV_VARS.TOKEN]).toStrictEqual(auth.token);
 		expect(localEnvVars.TEST_LOCAL).toStrictEqual(testEnvVars.TEST_LOCAL);
@@ -164,9 +165,9 @@ describe('apify run', () => {
 		const actOutputPath = joinPath(getLocalKeyValueStorePath(), 'OUTPUT.json');
 
 		const localEnvVars = JSON.parse(readFileSync(actOutputPath, 'utf8'));
-		const auth = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
+		const auth = await getLocalUserInfo();
 
-		expect(localEnvVars[APIFY_ENV_VARS.PROXY_PASSWORD]).toStrictEqual(auth.proxy.password);
+		expect(localEnvVars[APIFY_ENV_VARS.PROXY_PASSWORD]).toStrictEqual(auth.proxy!.password);
 		expect(localEnvVars[APIFY_ENV_VARS.USER_ID]).toStrictEqual(auth.id);
 		expect(localEnvVars[APIFY_ENV_VARS.TOKEN]).toStrictEqual(auth.token);
 		expect(localEnvVars.TEST_LOCAL).toStrictEqual(testEnvVars.TEST_LOCAL);
@@ -204,9 +205,9 @@ describe('apify run', () => {
 		const actOutputPath = joinPath(getLocalKeyValueStorePath(), 'OUTPUT.json');
 
 		const localEnvVars = JSON.parse(readFileSync(actOutputPath, 'utf8'));
-		const auth = JSON.parse(readFileSync(AUTH_FILE_PATH(), 'utf8'));
+		const auth = await getLocalUserInfo();
 
-		expect(localEnvVars[APIFY_ENV_VARS.PROXY_PASSWORD]).toStrictEqual(auth.proxy.password);
+		expect(localEnvVars[APIFY_ENV_VARS.PROXY_PASSWORD]).toStrictEqual(auth.proxy!.password);
 		expect(localEnvVars[APIFY_ENV_VARS.USER_ID]).toStrictEqual(auth.id);
 		expect(localEnvVars[APIFY_ENV_VARS.TOKEN]).toStrictEqual(auth.token);
 		expect(localEnvVars.TEST_LOCAL).toStrictEqual(testEnvVars.TEST_LOCAL);


### PR DESCRIPTION
There were some commented stubs and leftover conditions in the code, but they didn't really work properly. This would be really helpful for me for work on core, so when I found the stubs, I decided to actually implement the support properly.

This required adding a new version of the auth.json file, I implemented the logic that it transparently upgrades the old format to the new one.

I was also thinking about some support of multiple users for one backend (e.g. pushing to organizations). That would be a big feature, and I think we would want some nice logic similar to `rustup override` or `fnm` Node versions manager (use some global default, and allow remembering overrides per project folder), and I don't want to scope creep this. But we should think about the requirements for the v2 auth.json file - maybe `backends` could just be `Array<{backend: string; username: string; authData: {...}}>`? Then in the current implementation I would just find the first matching record, and later we could change the logic to match against the username too?

I will add some tests for the config schema migration, hopefully today.