### PR TITLE
ci: add --allow-same-version to pnpm version calls in release workflows

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -64,7 +64,7 @@ jobs:
               uses: apify/workflows/pnpm-install@main
 
             - name: Update package version in package.json
-              run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version
+              run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
 
             - name: Update CHANGELOG.md
               uses: DamianReeves/write-file-action@master
@@ -154,7 +154,7 @@ jobs:
                   bun build --compile --target=bun-windows-x64-baseline --outfile test index.ts
 
             - name: Set pre-release version
-              run: pnpm version ${{ needs.update_changelog.outputs.pre_release_version }} --no-git-tag-version
+              run: pnpm version ${{ needs.update_changelog.outputs.pre_release_version }} --no-git-tag-version --allow-same-version
 
             - name: Build Bundles
               run: pnpm run insert-cli-metadata && pnpm run build-bundles

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
               uses: apify/workflows/pnpm-install@main
 
             - name: Update package version in package.json
-              run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version
+              run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
 
             - name: Update README
               run: pnpm pack
@@ -182,7 +182,7 @@ jobs:
                   bun build --compile --target=bun-windows-x64-baseline --outfile test index.ts
 
             - name: Set version
-              run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version
+              run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
 
             - name: Build Bundles
               run: pnpm run insert-cli-metadata && pnpm run build-bundles


### PR DESCRIPTION
## Summary

- Adds `--allow-same-version` flag to `pnpm version` calls in `release.yaml` and `pre_release.yaml` workflows
- Prevents release failures when pnpm tries to set a version that is already set (e.g. on re-runs or when the version hasn't changed)
- No functional change to the release process itself

## Testing

- Not run — CI-only change; correctness is verified by the release workflows passing on next trigger