### PR TITLE
fix: drop only-allow preinstall, enforce pnpm via devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
 		"clean": "rimraf dist",
 		"build": "pnpm run clean && tsc && tsdown",
 		"build-bundles": "bun run scripts/build-cli-bundles.ts",
-		"preinstall": "npx only-allow pnpm",
 		"prepack": "pnpm run insert-cli-metadata && pnpm run build && pnpm run update-docs",
 		"insert-cli-metadata": "tsx scripts/insert-cli-metadata.ts",
 		"update-docs": "tsx scripts/generate-cli-docs.ts",
@@ -150,9 +149,9 @@
 	},
 	"volta": {
 		"node": "24.14.1",
-		"pnpm": "10.33.0"
+		"pnpm": "10.33.4"
 	},
-	"packageManager": "pnpm@10.33.0",
+	"packageManager": "pnpm@10.33.4",
 	"devEngines": {
 		"runtime": [
 			{
@@ -165,7 +164,12 @@
 				"version": ">= 1.2.5",
 				"onFail": "ignore"
 			}
-		]
+		],
+		"packageManager": {
+			"name": "pnpm",
+			"version": "10.33.4",
+			"onFail": "warn"
+		}
 	},
 	"lint-staged": {
 		"*": "biome format --write --no-errors-on-unmatched",


### PR DESCRIPTION
The `preinstall: npx only-allow pnpm` script ships in the published npm tarball and fires when downstream consumers install `apify-cli` via npm. In the `npm install -g apify-cli` flow the npx bootstrap of `only-allow` fails to put the binary on PATH in time:
- Linux: `sh: 1: only-allow: not found` (exit 127)
- Windows: `'only-allow' is not recognized as an internal or external command` (exit 1)

This was the user-visible symptom that first surfaced the bug (apify/apify-client-js#893).

Adds `devEngines.packageManager` (pnpm@10.33.0, `onFail: "warn"`) alongside the existing `devEngines.runtime`. `onFail: "warn"` avoids tripping CI steps that indirectly invoke npm (pnpm v10 shells to npm for `pnpm version`, `pnpm config`, etc.).

`devEngines` is only checked at the package's own repo root, never on transitive installs, so downstream consumers stay unaffected.

Mirrors apify/apify-client-js#895 + #896 and apify/apify-sdk-js#606. Patch release needed after merge.