### PR TITLE
ci: Fix docs building after the `pnpm` migration

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -49,7 +49,7 @@ jobs:
               uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: "chore: Automatic theme updating workflow [skip ci]"
-                  add: 'website/package.json website/package-lock.json pnpm-lock.yaml'
+                  add: 'website/package.json pnpm-lock.yaml'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Set up GitHub Pages


### PR DESCRIPTION
After the NPM -> PNPM migration, the `website/package-lock.json` file no longer exists. The `signed-commit` action is still trying to stage it during the docs build, and it throws an error on that.

This fixes it.