### PR TITLE
fix: replace structuredClone with es-toolkit cloneDeep in schema paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "configparser": "~0.3.10",
         "cors": "~2.8.5",
         "detect-indent": "~7.0.1",
+        "es-toolkit": "^1.45.1",
         "escape-string-regexp": "~5.0.0",
         "execa": "^9.5.2",
         "express": "~5.2.0",

--- a/src/lib/input_schema.ts
+++ b/src/lib/input_schema.ts
@@ -1,6 +1,8 @@
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { cloneDeep } from 'es-toolkit';
+
 import { KEY_VALUE_STORE_KEYS } from '@apify/consts';
 import { validateInputSchema } from '@apify/input_schema';
 
@@ -255,7 +257,7 @@ export const getDefaultsFromInputSchema = (inputSchema: any) => {
 
 // Lots of code copied from @apify-packages/actor, this really should be moved to the shared input_schema package
 export const getAjvValidator = (inputSchema: any, ajvInstance: import('ajv').Ajv) => {
-	const copyOfSchema = structuredClone(inputSchema);
+	const copyOfSchema = cloneDeep(inputSchema);
 	copyOfSchema.required = [];
 
 	for (const [inputSchemaFieldKey, inputSchemaField] of Object.entries<any>(inputSchema.properties)) {

--- a/src/lib/schema-transforms.ts
+++ b/src/lib/schema-transforms.ts
@@ -1,10 +1,12 @@
+import { cloneDeep } from 'es-toolkit';
+
 /**
  * Transforms a JSON schema so that all properties without a `default` value are marked as required.
  * Properties that have a `default` are left optional, since Apify fills them in at runtime.
  * Recurses into nested object properties.
  */
 export function makePropertiesRequired(schema: Record<string, unknown>): Record<string, unknown> {
-	const clone = structuredClone(schema);
+	const clone = cloneDeep(schema);
 
 	if (!clone.properties || typeof clone.properties !== 'object') {
 		return clone;
@@ -35,7 +37,7 @@ export function makePropertiesRequired(schema: Record<string, unknown>): Record<
  * making every property optional at all nesting levels.
  */
 export function clearAllRequired(schema: Record<string, unknown>): Record<string, unknown> {
-	const clone = structuredClone(schema);
+	const clone = cloneDeep(schema);
 
 	delete clone.required;
 
@@ -59,7 +61,7 @@ export function clearAllRequired(schema: Record<string, unknown>): Record<string
  * to be inlined, ensuring only one exported interface per schema.
  */
 export function stripTitles(schema: Record<string, unknown>): Record<string, unknown> {
-	const clone = structuredClone(schema);
+	const clone = cloneDeep(schema);
 
 	delete clone.title;
 
@@ -137,7 +139,7 @@ export function prepareFieldsSchemaForCompilation(schema: Record<string, unknown
 		return null;
 	}
 
-	const clone = structuredClone(fields);
+	const clone = cloneDeep(fields);
 
 	if (!clone.type) {
 		clone.type = 'object';
@@ -162,7 +164,7 @@ export function prepareOutputSchemaForCompilation(schema: Record<string, unknown
 		return null;
 	}
 
-	const clonedProperties = structuredClone(properties);
+	const clonedProperties = cloneDeep(properties);
 
 	// Strip non-JSON-Schema keys (like `template`) from each property
 	for (const prop of Object.values(clonedProperties)) {
@@ -214,7 +216,7 @@ export function prepareKvsCollectionsForCompilation(
 			continue;
 		}
 
-		const clone = structuredClone(jsonSchema);
+		const clone = cloneDeep(jsonSchema);
 
 		if (!clone.type) {
 			clone.type = 'object';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,6 +2441,7 @@ __metadata:
     cors: "npm:~2.8.5"
     cross-env: "npm:^10.0.0"
     detect-indent: "npm:~7.0.1"
+    es-toolkit: "npm:^1.45.1"
     escape-string-regexp: "npm:~5.0.0"
     eslint: "npm:^9.25.1"
     eslint-config-prettier: "npm:^10.1.2"
@@ -4076,7 +4077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-toolkit@npm:^1.39.7":
+"es-toolkit@npm:^1.39.7, es-toolkit@npm:^1.45.1":
   version: 1.45.1
   resolution: "es-toolkit@npm:1.45.1"
   dependenciesMeta:


### PR DESCRIPTION
Closes #1034. Switches all structuredClone calls in schema-transforms
and input_schema to es-toolkit's cloneDeep for faster deep cloning.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
