### PR TITLE
feat: send CI origin and GitHub Actions run URL on API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dependencies": {
         "@apify/actor-memory-expression": "^0.1.12",
         "@apify/actor-templates": "^0.1.5",
-        "@apify/consts": "^2.36.0",
+        "@apify/consts": "^2.53.0",
         "@apify/input_schema": "^3.17.0",
         "@apify/json_schemas": "^0.13.0",
         "@apify/utilities": "^2.18.0",

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -56,9 +56,10 @@ export const LOCAL_CONFIG_PATH = join(ACTOR_SPECIFICATION_FOLDER, LOCAL_CONFIG_N
 
 export const SUPPORTED_NODEJS_VERSION = pkg.engines.node;
 
-const githubActionsRunUrl = process.env.GITHUB_ACTIONS === 'true'
-	? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-	: undefined;
+const githubActionsRunUrl =
+	process.env.GITHUB_ACTIONS === 'true'
+		? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+		: undefined;
 
 export const APIFY_CLIENT_DEFAULT_HEADERS: Record<string, string> = {
 	'X-Apify-Request-Origin': process.env.CI === 'true' ? META_ORIGINS.CI : META_ORIGINS.CLI,

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -2,6 +2,7 @@
 
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import process from 'node:process';
 
 import { META_ORIGINS } from '@apify/consts';
 
@@ -55,7 +56,14 @@ export const LOCAL_CONFIG_PATH = join(ACTOR_SPECIFICATION_FOLDER, LOCAL_CONFIG_N
 
 export const SUPPORTED_NODEJS_VERSION = pkg.engines.node;
 
-export const APIFY_CLIENT_DEFAULT_HEADERS = { 'X-Apify-Request-Origin': META_ORIGINS.CLI };
+const githubActionsRunUrl = process.env.GITHUB_ACTIONS === 'true'
+	? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+	: undefined;
+
+export const APIFY_CLIENT_DEFAULT_HEADERS: Record<string, string> = {
+	'X-Apify-Request-Origin': process.env.CI === 'true' ? META_ORIGINS.CI : META_ORIGINS.CLI,
+	...(githubActionsRunUrl && { 'X-Apify-Github-Actions-Run-Url': githubActionsRunUrl }),
+};
 
 export const MINIMUM_SUPPORTED_PYTHON_VERSION = '3.9.0';
 

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -4,6 +4,8 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
 
+import ciInfo from 'ci-info';
+
 import { META_ORIGINS } from '@apify/consts';
 
 import pkg from '../../package.json' with { type: 'json' };
@@ -56,13 +58,12 @@ export const LOCAL_CONFIG_PATH = join(ACTOR_SPECIFICATION_FOLDER, LOCAL_CONFIG_N
 
 export const SUPPORTED_NODEJS_VERSION = pkg.engines.node;
 
-const githubActionsRunUrl =
-	process.env.GITHUB_ACTIONS === 'true'
-		? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-		: undefined;
+const githubActionsRunUrl = ciInfo.GITHUB_ACTIONS
+	? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+	: undefined;
 
 export const APIFY_CLIENT_DEFAULT_HEADERS: Record<string, string> = {
-	'X-Apify-Request-Origin': process.env.CI === 'true' ? META_ORIGINS.CI : META_ORIGINS.CLI,
+	'X-Apify-Request-Origin': ciInfo.isCI ? META_ORIGINS.CI : META_ORIGINS.CLI,
 	...(githubActionsRunUrl && { 'X-Apify-Github-Actions-Run-Url': githubActionsRunUrl }),
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/consts@npm:^2.20.0, @apify/consts@npm:^2.36.0, @apify/consts@npm:^2.50.0, @apify/consts@npm:^2.51.0, @apify/consts@npm:^2.51.1, @apify/consts@npm:^2.52.1":
+"@apify/consts@npm:^2.20.0, @apify/consts@npm:^2.50.0, @apify/consts@npm:^2.51.0, @apify/consts@npm:^2.51.1, @apify/consts@npm:^2.52.1":
   version: 2.52.1
   resolution: "@apify/consts@npm:2.52.1"
   checksum: 10c0/86d3a6b8a137bfecdb103a34b089c550a3a16d44b9b8b4373b1aec59ceacc91e444c7e121267b9d66363ce47efad650d5a50a1fd0800e0359eb1c67aec9d4b1e
+  languageName: node
+  linkType: hard
+
+"@apify/consts@npm:^2.53.0":
+  version: 2.53.0
+  resolution: "@apify/consts@npm:2.53.0"
+  checksum: 10c0/e2aa4a616d9ce60940fff8c1371cdbefb1aeb1a5408f6261c396efe6119da1c14a6ef3b5cb3f1d8a6247cf8d7c3e85bdf2a2e44302d33d2fa73f5c01d1773e30
   languageName: node
   linkType: hard
 
@@ -2202,7 +2209,7 @@ __metadata:
   dependencies:
     "@apify/actor-memory-expression": "npm:^0.1.12"
     "@apify/actor-templates": "npm:^0.1.5"
-    "@apify/consts": "npm:^2.36.0"
+    "@apify/consts": "npm:^2.53.0"
     "@apify/eslint-config": "npm:^1.0.0"
     "@apify/input_schema": "npm:^3.17.0"
     "@apify/json_schemas": "npm:^0.13.0"


### PR DESCRIPTION
Partially resolves apify/apify-core#26861

When `CI=true`, send `X-Apify-Request-Origin: CI` instead of `CLI`.
In GitHub Actions, also send `X-Apify-Github-Actions-Run-Url` so Console can link build rows back to the workflow run.

All env vars used (`CI`, `GITHUB_ACTIONS`, `GITHUB_SERVER_URL`, `GITHUB_REPOSITORY`, `GITHUB_RUN_ID`) should be set automatically by the GitHub Actions runner (no extra workflow setup needed).

I only tested it locally, not sure if I can do a full test on a real Github Actions run before merging this? 👀

<details>
<summary>Expand to see my local testing details</summary>

Tested the CLI in 3 environment setups using a local HTTP echo server (`APIFY_CLIENT_BASE_URL=http://localhost:8080`) and a single `apify api v2/users/me` request per setup to inspect what headers the CLI actually sends.

**Test 1 — Default (no CI env vars)**
```bash
APIFY_TOKEN=fake APIFY_CLIENT_BASE_URL=http://localhost:8080 \
  node dist/apify.js api v2/users/me
```
Expect: `x-apify-request-origin: 'CLI'`, no `x-apify-github-actions-run-url` ✅

**Test 2 — Plain CI**
```bash
CI=true \
  APIFY_TOKEN=fake APIFY_CLIENT_BASE_URL=http://localhost:8080 \
  node dist/apify.js api v2/users/me
```
Expect: `x-apify-request-origin: 'CI'`, no `x-apify-github-actions-run-url` ✅

**Test 3 — Full GitHub Actions environment**
```bash
CI=true GITHUB_ACTIONS=true \
  GITHUB_SERVER_URL=https://github.com \
  GITHUB_REPOSITORY=apify/apify-cli \
  GITHUB_RUN_ID=12345 \
  APIFY_TOKEN=fake APIFY_CLIENT_BASE_URL=http://localhost:8080 \
  node dist/apify.js api v2/users/me
```
Expect both headers ✅
```
x-apify-request-origin: 'CI'
x-apify-github-actions-run-url: 'https://github.com/apify/apify-cli/actions/runs/12345'
```

</details>
