### PR TITLE
feat: enrich cli_command_push telemetry with actorId and wasCreated

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -239,6 +239,11 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 			}
 		}
 
+		this.telemetryData.push = {
+			actorId,
+			wasCreated: isActorCreatedNow,
+		};
+
 		const actorClient = apifyClient.actor(actorId);
 
 		info({ message: `Deploying Actor '${actorConfig!.name}' to Apify.` });

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -959,6 +959,8 @@ export async function internalRunCommand<Cmd extends typeof BuiltApifyCommand>(
 
 	// eslint-disable-next-line dot-notation
 	await instance['_run'](rawObject);
+
+	return instance;
 }
 
 export declare class BuiltApifyCommand extends ApifyCommand {

--- a/src/lib/hooks/telemetry/trackEvent.ts
+++ b/src/lib/hooks/telemetry/trackEvent.ts
@@ -35,6 +35,11 @@ interface CliCommandEvent {
 		templateLanguage?: string;
 	};
 
+	push?: {
+		actorId?: string;
+		wasCreated?: boolean;
+	};
+
 	// init command
 	actorWrapper?: string;
 

--- a/test/api/commands/push.test.ts
+++ b/test/api/commands/push.test.ts
@@ -89,12 +89,10 @@ describe('[api] apify push', () => {
 			};
 			writeFileSync(joinPath(LOCAL_CONFIG_PATH), JSON.stringify(actorJson, null, '\t'), { flag: 'w' });
 
-			const pushInstance = (await testRunCommand(ActorsPushCommand, {
+			const pushInstance = await testRunCommand(ActorsPushCommand, {
 				flags_noPrompt: true,
 				flags_force: true,
-			})) as unknown as {
-				telemetryData: { push?: { actorId?: string; wasCreated?: boolean } };
-			};
+			});
 
 			const userInfo = await getLocalUserInfo();
 			const { name } = actorJson;
@@ -121,7 +119,8 @@ describe('[api] apify push', () => {
 			expect((createdActorVersion as any)!.sourceFiles.sort()).to.be.eql(sourceFiles.sort());
 			expect(createdActorVersion!.sourceType).to.be.eql(ACTOR_SOURCE_TYPES.SOURCE_FILES);
 
-			expect(pushInstance.telemetryData.push).to.be.eql({
+			// eslint-disable-next-line dot-notation
+			expect(pushInstance['telemetryData'].push).to.be.eql({
 				actorId: createdActor!.id,
 				wasCreated: true,
 			});
@@ -136,13 +135,11 @@ describe('[api] apify push', () => {
 			const testActorClient = testUserClient.actor(testActor.id);
 			const actorJson = JSON.parse(readFileSync(joinPath(LOCAL_CONFIG_PATH), 'utf8'));
 
-			const pushInstance = (await testRunCommand(ActorsPushCommand, {
+			const pushInstance = await testRunCommand(ActorsPushCommand, {
 				args_actorId: testActor.id,
 				flags_noPrompt: true,
 				flags_force: true,
-			})) as unknown as {
-				telemetryData: { push?: { actorId?: string; wasCreated?: boolean } };
-			};
+			});
 
 			actorsForCleanup.add(testActor.id);
 
@@ -165,7 +162,8 @@ describe('[api] apify push', () => {
 			expect((testActorVersion as any).sourceFiles.sort()).to.be.eql(sourceFiles.sort());
 			expect(testActorVersion!.sourceType).to.be.eql(ACTOR_SOURCE_TYPES.SOURCE_FILES);
 
-			expect(pushInstance.telemetryData.push).to.be.eql({
+			// eslint-disable-next-line dot-notation
+			expect(pushInstance['telemetryData'].push).to.be.eql({
 				actorId: testActor.id,
 				wasCreated: false,
 			});

--- a/test/api/commands/push.test.ts
+++ b/test/api/commands/push.test.ts
@@ -89,7 +89,12 @@ describe('[api] apify push', () => {
 			};
 			writeFileSync(joinPath(LOCAL_CONFIG_PATH), JSON.stringify(actorJson, null, '\t'), { flag: 'w' });
 
-			await testRunCommand(ActorsPushCommand, { flags_noPrompt: true, flags_force: true });
+			const pushInstance = (await testRunCommand(ActorsPushCommand, {
+				flags_noPrompt: true,
+				flags_force: true,
+			})) as unknown as {
+				telemetryData: { push?: { actorId?: string; wasCreated?: boolean } };
+			};
 
 			const userInfo = await getLocalUserInfo();
 			const { name } = actorJson;
@@ -115,6 +120,11 @@ describe('[api] apify push', () => {
 			// TODO: vlad, fix this too
 			expect((createdActorVersion as any)!.sourceFiles.sort()).to.be.eql(sourceFiles.sort());
 			expect(createdActorVersion!.sourceType).to.be.eql(ACTOR_SOURCE_TYPES.SOURCE_FILES);
+
+			expect(pushInstance.telemetryData.push).to.be.eql({
+				actorId: createdActor!.id,
+				wasCreated: true,
+			});
 		},
 		TEST_TIMEOUT,
 	);
@@ -126,11 +136,13 @@ describe('[api] apify push', () => {
 			const testActorClient = testUserClient.actor(testActor.id);
 			const actorJson = JSON.parse(readFileSync(joinPath(LOCAL_CONFIG_PATH), 'utf8'));
 
-			await testRunCommand(ActorsPushCommand, {
+			const pushInstance = (await testRunCommand(ActorsPushCommand, {
 				args_actorId: testActor.id,
 				flags_noPrompt: true,
 				flags_force: true,
-			});
+			})) as unknown as {
+				telemetryData: { push?: { actorId?: string; wasCreated?: boolean } };
+			};
 
 			actorsForCleanup.add(testActor.id);
 
@@ -152,6 +164,11 @@ describe('[api] apify push', () => {
 			]);
 			expect((testActorVersion as any).sourceFiles.sort()).to.be.eql(sourceFiles.sort());
 			expect(testActorVersion!.sourceType).to.be.eql(ACTOR_SOURCE_TYPES.SOURCE_FILES);
+
+			expect(pushInstance.telemetryData.push).to.be.eql({
+				actorId: testActor.id,
+				wasCreated: false,
+			});
 		},
 		TEST_TIMEOUT,
 	);


### PR DESCRIPTION
## Summary

- Adds `push.actorId` and `push.wasCreated` to the unified `cli_command` telemetry payload so each `cli_command_push` event carries the Actor ID being pushed and whether the push created a new Actor vs. updated an existing one.
- After Keboola ETL refresh, this flattens to `push_actor_id` / `push_was_created` columns in Snowflake (mirroring the existing `create.*` pattern), unlocking per-surface attribution and dedup'd new-Actor counts.

Closes #1151