### PR TITLE
docs: remove empty 'not yet released' section from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 All notable changes to this project will be documented in this file.
 
 <!-- git-cliff-unreleased-start -->
-## 1.6.3 - **not yet released**
-
-
 <!-- git-cliff-unreleased-end -->
 ## [1.6.2](https://github.com/apify/apify-cli/releases/tag/v1.6.2) (2026-06-03)
 


### PR DESCRIPTION
## Summary

Follow-up to #1182. The [changelog page](https://docs.apify.com/cli/docs/changelog) shows an empty `## 1.6.3 - **not yet released**` heading at the top. This PR removes it while keeping the `git-cliff-unreleased` marker comments, which the release tooling (`apify/actions/git-cliff-release`) uses to locate and regenerate the unreleased section — HTML comments don't render on the docs page, so the result is clean.

Closes https://github.com/apify/apify-cli/issues/1186