### PR TITLE
chore: Improve download message clarity during CLI upgrade

### DIFF
--- a/src/commands/cli-management/upgrade.ts
+++ b/src/commands/cli-management/upgrade.ts
@@ -287,7 +287,7 @@ export class UpgradeCommand extends ApifyCommand<typeof UpgradeCommand> {
 			const cliName = asset.name.split('-')[0];
 			const filePath = join(bundleDirectory, cliName);
 
-			info({ message: `Downloading ${cliName}...` });
+			info({ message: `Downloading \`${cliName}\` binary of the Apify CLI...` });
 
 			const res = await fetch(asset.browser_download_url, { headers: { 'User-Agent': USER_AGENT } });
 


### PR DESCRIPTION
Update the download message from "Downloading actor/apify..." to "Downloading `actor`/`apify` binary of the Apify CLI..." to better explain what is being downloaded during the upgrade process.