### PR TITLE
chore(deps): update lockfile to resolve security vulnerabilities

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,11 +1012,11 @@ __metadata:
   linkType: hard
 
 "@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  version: 5.0.1
+  resolution: "@isaacs/brace-expansion@npm:5.0.1"
   dependencies:
     "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
+  checksum: 10c0/e5d67c7bbf1f17b88132a35bc638af306d48acbb72810d48fa6e6edd8ab375854773108e8bf70f021f7ef6a8273455a6d1f0c3b5aa2aff06ce7894049ab77fb8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Updates `@isaacs/brace-expansion` from 5.0.0 to 5.0.1 to resolve [Dependabot alert #141](https://github.com/apify/apify-cli/security/dependabot/141) (high severity)
- `axios` was already at the patched version 1.13.5 ([alert #143](https://github.com/apify/apify-cli/security/dependabot/143))

Only `yarn.lock` is changed — no dependency version bumps in `package.json`.

## Test plan
- [ ] CI passes (no code changes, lockfile-only update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)