### PR TITLE
docs: Add changelog from root in Docusaurus config (similar to apify sdks)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -39,6 +39,7 @@ module.exports = {
         [
             '@apify/docs-theme',
             {
+				changelogFromRoot: true,
                 subNavbar: {
                     title: 'Apify CLI',
                     items: [


### PR DESCRIPTION
Apify CLI: Changelog is not available: https://docs.apify.com/cli/docs/changelog
(for the sdks the changelog is present)

This was suggested by Claude. I've checked apify SDKs were this config is present