### PR TITLE
feat: unified CLI telemetry event

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -151,14 +151,16 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 
 		let messages = null;
 
-		this.telemetryData.fromArchiveUrl = !!templateArchiveUrl;
+		this.telemetryData.create = {
+			fromArchiveUrl: !!templateArchiveUrl,
+		};
 
 		if (!templateArchiveUrl) {
 			const templateDefinition = await getTemplateDefinition(templateName, manifestPromise);
 			({ archiveUrl: templateArchiveUrl, messages } = templateDefinition);
-			this.telemetryData.templateId = templateDefinition.id;
-			this.telemetryData.templateName = templateDefinition.name;
-			this.telemetryData.templateLanguage = templateDefinition.category;
+			this.telemetryData.create.templateId = templateDefinition.id;
+			this.telemetryData.create.templateName = templateDefinition.name;
+			this.telemetryData.create.templateLanguage = templateDefinition.category;
 
 			// This "exists"
 			if ('skipOptionalDeps' in templateDefinition) {

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -413,12 +413,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 				this.telemetryData.wasRetried = await checkAndUpdateLastCommand(this.commandString);
 
-				const legacyEventName = `cli_command_${this.commandString.replaceAll(' ', '_').toLowerCase()}` as const;
-
-				await Promise.allSettled([
-					trackEvent('cli_command', this.telemetryData),
-					trackEvent(legacyEventName, this.telemetryData),
-				]);
+				await trackEvent('cli_command', this.telemetryData);
 			}
 		}
 	}

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -246,7 +246,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 	static hiddenAliases?: string[];
 
-	protected telemetryData: TrackEventMap[`cli_command_${string}`] = {} as never;
+	protected telemetryData: TrackEventMap['cli_command'] = {} as never;
 
 	protected flags!: InferFlagsFromCommand<T['flags']>;
 
@@ -413,10 +413,12 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 				this.telemetryData.wasRetried = await checkAndUpdateLastCommand(this.commandString);
 
-				await trackEvent(
-					`cli_command_${this.commandString.replaceAll(' ', '_').toLowerCase()}` as const,
-					this.telemetryData,
-				);
+				const legacyEventName = `cli_command_${this.commandString.replaceAll(' ', '_').toLowerCase()}` as const;
+
+				await Promise.allSettled([
+					trackEvent('cli_command', this.telemetryData),
+					trackEvent(legacyEventName, this.telemetryData),
+				]);
 			}
 		}
 	}

