### PR TITLE
test: Fix tests after templates update

### DIFF
--- a/test/local/__fixtures__/commands/run/python/prints-error-message-on-project-with-no-detected-start.test.ts
+++ b/test/local/__fixtures__/commands/run/python/prints-error-message-on-project-with-no-detected-start.test.ts
@@ -23,12 +23,15 @@ describe('[python] prints error message on project with no detected start', () =
 	beforeAll(async () => {
 		await beforeAllCalls();
 
-		await testRunCommand(CreateCommand, { flags_template: 'python-start', args_actorName: actorName });
+		await testRunCommand(CreateCommand, {
+			flags_template: 'python-start',
+			args_actorName: actorName,
+		});
 		toggleCwdBetweenFullAndParentPath();
 
-		// Remove src/ package and requirements.txt so there is no detectable Python package structure
-		const srcFolder = joinPath('src');
-		await rm(srcFolder, { recursive: true, force: true });
+		// Remove my_actor/ package and requirements.txt so there is no detectable Python package structure
+		const myActorFolder = joinPath('my_actor');
+		await rm(myActorFolder, { recursive: true, force: true });
 
 		const requirementsTxt = joinPath('requirements.txt');
 		await rm(requirementsTxt, { force: true });

--- a/test/local/__fixtures__/commands/run/python/works-with-spaces-in-path-to-actor.test.ts
+++ b/test/local/__fixtures__/commands/run/python/works-with-spaces-in-path-to-actor.test.ts
@@ -30,11 +30,14 @@ describe('[python] spaces in path to actor', () => {
 	beforeAll(async () => {
 		await beforeAllCalls();
 
-		await testRunCommand(CreateCommand, { flags_template: 'python-start', args_actorName: actorName });
+		await testRunCommand(CreateCommand, {
+			flags_template: 'python-start',
+			args_actorName: actorName,
+		});
 
 		forceNewCwd(actorName);
 
-		await writeFile(joinCwdPath('src', 'main.py'), mainFile);
+		await writeFile(joinCwdPath('my_actor', 'main.py'), mainFile);
 
 		outputPath = joinCwdPath(getLocalKeyValueStorePath(), 'OUTPUT');
 	});

--- a/test/local/__fixtures__/python_support.test.ts
+++ b/test/local/__fixtures__/python_support.test.ts
@@ -70,7 +70,9 @@ async def main():
         await Actor.set_value('OUTPUT', ${JSON.stringify(expectedOutput)})
 `;
 
-		writeFileSync(joinPath('src', 'main.py'), actorCode, { flag: 'w' });
+		writeFileSync(joinPath('my_actor', 'main.py'), actorCode, {
+			flag: 'w',
+		});
 
 		toggleCwdBetweenFullAndParentPath();
 


### PR DESCRIPTION
Looks like a recent update to the `python-start` template broke our tests, this should fix it.
