### PR TITLE
feat(push): validate .actor/actor.json version against MAJOR.MINOR before upload

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -42,6 +42,11 @@ const DEFAULT_RUN_OPTIONS = {
 };
 const DEFAULT_ACTOR_VERSION_NUMBER = '0.0';
 
+// Actor versions on the platform are MAJOR.MINOR (both non-negative integers).
+// TODO: import from @apify/consts / apify-shared-js once the shared regex lands
+// (see apify-shared-js #655).
+const MAJOR_MINOR_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
 // It would be better to use `version-0.0` or similar,
 // or even have no default tag, but the platform complains when
 // Actor does not have a build with a `latest` tag, so until
@@ -248,6 +253,22 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 		}
 
 		const { config: actorConfig } = actorConfigResult.unwrap();
+
+		// Client-side guard: the platform rejects `.version` values that are not
+		// exactly MAJOR.MINOR (e.g. `1.0.0` fails during the build step with a
+		// cryptic admission error). Catch it here so agents/users get a fast,
+		// actionable message pointing at the field.
+		const rawVersion = (actorConfig?.version as string | undefined) ?? this.flags.version;
+		if (rawVersion !== undefined && !MAJOR_MINOR_VERSION_REGEX.test(rawVersion)) {
+			error({
+				message:
+					`Invalid Actor version '${rawVersion}' in ${LOCAL_CONFIG_PATH}. ` +
+					`Actor versions must be MAJOR.MINOR (e.g. "0.0", "1.2") — patch versions like "1.0.0" are not supported. ` +
+					`Fix the \`version\` field in ${LOCAL_CONFIG_PATH} and retry.`,
+			});
+			process.exitCode = CommandExitCodes.InvalidActorJson;
+			return;
+		}
 
 		const userInfo = await getLocalUserInfo();
 		const isOrganizationLoggedIn = !!userInfo.organizationOwnerUserId;


### PR DESCRIPTION
## Summary

`apify push` now validates `.actor/actor.json`'s `version` field against `MAJOR.MINOR` *before* uploading source files. Bad values like `1.0.0` fail with a clear pointer to the field, exit code `InvalidActorJson` (5), and no source upload.

## Why

Today, three-part SemVer (`1.0.0`) is only rejected at build admission on the platform — after upload, after a build slot has been allocated. The failure surface is a cryptic admission error, and each retry burns a build cycle. Every agent-authored Actor hits this at least once (14/14 CLI-based eval scenarios in our observations).

This PR is the CLI-side enforcement half of the trio started by:
- apify/apify-shared-js#655 — shared regex constant
- apify/apify-docs#2662 — docs correction

Regex is inlined here with a TODO comment; a follow-up will swap in `@apify/consts` once #655 merges.

## Test plan

- [ ] Unit: `MAJOR_MINOR_VERSION_REGEX` accepts `0.0`, `1.2`, `12.34`; rejects `1.0.0`, `v1.2`, `1`, `1.`, `01.2`, empty string.
- [ ] Integration: `apify push` on a project with `"version": "1.0.0"` in `.actor/actor.json` fails before upload with exit 5 and error text mentioning the field.
- [ ] Integration: `--version 1.0.0` flag override also rejected before upload.
- [ ] Regression: default (no version set, defaults to `0.0`) still pushes.
