### PR TITLE
ci: add --no-git-checks to pnpm publish in release workflow

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -46,4 +46,4 @@ jobs:
               run: pnpm run build
 
             - name: Publish to NPM
-              run: pnpm publish --provenance --access public --tag ${{ inputs.tag }}
+              run: pnpm publish --provenance --access public --no-git-checks --tag ${{ inputs.tag }}


### PR DESCRIPTION
## Summary

- Adds `--no-git-checks` to the `pnpm publish` command in `publish_to_npm.yaml`
- Unlike `yarn npm publish`, pnpm by default fails if the git working tree is not clean; the release workflow commits changelog/version changes before publishing, so the tree is intentionally dirty at publish time
- Unblocks NPM publishing after the yarn → pnpm migration (#1068)

## Testing

- Not run locally — CI-only change; verify by triggering a beta or stable release and confirming the publish step succeeds without a "dirty working tree" error