### PR TITLE
test(push): match standby subset so undocumented API fields don't break it

### DIFF
--- a/test/api/commands/push.test.ts
+++ b/test/api/commands/push.test.ts
@@ -403,8 +403,10 @@ describe('[api] apify push', () => {
 			const createdActorClient = testUserClient.actor(actorId);
 			const createdActor = await createdActorClient.get();
 
-			// Verify all standby options are set to default values
-			expect(createdActor?.actorStandby).to.be.eql({
+			// Verify all standby options are set to default values. Match a subset so the
+			// assertion doesn't break when the API adds/renames server-owned fields it doesn't
+			// document (e.g. hostedBy -> tenancy).
+			expect(createdActor?.actorStandby).to.deep.include({
 				isEnabled: true,
 				disableStandbyFieldsOverride: false,
 				maxRequestsPerActorRun: 4,
@@ -413,7 +415,6 @@ describe('[api] apify push', () => {
 				build: 'latest',
 				memoryMbytes: 1024,
 				shouldPassActorInput: false,
-				hostedBy: 'user',
 			});
 
 			if (createdActor) await createdActorClient.delete();


### PR DESCRIPTION
The `apify push` standby test does an exact `.eql()` match on `createdActor.actorStandby` and pins `hostedBy: 'user'`. The platform has swapped that undocumented field for `tenancy: "SINGLE_TENANT"`, so the assertion now fails on every branch that hits the live API (seen on #1197 and on unrelated branches) — not flaky, a contract drift.

Neither `hostedBy` nor `tenancy` is in the [public API docs](https://docs.apify.com/api/v2/act-get); only the eight documented standby fields are. So assert just those via `deep.include` and stop pinning server-owned, undocumented fields.
