### PR TITLE
docs: restore sidebar on changelog pages via displayed_sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,5 +1,5 @@
-module.exports = [
-    [
+module.exports = {
+    docs: [
         {
             type: 'doc',
             id: 'index',
@@ -41,5 +41,5 @@ module.exports = [
             id: 'troubleshooting',
             label: 'Troubleshooting',
         },
-   ],
-];
+    ],
+};

--- a/website/versioned_docs/version-0.20/changelog.md
+++ b/website/versioned_docs/version-0.20/changelog.md
@@ -1,6 +1,7 @@
 ---
 title: Changelog
 sidebar_label: Changelog
+displayed_sidebar: docs
 toc_max_heading_level: 3
 ---
 

--- a/website/versioned_docs/version-0.21/changelog.md
+++ b/website/versioned_docs/version-0.21/changelog.md
@@ -1,6 +1,7 @@
 ---
 title: Changelog
 sidebar_label: Changelog
+displayed_sidebar: docs
 toc_max_heading_level: 3
 ---
 

--- a/website/versioned_docs/version-1.1.0/changelog.md
+++ b/website/versioned_docs/version-1.1.0/changelog.md
@@ -1,6 +1,7 @@
 ---
 title: Changelog
 sidebar_label: Changelog
+displayed_sidebar: docs
 toc_max_heading_level: 3
 ---
 

--- a/website/versioned_docs/version-1.4/changelog.md
+++ b/website/versioned_docs/version-1.4/changelog.md
@@ -1,6 +1,7 @@
 ---
 title: Changelog
 sidebar_label: Changelog
+displayed_sidebar: docs
 toc_max_heading_level: 3
 ---
 

--- a/website/versioned_sidebars/version-0.20-sidebars.json
+++ b/website/versioned_sidebars/version-0.20-sidebars.json
@@ -1,5 +1,5 @@
-[
-    [
+{
+    "docs": [
         {
             "type": "doc",
             "id": "index",
@@ -31,4 +31,4 @@
             "label": "Troubleshooting"
         }
     ]
-]
+}

--- a/website/versioned_sidebars/version-0.21-sidebars.json
+++ b/website/versioned_sidebars/version-0.21-sidebars.json
@@ -1,5 +1,5 @@
-[
-    [
+{
+    "docs": [
         {
             "type": "doc",
             "id": "index",
@@ -31,4 +31,4 @@
             "label": "Troubleshooting"
         }
     ]
-]
+}

--- a/website/versioned_sidebars/version-1.1.0-sidebars.json
+++ b/website/versioned_sidebars/version-1.1.0-sidebars.json
@@ -1,5 +1,5 @@
-[
-    [
+{
+    "docs": [
         {
             "type": "doc",
             "id": "index",
@@ -42,4 +42,4 @@
             "label": "Troubleshooting"
         }
     ]
-]
+}

--- a/website/versioned_sidebars/version-1.4-sidebars.json
+++ b/website/versioned_sidebars/version-1.4-sidebars.json
@@ -1,5 +1,5 @@
-[
-    [
+{
+    "docs": [
         {
             "type": "doc",
             "id": "index",
@@ -42,4 +42,4 @@
             "label": "Troubleshooting"
         }
     ]
-]
+}


### PR DESCRIPTION
Convert sidebar config from anonymous array to named `{ docs: [...] }` format so changelog pages can reference it with `displayed_sidebar: docs` frontmatter. This keeps changelog out of the sidebar nav while still rendering the version-appropriate sidebar on each changelog page.