### PR TITLE
fix(e2e): stop flaky pull test from spawning into a missing cwd

### DIFF
--- a/test/e2e/__helpers__/run-cli.ts
+++ b/test/e2e/__helpers__/run-cli.ts
@@ -1,3 +1,4 @@
+import { mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 import { execa } from 'execa';
@@ -36,6 +37,10 @@ export async function runCli(
 ): Promise<RunCliResult> {
 	const distFile = binary === 'actor' ? DistActor : DistApify;
 
+	// Spawning into a non-existent cwd fails with an opaque ENOENT before the CLI
+	// even runs, so ensure it exists first — every caller's cwd is a scratch dir.
+	if (options.cwd) await mkdir(options.cwd, { recursive: true });
+
 	const result = await execa('node', [distFile, ...args], {
 		cwd: options.cwd,
 		reject: false,
@@ -51,7 +56,9 @@ export async function runCli(
 
 	return {
 		stdout: result.stdout ?? '',
-		stderr: result.stderr ?? '',
+		// Fall back to execa's error message so spawn failures surface instead of
+		// an empty string + bare exit code 1.
+		stderr: result.stderr || result.shortMessage || '',
 		exitCode: result.exitCode ?? 1,
 	};
 }

--- a/test/e2e/__helpers__/test-actor.ts
+++ b/test/e2e/__helpers__/test-actor.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from 'node:crypto';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { runCli } from './run-cli.js';
+import { TestTmpRoot } from './tmp.js';
 
-const TestTmpRoot = fileURLToPath(new URL('../../tmp/', import.meta.url));
 const BasicActorPath = fileURLToPath(new URL('../__fixtures__/basic-actor.js', import.meta.url));
 const basicActorSource = await readFile(BasicActorPath, 'utf-8');
 
@@ -24,8 +24,6 @@ export interface TestActor {
  */
 export async function createTestActor(prefix = 'e2e'): Promise<TestActor> {
 	const name = `${prefix}-${randomBytes(6).toString('hex')}`;
-
-	await mkdir(TestTmpRoot, { recursive: true });
 
 	const result = await runCli('apify', ['create', name, '--template', 'project_empty'], {
 		cwd: TestTmpRoot,

--- a/test/e2e/__helpers__/tmp.ts
+++ b/test/e2e/__helpers__/tmp.ts
@@ -1,0 +1,4 @@
+import { fileURLToPath } from 'node:url';
+
+/** Absolute path to the repo-root `tmp/` directory used by e2e tests for scratch files. */
+export const TestTmpRoot = fileURLToPath(new URL('../../../tmp/', import.meta.url));

--- a/test/e2e/commands/create.test.ts
+++ b/test/e2e/commands/create.test.ts
@@ -1,11 +1,9 @@
 import { randomBytes } from 'node:crypto';
 import { access, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { runCli } from '../__helpers__/run-cli.js';
-
-const TestTmpRoot = fileURLToPath(new URL('../../../tmp/', import.meta.url));
+import { TestTmpRoot } from '../__helpers__/tmp.js';
 
 describe('[e2e] apify create', () => {
 	let tmpDir: string;

--- a/test/e2e/commands/init.test.ts
+++ b/test/e2e/commands/init.test.ts
@@ -1,11 +1,9 @@
 import { randomBytes } from 'node:crypto';
 import { access, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { runCli } from '../__helpers__/run-cli.js';
-
-const TestTmpRoot = fileURLToPath(new URL('../../../tmp/', import.meta.url));
+import { TestTmpRoot } from '../__helpers__/tmp.js';
 
 describe('[e2e] apify init', () => {
 	let tmpDir: string;

--- a/test/e2e/commands/runs/lifecycle.test.ts
+++ b/test/e2e/commands/runs/lifecycle.test.ts
@@ -1,15 +1,13 @@
 import { randomBytes } from 'node:crypto';
 import { access, rm } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { ApifyClient } from 'apify-client';
 
 import { getApifyClientOptions } from '../../../../src/lib/utils.js';
 import { runCli } from '../../__helpers__/run-cli.js';
 import { createTestActor, removeTestActor, type TestActor } from '../../__helpers__/test-actor.js';
-
-const TestTmpRoot = fileURLToPath(new URL('../../../../tmp/', import.meta.url));
+import { TestTmpRoot } from '../../__helpers__/tmp.js';
 
 describe('[e2e][api] runs lifecycle', () => {
 	let actor: TestActor;


### PR DESCRIPTION
The `pull — downloads actor source` test ran the CLI with `cwd: <root>/tmp/`
but never created that directory — it only existed as a side effect of
`create.test.ts`/`init.test.ts` racing their `beforeAll` mkdir first. On a
fresh checkout where it didn't exist yet, execa failed to spawn with an opaque
ENOENT (exit 1, empty stderr, ~26ms), surfacing as a flaky failure.

Fix the whole class at the right altitude instead of per-test:
- `runCli` now ensures `options.cwd` exists before spawning, so no test can
  hit the missing-cwd ENOENT again.
- `runCli` falls back to execa's `shortMessage` so any spawn-level failure
  surfaces a message instead of an empty string + bare exit code.
- Centralize the repo-root `tmp/` path in a shared `tmp.ts` helper, removing
  the inconsistent `../` depths each file derived independently.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
