### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,21 +45,11 @@ jobs:
                   APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
-            - name: Stage updated package(-lock).json
-              id: stage-package
-              run: |
-                  git add website/package.json website/package-lock.json pnpm-lock.yaml 2>/dev/null || true
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit the updated package(-lock).json
-              if: steps.stage-package.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: "chore: Automatic theme updating workflow [skip ci]"
+                  message: "chore: Automatic theme updating workflow [skip ci]"
+                  add: 'website/package.json website/package-lock.json pnpm-lock.yaml'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Set up GitHub Pages

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,14 +45,22 @@ jobs:
                   APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
+            - name: Stage updated package(-lock).json
+              id: stage-package
+              run: |
+                  git add website/package.json website/package-lock.json pnpm-lock.yaml 2>/dev/null || true
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit the updated package(-lock).json
-              uses: stefanzweifel/git-auto-commit-action@v7
+              if: steps.stage-package.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  commit_message: "chore: Automatic theme updating workflow [skip ci]"
-                  file_pattern: "website/package*.json pnpm-lock.yaml"
-                  commit_user_name: Apify Bot
-                  commit_user_email: my-github-actions-bot@example.org
-                  commit_author: Apify Bot <apify@apify.com>
+                  commit-message: "chore: Automatic theme updating workflow [skip ci]"
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Set up GitHub Pages
               uses: actions/configure-pages@v6

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -46,7 +46,7 @@ jobs:
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
             - name: Commit the updated package(-lock).json
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: "chore: Automatic theme updating workflow [skip ci]"
                   add: 'website/package.json website/package-lock.json pnpm-lock.yaml'

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -45,7 +45,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
             pre_release_version: ${{ steps.get-pre-release-version.outputs.pre_release_version }}
 
         steps:
@@ -76,23 +76,12 @@ jobs:
             - name: Format
               run: pnpm install && pnpm run format:fix
 
-            - name: Stage changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: "chore(release): Update changelog and package version [skip ci]"
+                  message: "chore(release): Update changelog and package version [skip ci]"
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Get pre-release version

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -45,7 +45,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
             pre_release_version: ${{ steps.get-pre-release-version.outputs.pre_release_version }}
 
         steps:
@@ -76,14 +76,24 @@ jobs:
             - name: Format
               run: pnpm install && pnpm run format:fix
 
+            - name: Stage changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: "chore(release): Update changelog and package version [skip ci]"
-                  pull: "--rebase --autostash"
+                  commit-message: "chore(release): Update changelog and package version [skip ci]"
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Get pre-release version
               id: get-pre-release-version

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -45,7 +45,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
             pre_release_version: ${{ steps.get-pre-release-version.outputs.pre_release_version }}
 
         steps:

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -78,7 +78,7 @@ jobs:
 
             - name: Commit changes
               id: commit
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: "chore(release): Update changelog and package version [skip ci]"
                   pull: '--rebase --autostash'

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -45,7 +45,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha }}
             pre_release_version: ${{ steps.get-pre-release-version.outputs.pre_release_version }}
 
         steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
 
             - name: Commit changes
               id: commit
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: "chore(release): Update changelog and package version [skip ci]"
                   pull: '--rebase --autostash'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
 
         steps:
             - name: Checkout repository
@@ -110,14 +110,24 @@ jobs:
               run: |
                   git update-index --assume-unchanged src/lib/hooks/useCLIMetadata.ts
 
+            - name: Stage changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: "chore(release): Update changelog and package version [skip ci]"
-                  pull: "--rebase --autostash"
+                  commit-message: "chore(release): Update changelog and package version [skip ci]"
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     build-bundles:
         name: Build bundles

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
 
         steps:
             - name: Checkout repository
@@ -110,23 +110,12 @@ jobs:
               run: |
                   git update-index --assume-unchanged src/lib/hooks/useCLIMetadata.ts
 
-            - name: Stage changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: "chore(release): Update changelog and package version [skip ci]"
+                  message: "chore(release): Update changelog and package version [skip ci]"
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     build-bundles:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/version_docs.yaml
+++ b/.github/workflows/version_docs.yaml
@@ -36,7 +36,7 @@ jobs:
                   pnpm --filter apify-cli-website exec -- docusaurus docs:version $MAJOR_MINOR
 
             - name: Commit and push the version snapshot
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: "docs: version docs for ${{ steps.version.outputs.version }} [docs build]"
                   pull: '--rebase --autostash'

--- a/.github/workflows/version_docs.yaml
+++ b/.github/workflows/version_docs.yaml
@@ -35,13 +35,9 @@ jobs:
                   jq --arg v "$MAJOR_MINOR" 'map(select(. != $v))' website/versions.json > website/tmp.json && mv website/tmp.json website/versions.json
                   pnpm --filter apify-cli-website exec -- docusaurus docs:version $MAJOR_MINOR
 
-            - name: Stage the version snapshot
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-
             - name: Commit and push the version snapshot
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: "docs: version docs for ${{ steps.version.outputs.version }} [docs build]"
+                  message: "docs: version docs for ${{ steps.version.outputs.version }} [docs build]"
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/version_docs.yaml
+++ b/.github/workflows/version_docs.yaml
@@ -35,10 +35,13 @@ jobs:
                   jq --arg v "$MAJOR_MINOR" 'map(select(. != $v))' website/versions.json > website/tmp.json && mv website/tmp.json website/versions.json
                   pnpm --filter apify-cli-website exec -- docusaurus docs:version $MAJOR_MINOR
 
+            - name: Stage the version snapshot
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+
             - name: Commit and push the version snapshot
-              uses: EndBug/add-and-commit@v10
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: "docs: version docs for ${{ steps.version.outputs.version }} [docs build]"
-                  pull: "--rebase --autostash"
+                  commit-message: "docs: version docs for ${{ steps.version.outputs.version }} [docs build]"
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.