### PR TITLE
ci: rebase before pushing release/pre-release commits

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -92,6 +92,7 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: "chore(release): Update changelog and package version [skip ci]"
+                  pull: "--rebase --autostash"
 
             - name: Get pre-release version
               id: get-pre-release-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,7 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: "chore(release): Update changelog and package version [skip ci]"
+                  pull: "--rebase --autostash"
 
     build-bundles:
         name: Build bundles


### PR DESCRIPTION
## Summary
Add `pull: '--rebase --autostash'` to the `EndBug/add-and-commit` step in the `update_changelog` jobs of both `release.yaml` and `pre_release.yaml`, so the changelog/version commits survive a concurrent ref update on master.

## Context
Same race that bit `apify/apify-client-js` in [run 25114327598](https://github.com/apify/apify-client-js/actions/runs/25114327598/job/73597522121):

```
remote rejected (cannot lock ref 'refs/heads/master': is at <new> but expected <old>)
```

The bypass logs `remote: Bypassed rule violations for refs/heads/master` — so it's not permissions, it's just non-fast-forward because something landed on master between checkout and push. `pre_release.yaml` is especially exposed since it's triggered on every push to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)