### PR TITLE
perf: Speed up creating archives when pusing big codebases

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -307,10 +307,13 @@ export const createActZip = async (zipName: string, pathsToZip: string[], cwd: s
 	}
 
 	const writeStream = createWriteStream(zipName);
-	const archive = archiver('zip');
+	// Use compression level 6 for better balance between speed and compression ratio (default is 9)
+	const archive = archiver('zip', {
+		zlib: { level: 6 },
+	});
 	archive.pipe(writeStream);
 
-	pathsToZip.forEach((globPath) => archive.glob(globPath, { cwd }));
+	pathsToZip.forEach((filePath) => archive.file(join(cwd, filePath), { name: filePath }));
 
 	await archive.finalize();
 };


### PR DESCRIPTION
This PR somewhat relates to https://github.com/apify/apify-cli/issues/982. The main goal is to speed up creating ZIP archives for codebases larger than 2MB when using `apify push`.

The issue was in using `archive.glob()` function within the loop. This approach forces the library to go through the entire current working directory (and its children). Using this function is also redundant because the `getActorLocalFilePaths` already uses `globby` to get all of the valid file paths to be archived.

This issue is easy to measure while working on a generic actor for `eu-monitoring-tool` which has roughly 1200 source code files and large `node_modules`.

Here is comparison of the compression times:
- without fix: 137s
- with fix: 6s

@B4nan or @vladfrangu Could you please have a look?