### PR TITLE
fix: assign distinct exit codes per failure category (resolves F17 collision)

### DIFF
--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-duplicate-enum-values */
-
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
@@ -71,20 +69,34 @@ export const MINIMUM_SUPPORTED_PYTHON_VERSION = '3.9.0';
 
 export const PYTHON_VENV_PATH = '.venv';
 
+/**
+ * Exit codes emitted by `apify-cli` for distinct failure categories.
+ *
+ * Each category gets a distinct code so callers (CI scripts, agent harnesses,
+ * MCP servers, eval pipelines) can decide whether to retry, re-authenticate,
+ * fix config, etc. without parsing prose from stderr.
+ *
+ * Codes 1-5 are preserved for the categories that already had them; previously-
+ * colliding categories now use:
+ *  - `RunFailed = 6` (was 1; distinct from BuildFailed)
+ *  - `RunAborted = 7` (was 3; distinct from BuildAborted)
+ *  - `MissingAuth = 77` — BSD `sysexits.h` `EX_NOPERM` (was 1)
+ *  - `InvalidActorJson = 78` — BSD `sysexits.h` `EX_CONFIG` (was 5)
+ *
+ * Callers checking only `exitCode !== 0` are unaffected.
+ */
 export enum CommandExitCodes {
 	BuildFailed = 1,
-	RunFailed = 1,
-	MissingAuth = 1,
-
 	BuildTimedOut = 2,
-
 	BuildAborted = 3,
-	RunAborted = 3,
-
 	NoFilesToPush = 4,
-
 	InvalidInput = 5,
-	InvalidActorJson = 5,
+
+	RunFailed = 6,
+	RunAborted = 7,
+
+	MissingAuth = 77,
+	InvalidActorJson = 78,
 
 	NotFound = 250,
 	NotImplemented = 255,


### PR DESCRIPTION
## Summary

The `CommandExitCodes` enum at [`src/lib/consts.ts:74-91`](https://github.com/apify/apify-cli/blob/master/src/lib/consts.ts#L74-L91) currently collapses three semantically-distinct failure categories onto exit code `1`, two onto `3`, and two onto `5` — with an `eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values` directive admitting the collision was deliberate.

The collapse means callers (CI scripts, agent harnesses, MCP servers, eval pipelines) **cannot tell from the exit code alone what category of failure occurred**, forcing brittle stderr string-matching to answer basic questions like *"did this fail because of auth, or because of code?"* and *"should I retry, or fail fast?"*

This PR assigns distinct exit codes per category, preserving existing values where possible and using BSD `sysexits.h` conventions for the semantic ones.

## New enum

```ts
export enum CommandExitCodes {
    BuildFailed = 1,         // unchanged
    BuildTimedOut = 2,        // unchanged
    BuildAborted = 3,         // unchanged
    NoFilesToPush = 4,        // unchanged
    InvalidInput = 5,         // unchanged
    RunFailed = 6,            // was 1; distinct from BuildFailed
    RunAborted = 7,           // was 3; distinct from BuildAborted
    MissingAuth = 77,         // was 1; BSD sysexits.h EX_NOPERM
    InvalidActorJson = 78,    // was 5; BSD sysexits.h EX_CONFIG
    NotFound = 250,           // unchanged
    NotImplemented = 255,     // unchanged
}
```

The previously-required `eslint-disable @typescript-eslint/no-duplicate-enum-values` directive at the top of the file is removed (no more duplicates).

## Why these specific values

- **Preserved (1-5, 250, 255)**: any caller that already keyed on a specific code keeps the same behavior. The most common failure mode (`BuildFailed = 1`) is unchanged.
- **`RunFailed = 6`, `RunAborted = 7`**: next-free sequential codes. The "Run*" categories logically pair with "Build*" but should be distinct since they describe distinct execution phases.
- **`MissingAuth = 77`, `InvalidActorJson = 78`**: BSD `sysexits.h` `EX_NOPERM` and `EX_CONFIG` respectively. Self-documenting to anyone familiar with POSIX sysexits.

## Backwards-compatibility

- Callers that only check `exitCode !== 0` are **unaffected**.
- Callers that key on `exitCode === 1` for "BuildFailed" still get the right answer (BuildFailed is still 1).
- The only callers affected are those that specifically distinguished one of the previously-colliding categories from "code 1 means anything" — and since the codes were indistinguishable before, no such caller can exist.

## What other CLIs do

| Tool | Convention |
|---|---|
| **gh** (GitHub CLI) | `0` success, `1` generic, `2` cancelled, **`4` auth required** — the most widely-copied modern pattern |
| **AWS CLI** | `0`, `1`, `2` usage error, `130` Ctrl+C, `252` syntax error, `253` env vars, `254` service error |
| **curl** | 90+ distinct codes (one per error class) |
| **git** | `0`, `1`, `128` fatal, `129` usage error |
| **Docker** | `125` daemon, `126` not executable, `127` not found, `128+N` signal-killed |
| **npm** | documented per-error-class codes (`127`, `134` SIGABRT, `137` SIGKILL/OOM, ...) |

**Distinct error categories getting distinct exit codes is the de-facto modern standard.** The current apify-cli `MissingAuth = BuildFailed = RunFailed = 1` collapse violates the pattern that gh, AWS CLI, curl, git, Docker, and npm all follow.

## Sources

- POSIX (IEEE Std 1003.1) — Shell & Utilities §2.8.2 Exit Status: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html>
- BSD `sysexits.h` — FreeBSD `man 3 sysexits`: <https://man.freebsd.org/cgi/man.cgi?query=sysexits&sektion=3>
- Original finding write-up (with full survey of other CLIs): <https://github.com/apify/agentic-actor-dev-eval/blob/main/FINDINGS.md#f17--apify-cli-collapses-missingauth--buildfailed--runfailed-all-into-exit-code-1-preventing-programmatic-distinction-between-failure-categories>

## Test plan

- [x] `tsc --noEmit` passes cleanly
- [x] No call-site changes needed (all 11 references use enum names, not numeric values)
- [x] No existing test pins to literal exit code values (the new `propagates-non-zero-exit-code.test.ts` checks Actor-exit-code passthrough, not the CLI's enum)
- [ ] Reviewer eyeballs the new code values + decides if the `77`/`78` sysexits choice is acceptable vs. e.g. compact `6`/`7`/`8`/`9` (both options are defensible)

Filed as **draft** pending review of the code-assignment strategy.