### PR TITLE
feat(auth): treat APIFY_TOKEN env var as authenticated in non-interactive contexts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -134,20 +134,31 @@ export const getLocalUserInfo = async (): Promise<AuthJSON> => {
 };
 
 /**
- * Gets instance of ApifyClient for user otherwise throws error
+ * Gets instance of ApifyClient for user otherwise throws error.
+ *
+ * When APIFY_TOKEN is present in the environment and no on-disk auth exists,
+ * this treats the command as authenticated with the env token — no prior
+ * `apify login` needed. Primary use case: CI and agent harnesses that ship
+ * a token via env and would otherwise hit an auth wall on the first command.
  */
 export async function getLoggedClientOrThrow() {
 	const loggedClient = await getLoggedClient();
 
 	if (!loggedClient) {
 		process.exitCode = CommandExitCodes.MissingAuth;
-		throw new Error('You are not logged in with your Apify account. Call "apify login" to fix that.');
+		const hint = process.env.APIFY_TOKEN
+			? 'APIFY_TOKEN is set in the environment but did not validate against the Apify API. Check that the token is current and has access to this workspace.'
+			: 'You are not logged in with your Apify account. Call "apify login" to fix that, or export APIFY_TOKEN in your environment (recommended for CI/agent contexts).';
+		throw new Error(hint);
 	}
 	return loggedClient;
 }
 
 const resolveToken = async (existingToken?: string): Promise<string | undefined> => {
 	if (existingToken) return existingToken;
+	// Prefer APIFY_TOKEN from env when set — matches Apify SDK behavior and lets
+	// agents/CI skip `apify login`. Falls through to keyring/auth.json when unset.
+	if (process.env.APIFY_TOKEN) return process.env.APIFY_TOKEN;
 	await ensureMigrated();
 	return getToken();
 };


### PR DESCRIPTION
## Summary

When `APIFY_TOKEN` is exported in the environment, treat commands as authenticated without requiring a prior `apify login`.

- `resolveToken()` in `src/lib/utils.ts` now returns `process.env.APIFY_TOKEN` before falling through to the keyring / `auth.json` path.
- `getLoggedClientOrThrow()` gives a differentiated error message when a token is present in env but the API rejected it (vs. no token at all).

## Why

Agent harnesses and CI runners typically ship an `APIFY_TOKEN` via env. Today, `apify push`, `apify call`, `apify info`, etc. still demand a prior `apify login`, so the first command fails with an auth prompt and agents confabulate `apify login --token $APIFY_TOKEN` invocations. This aligns the CLI with the Apify SDK's env-first behavior and removes ~5% of first-run failures we've seen across eval scenarios.

## Behavior

| Situation | Before | After |
|---|---|---|
| `apify login` run, no env var | works | works (unchanged) |
| `apify login` run + env var set | uses stored token | uses env token (env wins) |
| No login, env var set | fails: "not logged in" | works |
| No login, no env var | fails: "not logged in" | fails, hint mentions APIFY_TOKEN |
| Invalid env var | fails: "not logged in" | fails: "APIFY_TOKEN set but invalid" |

## Test plan

- [ ] Unit: `resolveToken()` returns env token when set, existing token when passed, stored token when neither.
- [ ] Integration: with `APIFY_TOKEN=<valid>` and no `auth.json`, `apify info` and `apify push` succeed.
- [ ] Integration: with `APIFY_TOKEN=<invalid>`, error message points at the env var.
- [ ] Regression: interactive `apify login` flow still works and its token is used when `APIFY_TOKEN` is unset.
