### PR TITLE
docs: add missing changelog entry for v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.1](https://github.com/apify/apify-cli/releases/tag/v1.2.1) (2026-01-06)
 
+### 🔧 CI/CD
+
+- Fix release flow permissions ([#988](https://github.com/apify/apify-cli/pull/988)) ([a9d0d90](https://github.com/apify/apify-cli/commit/a9d0d9013f42e48bfcdddbc467e995b1655cf853)) by [@vladfrangu](https://github.com/vladfrangu)
+
 ## [1.2.0](https://github.com/apify/apify-cli/releases/tag/v1.2.0) (2026-01-06)
 
 ### 🚀 Features

--- a/website/versioned_docs/version-1.4/changelog.md
+++ b/website/versioned_docs/version-1.4/changelog.md
@@ -56,6 +56,10 @@ All notable changes to this project will be documented in this file.
 
 ### [1.2.1](https://github.com/apify/apify-cli/releases/tag/v1.2.1) (2026-01-06)
 
+#### 🔧 CI/CD
+
+- Fix release flow permissions ([#988](https://github.com/apify/apify-cli/pull/988)) ([a9d0d90](https://github.com/apify/apify-cli/commit/a9d0d9013f42e48bfcdddbc467e995b1655cf853)) by [@vladfrangu](https://github.com/vladfrangu)
+
 ### [1.2.0](https://github.com/apify/apify-cli/releases/tag/v1.2.0) (2026-01-06)
 
 #### 🚀 Features


### PR DESCRIPTION
The v1.2.1 release section was empty because the only change was a CI fix that the automated changelog generator did not categorize.