### PR TITLE
feat(create,push): look up template by name OR aliases

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -214,7 +214,9 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 				actorId = actor.id;
 			} else {
 				const { templates } = await fetchManifest();
-				const actorTemplate = templates.find((t) => t.name === actorConfig!.template);
+				const actorTemplate = templates.find(
+					(t) => t.name === actorConfig!.template || t.aliases?.includes(actorConfig!.template as string),
+				);
 				const defaultRunOptions = (actorTemplate?.defaultRunOptions || DEFAULT_RUN_OPTIONS) as ActorDefaultRunOptions;
 				const newActor: ActorCollectionCreateOptions = {
 					name: actorConfig!.name as string,

--- a/src/lib/create-utils.ts
+++ b/src/lib/create-utils.ts
@@ -33,7 +33,9 @@ export async function getTemplateDefinition(
 	if (manifest instanceof Error) throw manifest;
 
 	if (maybeTemplateName) {
-		const templateDefinition = manifest.templates.find((t) => t.name === maybeTemplateName);
+		const templateDefinition = manifest.templates.find(
+			(t) => t.name === maybeTemplateName || t.aliases?.includes(maybeTemplateName),
+		);
 		if (!templateDefinition) {
 			throw new Error(`Could not find the selected template: ${maybeTemplateName} in the list of templates.`);
 		}


### PR DESCRIPTION
## Summary

Allow `apify create -t <id>` and `apify push` to resolve templates by their `aliases` array in addition to `name`. The `Template` type at `@apify/actor-templates` already declares `aliases?: string[]` and the manifest supports it (`python-crawlee-beautifulsoup` already uses it), but two consumer call sites in this repo were checking only `t.name === input`:

- `src/lib/create-utils.ts` — `getTemplateDefinition()` (used by `apify create -t <name>`)
- `src/commands/actors/push.ts` — Actor-create lookup when name not on platform yet (uses `actorConfig.template` from `.actor/actor.json`)

Both call sites now mirror the same predicate:

```ts
templates.find((t) => t.name === input || t.aliases?.includes(input))
```

## Why now

Coordinated with **apify/actor-templates#818** (DRAFT) which renames 19 JS/TS template `name` fields to match their `id` and adds the old name to `aliases` for backward compatibility (e.g. `id: "js-empty"` was `name: "project_empty"`, will become `name: "js-empty"` with `aliases: ["project_empty"]`). Without this PR, `apify create -t js-empty` would fail after the rename. With this PR, both `apify create -t project_empty` (existing users) and `apify create -t js-empty` (canonical) work.

## Test plan

- [ ] CI green on existing tests
- [ ] `apify create -t python-crawlee-beautifulsoup` continues to work (canonical name)
- [ ] `apify create -t getting_started_crawlee_beautifulsoup` continues to work (existing alias — proves alias path works pre-rename)
- [ ] After apify/actor-templates#818 lands: `apify create -t js-empty` works (new canonical name)
- [ ] After apify/actor-templates#818 lands: `apify create -t project_empty` continues to work (legacy alias)

Refs: apify/actor-templates#818 (DRAFT — coordinated rename PR), chocholous/apify-evals F37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)