### PR TITLE
feat(generate-schema-types): change default output path to src/__generated__/actor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ _mytests
 .idea
 .zed
 docs/changelog.md
-.generated
+__generated__
 
 # Yarn files
 .yarn/install-state.gz

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -464,7 +464,7 @@ FLAGS
       --all-optional    Mark all properties as optional in
                         generated types.
   -o, --output=<value>  Directory where the generated files
-                        should be outputted. Defaults to src/.generated/actor/ to
+                        should be outputted. Defaults to src/__generated__/actor/ to
                         stay within the typical tsconfig rootDir.
       --strict          Whether generated interfaces should be
                         strict (no index signature [key: string]: unknown).

--- a/src/commands/actor/generate-schema-types.ts
+++ b/src/commands/actor/generate-schema-types.ts
@@ -60,9 +60,9 @@ Optionally specify custom schema path to use.`;
 		output: Flags.string({
 			char: 'o',
 			description:
-				'Directory where the generated files should be outputted. Defaults to src/.generated/actor/ to stay within the typical tsconfig rootDir.',
+				'Directory where the generated files should be outputted. Defaults to src/__generated__/actor/ to stay within the typical tsconfig rootDir.',
 			required: false,
-			default: path.join('src', '.generated', 'actor'),
+			default: path.join('src', '__generated__', 'actor'),
 		}),
 		strict: Flags.boolean({
 			description: 'Whether generated interfaces should be strict (no index signature [key: string]: unknown).',

--- a/test/local/commands/actor/generate-schema-types.test.ts
+++ b/test/local/commands/actor/generate-schema-types.test.ts
@@ -139,9 +139,9 @@ describe('apify actor generate-schema-types', () => {
 		});
 
 		expect(lastErrorMessage()).include('Generated types written to');
-		expect(lastErrorMessage()).include(join('.generated', 'actor', 'input.ts'));
+		expect(lastErrorMessage()).include(join('__generated__', 'actor', 'input.ts'));
 
-		const generatedFile = await readFile(joinPath('src', '.generated', 'actor', 'input.ts'), 'utf-8');
+		const generatedFile = await readFile(joinPath('src', '__generated__', 'actor', 'input.ts'), 'utf-8');
 		expect(generatedFile).toContain('export interface');
 	});
 


### PR DESCRIPTION
## Summary

- Changed default output directory for `actor generate-schema-types` from `src/.generated/actor/` to `src/__generated__/actor/`
- Updated `.gitignore` to ignore `__generated__` instead of `.generated`
- Updated docs, flag description, and test assertions to match the new path

## Testing

- Local unit tests updated and passing: `generate-schema-types.test.ts` verifies the new default output path `src/__generated__/actor/input.ts`
- `yarn lint && yarn format && yarn build` should be run before merge