### PR TITLE
ci: bump apify/actions/pnpm-install to v1.3.1

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,7 +33,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Run TSC
               run: pnpm run build
@@ -57,7 +57,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Run lint checks
               run: pnpm run lint
@@ -93,7 +93,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Setup Python 3.12 (Windows)
               if: ${{ matrix.os == 'windows-2025' }}
@@ -126,7 +126,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Run API tests
               env:
@@ -161,7 +161,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
@@ -189,7 +189,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Build & deploy docs
               run: pnpm --filter apify-cli-website run build
@@ -223,7 +223,7 @@ jobs:
                   node-version: ${{ env.LATEST_NODE_VERSION }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Install bun
               uses: oven-sh/setup-bun@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Build docs
               run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Build CLI from source
               run: pnpm run build

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -61,7 +61,7 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Update package version in package.json
               run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
@@ -114,7 +114,7 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Install bun
               uses: oven-sh/setup-bun@v2

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -36,7 +36,7 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Update package version in package.json
               run: pnpm version ${{ needs.release_metadata.outputs.version_number }} --no-git-tag-version --allow-same-version
@@ -149,7 +149,7 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Install bun
               uses: oven-sh/setup-bun@v2

--- a/.github/workflows/version_docs.yaml
+++ b/.github/workflows/version_docs.yaml
@@ -22,7 +22,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Snapshot the current version
               id: version


### PR DESCRIPTION
Bumps the pinned `apify/actions/pnpm-install` composite action to `v1.3.1`.

That release updates `actions/cache` to `v6.1.0`, so the action runs on the Node.js 24 runtime. It clears the "Node.js 20 is deprecated" warning that shows up on every CI run. For details, see apify/actions#29.