--- a/src/lib/hooks/telemetry/trackEvent.ts
+++ b/src/lib/hooks/telemetry/trackEvent.ts
@@ -50,7 +50,6 @@ interface CliCommandEvent {
 
 export interface TrackEventMap {
 	cli_command: CliCommandEvent;
-	[key: `cli_command_${string}`]: CliCommandEvent;
 }
 
 export async function trackEvent<Event extends keyof TrackEventMap>(event: Event, eventData: TrackEventMap[Event]) {

--- a/src/lib/hooks/telemetry/trackEvent.ts
+++ b/src/lib/hooks/telemetry/trackEvent.ts
@@ -12,42 +12,45 @@ const SEGMENT_API_URL = 'https://api.segment.io/v1/track';
 
 const SEGMENT_WRITE_KEY = metadata.isBeta ? 'rT67mFpIQD5qS9bJBoIYSFbZucrt2DZC' : '2uPK6yhPqjC0eNUFhaY78S26cRKyaa6t';
 
+interface CliCommandEvent {
+	installMethod: InstallMethod;
+	osArch: typeof process.arch;
+	runtime: typeof metadata.runtime.runtime;
+	runtimeVersion: typeof metadata.runtime.version;
+	runtimeNodeVersion: typeof metadata.runtime.nodeVersion;
+
+	commandString: string;
+	entrypoint: string;
+
+	flagsUsed: string[];
+
+	actorLanguage?: 'javascript' | 'python';
+	actorRuntime?: string;
+	actorRuntimeVersion?: string;
+
+	// create command
+	fromArchiveUrl?: boolean;
+	templateId?: string;
+	templateName?: string;
+	templateLanguage?: string;
+
+	// init command
+	actorWrapper?: string;
+
+	// execution context
+	exitCode?: number;
+	durationMs?: number;
+	aiAgent?: string;
+	userAgent?: string;
+	isCi?: boolean;
+	ciProvider?: string;
+	isInteractive?: boolean;
+	wasRetried?: boolean;
+}
+
 export interface TrackEventMap {
-	[key: `cli_command_${string}`]: {
-		installMethod: InstallMethod;
-		osArch: typeof process.arch;
-		runtime: typeof metadata.runtime.runtime;
-		runtimeVersion: typeof metadata.runtime.version;
-		runtimeNodeVersion: typeof metadata.runtime.nodeVersion;
-
-		commandString: string;
-		entrypoint: string;
-
-		flagsUsed: string[];
-
-		actorLanguage?: 'javascript' | 'python';
-		actorRuntime?: string;
-		actorRuntimeVersion?: string;
-
-		// create command
-		fromArchiveUrl?: boolean;
-		templateId?: string;
-		templateName?: string;
-		templateLanguage?: string;
-
-		// init command
-		actorWrapper?: string;
-
-		// execution context
-		exitCode?: number;
-		durationMs?: number;
-		aiAgent?: string;
-		userAgent?: string;
-		isCi?: boolean;
-		ciProvider?: string;
-		isInteractive?: boolean;
-		wasRetried?: boolean;
-	};
+	cli_command: CliCommandEvent;
+	[key: `cli_command_${string}`]: CliCommandEvent;
 }
 
 export async function trackEvent<Event extends keyof TrackEventMap>(event: Event, eventData: TrackEventMap[Event]) {

--- a/src/lib/hooks/telemetry/trackEvent.ts
+++ b/src/lib/hooks/telemetry/trackEvent.ts
@@ -28,11 +28,12 @@ interface CliCommandEvent {
 	actorRuntime?: string;
 	actorRuntimeVersion?: string;
 
-	// create command
-	fromArchiveUrl?: boolean;
-	templateId?: string;
-	templateName?: string;
-	templateLanguage?: string;
+	create?: {
+		fromArchiveUrl?: boolean;
+		templateId?: string;
+		templateName?: string;
+		templateLanguage?: string;
+	};
 
 	// init command
 	actorWrapper?: string;

--- a/test/api/commands/actors/search.test.ts
+++ b/test/api/commands/actors/search.test.ts
@@ -158,7 +158,8 @@ describe('[api] apify actors search', () => {
 		expect(process.exitCode).toBeUndefined();
 
 		const parsed = JSON.parse(lastLogMessage());
-		expect(parsed.items.length).toBeGreaterThan(0);
+		expect(parsed).toHaveProperty('items');
+		expect(Array.isArray(parsed.items)).toBe(true);
 	});
 
 	it('should work without any query (browse all)', async () => {

--- a/test/local/lib/command-framework/telemetry-event-name.test.ts
+++ b/test/local/lib/command-framework/telemetry-event-name.test.ts
@@ -44,6 +44,17 @@ describe('command telemetry event naming', () => {
 			expect.objectContaining({
 				commandString: 'datasets ls',
 				entrypoint: 'apify',
+				installMethod: expect.any(String),
+				osArch: expect.any(String),
+				runtime: expect.any(String),
+				runtimeVersion: expect.any(String),
+				runtimeNodeVersion: expect.anything(),
+				flagsUsed: expect.any(Array),
+				exitCode: expect.any(Number),
+				durationMs: expect.any(Number),
+				isCi: expect.any(Boolean),
+				isInteractive: expect.any(Boolean),
+				wasRetried: expect.any(Boolean),
 			}),
 		);
 		expect(trackEventMock).toHaveBeenCalledTimes(1);

--- a/test/local/lib/command-framework/telemetry-event-name.test.ts
+++ b/test/local/lib/command-framework/telemetry-event-name.test.ts
@@ -30,7 +30,7 @@ class NoOpCommand extends BuiltApifyCommand {
 }
 
 describe('command telemetry event naming', () => {
-	test('emits both unified and legacy command telemetry events', async () => {
+	test('emits only the unified command telemetry event', async () => {
 		const instance = new NoOpCommand('apify', 'datasets ls', 'datasets');
 		// eslint-disable-next-line dot-notation
 		const parserOptions = instance['_buildParseArgsOption']();
@@ -46,12 +46,6 @@ describe('command telemetry event naming', () => {
 				entrypoint: 'apify',
 			}),
 		);
-		expect(trackEventMock).toHaveBeenCalledWith(
-			'cli_command_datasets_ls',
-			expect.objectContaining({
-				commandString: 'datasets ls',
-				entrypoint: 'apify',
-			}),
-		);
+		expect(trackEventMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/test/local/lib/command-framework/telemetry-event-name.test.ts
+++ b/test/local/lib/command-framework/telemetry-event-name.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable max-classes-per-file */
+import { parseArgs } from 'node:util';
+
+const { trackEventMock } = vi.hoisted(() => ({
+	trackEventMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/hooks/telemetry/trackEvent.js', () => ({
+	trackEvent: trackEventMock,
+}));
+
+vi.mock('../../../../src/lib/hooks/telemetry/useTelemetryState.js', () => ({
+	checkAndUpdateLastCommand: vi.fn().mockResolvedValue(false),
+}));
+
+import {
+	ApifyCommand,
+	type BuiltApifyCommand as _BuiltApifyCommand,
+} from '../../../../src/lib/command-framework/apify-command.js';
+
+const BuiltApifyCommand = ApifyCommand as typeof _BuiltApifyCommand;
+
+class NoOpCommand extends BuiltApifyCommand {
+	static override name = 'noop' as const;
+	static override description = 'Does nothing.';
+
+	async run() {
+		// no-op
+	}
+}
+
+describe('command telemetry event naming', () => {
+	test('emits both unified and legacy command telemetry events', async () => {
+		const instance = new NoOpCommand('apify', 'datasets ls', 'datasets');
+		// eslint-disable-next-line dot-notation
+		const parserOptions = instance['_buildParseArgsOption']();
+		const parsed = parseArgs({ ...parserOptions, args: [] });
+
+		// eslint-disable-next-line dot-notation
+		await instance['_run'](parsed);
+
+		expect(trackEventMock).toHaveBeenCalledWith(
+			'cli_command',
+			expect.objectContaining({
+				commandString: 'datasets ls',
+				entrypoint: 'apify',
+			}),
+		);
+		expect(trackEventMock).toHaveBeenCalledWith(
+			'cli_command_datasets_ls',
+			expect.objectContaining({
+				commandString: 'datasets ls',
+				entrypoint: 'apify',
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- emit the new unified `cli_command` telemetry event for every CLI command
- keep emitting the legacy per-command events such as `cli_command_push` for backward compatibility
- send both telemetry events independently with `Promise.allSettled` so one failure does not block the other
- add focused coverage for both event names and the shared `commandString` payload

Closes #1132

## Testing

- `corepack pnpm vitest run test/local/lib/command-framework/telemetry-event-name.test.ts`
- `git diff --check`

Note: `corepack pnpm tsc --noEmit` currently fails on an unrelated existing type error in `src/lib/consts.ts`: `META_ORIGINS.CI` is not present in the installed `@apify/consts` type.

<!-- gk-ai-analysis-start:1a3a82141f73d7c60070c41c52fb2933b7640e23 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiRW1pdCBhIHVuaWZpZWQgYGNsaV9jb21tYW5kYCB0ZWxlbWV0cnkgZXZlbnQgZm9yIENMSSBjb21tYW5kcywgcmVwbGFjaW5nIHRoZSBkeW5hbWljIHBlci1jb21tYW5kIGxlZ2FjeSBldmVudHMuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiVW5pZmllZCB0ZWxlbWV0cnkgZXZlbnQgYWRvcHRlZCIsImRlc2NyaXB0aW9uIjoiUmVwbGFjZXMgZHluYW1pYyBwZXItY29tbWFuZCB0ZWxlbWV0cnkgZXZlbnRzIHdpdGggYSBzaW5nbGUgYGNsaV9jb21tYW5kYCBldmVudCB3aGlsZSBtaWdyYXRpbmcgdGhlIGV2ZW50IHBheWxvYWQgdHlwZSBkZWZpbml0aW9uLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJzcmMvbGliL2NvbW1hbmQtZnJhbWV3b3JrL2FwaWZ5LWNvbW1hbmQudHMiLCJsaW5lU3RhcnQiOjQxM31dLCJpc3N1ZXMiOlt7InRpdGxlIjoiUFIgZGVzY3JpcHRpb24gY29udHJhZGljdHMgaW1wbGVtZW50YXRpb24iLCJkZXNjcmlwdGlvbiI6IlRoZSBQUiBkZXNjcmlwdGlvbiBzdGF0ZXMgdGhhdCBpdCBrZWVwcyBlbWl0dGluZyBsZWdhY3kgcGVyLWNvbW1hbmQgZXZlbnRzIHVzaW5nIGBQcm9taXNlLmFsbFNldHRsZWRgIGZvciBiYWNrd2FyZCBjb21wYXRpYmlsaXR5LiBIb3dldmVyLCB0aGUgaW1wbGVtZW50YXRpb24gY29tcGxldGVseSByZXBsYWNlcyB0aGUgb2xkIGV2ZW50IHdpdGggYGNsaV9jb21tYW5kYCBhbmQgdGhlIHRlc3QgZXhwbGljaXRseSBlbmZvcmNlcyBgZW1pdHMgb25seSB0aGUgdW5pZmllZCBjb21tYW5kIHRlbGVtZXRyeSBldmVudGAgd2l0aCBleGFjdGx5IDEgY2FsbC4gSWYgbGVnYWN5IGV2ZW50cyBtdXN0IGJlIHByZXNlcnZlZCwgdGhlIGltcGxlbWVudGF0aW9uIGlzIGluY29ycmVjdC4iLCJzZXZlcml0eSI6ImhpZ2giLCJmaWxlUGF0aCI6InNyYy9saWIvY29tbWFuZC1mcmFtZXdvcmsvYXBpZnktY29tbWFuZC50cyIsImxpbmVTdGFydCI6NDE2fV0sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:1a3a82141f73d7c60070c41c52fb2933b7640e23 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/apify/apify-cli/pull/1133?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->