### PR TITLE
fix: add release notes to pre-release GitHub releases and enable changelogFromRoot

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -192,6 +192,7 @@ jobs:
                   tag_name: v${{ needs.update_changelog.outputs.pre_release_version }}
                   name: ${{ needs.update_changelog.outputs.pre_release_version }}
                   target_commitish: ${{ needs.update_changelog.outputs.changelog_commitish }}
+                  body: ${{ needs.release_metadata.outputs.release_notes }}
                   prerelease: true
                   files: |
                       bundles/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,7 +381,7 @@ All notable changes to this project will be documented in this file.
   # 0.2.1 / 2018-09-17
 
 - **BREAKING CHANGES**: The local storage directories have been renamed and package.json files needs a new `start` command.
-  See [migration guide](/MIGRATIONS.md) for existing projects if you are upgrading from 0.1._ to 0.2._.
+  See [migration guide](https://github.com/apify/apify-cli/blob/master/MIGRATIONS.md) for existing projects if you are upgrading from 0.1._ to 0.2._.
 - You can specified another file that main.js for `apify run` command using npm start script.
 
   # 0.2.0 / 2018-09-12

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -39,6 +39,7 @@ module.exports = {
         [
             '@apify/docs-theme',
             {
+                changelogFromRoot: true,
                 subNavbar: {
                     title: 'Apify CLI',
                     items: [


### PR DESCRIPTION
Pre-release GitHub releases were missing release notes because the `body`
parameter was not passed to the release action. Also re-applies the lost
changelogFromRoot config (bf7e9df7) so the Docusaurus website automatically
syncs the root CHANGELOG.md to docs and versioned docs on every build.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

closes #1108 
