### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,7 +33,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Run TSC
               run: pnpm run build
@@ -57,7 +57,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Run lint checks
               run: pnpm run lint
@@ -93,7 +93,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Setup Python 3.12 (Windows)
               if: ${{ matrix.os == 'windows-2025' }}
@@ -126,7 +126,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Run API tests
               env:
@@ -161,7 +161,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
@@ -189,7 +189,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build & deploy docs
               run: pnpm --filter apify-cli-website run build
@@ -223,7 +223,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install bun
               uses: oven-sh/setup-bun@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build docs
               run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build CLI from source
               run: pnpm run build

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -22,7 +22,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/workflows/git-cliff-release@main
+            - uses: apify/actions/git-cliff-release@v1.0.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -61,7 +61,7 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Update package version in package.json
               run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
@@ -122,7 +122,7 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install bun
               uses: oven-sh/setup-bun@v2
@@ -204,7 +204,7 @@ jobs:
 
         steps:
             - name: Execute publish workflow
-              uses: apify/workflows/execute-workflow@main
+              uses: apify/actions/execute-workflow@v1.0.0
               with:
                   workflow: publish_to_npm.yaml
                   inputs: >

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -36,7 +36,7 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/workflows/git-cliff-release@main
+            - uses: apify/actions/git-cliff-release@v1.0.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -88,7 +88,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Update package version in package.json
               run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
@@ -150,7 +150,7 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install bun
               uses: oven-sh/setup-bun@v2
@@ -230,7 +230,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/workflows/execute-workflow@main
+              uses: apify/actions/execute-workflow@v1.0.0
               with:
                   workflow: publish_to_npm.yaml
                   inputs: >

--- a/.github/workflows/version_docs.yaml
+++ b/.github/workflows/version_docs.yaml
@@ -22,7 +22,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Snapshot the current version
               id: version


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.