### PR TITLE
fix(run): propagate the Actor's non-zero exit code

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -447,11 +447,9 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 					});
 			}
 		} catch (err) {
-			const { stderr } = err as ExecaError;
-
-			if (stderr) {
-				// TODO: maybe throw in helpful tips for debugging issues (missing scripts, trying to start a ts file with old node, etc)
-			}
+			// Propagate the child's failure so the CLI exits non-zero (e.g. for CI/shell chains).
+			// The command framework only defaults exitCode to 1; preserve the Actor's own code when present.
+			process.exitCode = (err as ExecaError).exitCode ?? 1;
 		} finally {
 			if (storedInputResults) {
 				if ('tempInputKey' in storedInputResults) {

--- a/test/local/__fixtures__/commands/run/javascript/propagates-non-zero-exit-code.test.ts
+++ b/test/local/__fixtures__/commands/run/javascript/propagates-non-zero-exit-code.test.ts
@@ -1,0 +1,49 @@
+import { copyFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { testRunCommand } from '../../../../../../src/lib/command-framework/apify-command.js';
+import { useTempPath } from '../../../../../__setup__/hooks/useTempPath.js';
+
+const actorName = 'propagates-non-zero-exit-code';
+
+const failingActorMainPath = fileURLToPath(new URL('./sources/failing-main.js', import.meta.url));
+
+const { beforeAllCalls, afterAllCalls, joinPath, toggleCwdBetweenFullAndParentPath } = useTempPath(actorName, {
+	create: true,
+	remove: true,
+	cwd: true,
+	cwdParent: true,
+});
+
+const { CreateCommand } = await import('../../../../../../src/commands/create.js');
+const { RunCommand } = await import('../../../../../../src/commands/run.js');
+
+describe('[javascript] propagates the non-zero exit code when the Actor fails', () => {
+	beforeAll(async () => {
+		await beforeAllCalls();
+
+		await testRunCommand(CreateCommand, {
+			flags_template: 'project_empty',
+			args_actorName: actorName,
+		});
+		toggleCwdBetweenFullAndParentPath();
+
+		await copyFile(failingActorMainPath, joinPath('src', 'main.js'));
+	});
+
+	afterAll(async () => {
+		await afterAllCalls();
+	});
+
+	it('should set process.exitCode to the Actor exit code', async () => {
+		// The cwd mock (useTempPath with cwd: true) replaces the `node:process` module, so the
+		// command writes process.exitCode to that mocked copy. Read it back from the same instance.
+		const { default: cliProcess } = await import('node:process');
+		cliProcess.exitCode = 0;
+
+		await testRunCommand(RunCommand, { flags_purge: true });
+
+		// Matches the `process.exit(10)` in sources/failing-main.js
+		expect(cliProcess.exitCode).toBe(10);
+	});
+});

--- a/test/local/__fixtures__/commands/run/javascript/sources/failing-main.js
+++ b/test/local/__fixtures__/commands/run/javascript/sources/failing-main.js
@@ -1,0 +1,5 @@
+// Fixture for the run exit-code propagation test.
+// See https://github.com/apify/apify-cli/issues/1180 and https://github.com/apify/apify-cli/issues/1190
+// A failing Actor: `npm start` exits with a non-zero code that the CLI must
+// propagate instead of swallowing.
+process.exit(10);


### PR DESCRIPTION
## What & why

`apify run` exited with code `0` even when the Actor failed. The `catch` block wrapping `execWithLog` in `RunCommand` read `stderr` but never set `process.exitCode` or re-threw (it held only a `TODO`), so the error was swallowed and the command framework's `process.exitCode ||= 1` never fired.

This silently broke CI and shell chains like `apify run && deploy` — a failing Actor looked successful to any caller inspecting the exit code.

Fixes #1190
Fixes #1180

## Change

In the `catch` block, forward the child's exit code:

```ts
} catch (err) {
    process.exitCode = (err as ExecaError).exitCode ?? 1;
}
```

- Preserves the Actor's **exact** exit code (e.g. `process.exit(10)` → CLI exits `10`).
- Falls back to `1` for signal-killed children, where `ExecaError.exitCode` is `undefined`.
- No change to error output — `execWithLog` already prints the message and the Actor's own stdout/stderr is inherited regardless. Only the exit code was being lost.

## Tests

Added a scenario test (`test/local/__fixtures__/commands/run/javascript/propagates-non-zero-exit-code.test.ts`) following the existing fixture convention: it scaffolds a `project_empty` Actor, copies in a failing `main.js` fixture that exits `10`, runs it, and asserts the CLI's `process.exitCode` is `10`.

Verified TDD red → green, plus end-to-end with the built CLI:

| | Actor stderr shown | Error line shown | Exit code |
|---|---|---|---|
| Before | ✅ | ✅ | `0` ❌ |
| After | ✅ | ✅ | `10` ✅ |

`lint`, `format`, `build`, and `test:local` all pass; existing `run` tests unaffected.

## Follow-up

Exit-code handling for `execWithLog` children is inconsistent across commands (`run.ts`, `create.ts`, `upgrade.ts` each differ), and `exec.ts` discards the friendly error it builds. Tracked in #1196 — out of scope for this fix.