### PR TITLE
feat(create): add --list flag to print available templates

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -34,6 +34,7 @@ import {
 	getJsonFileContent,
 	isNodeVersionSupported,
 	isPythonVersionSupported,
+	printJsonToStdout,
 	setLocalConfig,
 	setLocalEnv,
 } from '../lib/utils.js';
@@ -64,6 +65,14 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 			description: 'Create without installing dependencies (faster; run install yourself later).',
 			command: 'apify create my-actor --template python-start --skip-dependency-install',
 		},
+		{
+			description: 'List available template ids (non-interactive; useful for discovery in agent contexts).',
+			command: 'apify create --list',
+		},
+		{
+			description: 'List available templates as JSON for machine parsing.',
+			command: 'apify create --list --json',
+		},
 	];
 
 	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-create';
@@ -92,7 +101,15 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 			description: 'Skip initializing a git repository in the Actor directory.',
 			required: false,
 		}),
+		list: Flags.boolean({
+			description:
+				'Print available template ids (name, language, description) instead of creating an Actor. ' +
+				'Combine with --json for machine-parseable output. Useful for non-interactive discovery.',
+			required: false,
+		}),
 	};
+
+	static override enableJsonFlag = true;
 
 	static override args = {
 		actorName: Args.string({
@@ -103,7 +120,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 
 	async run() {
 		let { actorName } = this.args;
-		const { template: templateName, skipDependencyInstall, skipGitInit } = this.flags;
+		const { template: templateName, skipDependencyInstall, skipGitInit, list, json } = this.flags;
 
 		// --template-archive-url is an internal, undocumented flag that's used
 		// for testing of templates that are not yet published in the manifest
@@ -115,6 +132,33 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 		const manifestPromise = fetchManifest().catch((err) => {
 			return new Error(`Could not fetch template list from server. Cause: ${err?.message}`);
 		});
+
+		// --list: print available templates and exit without creating anything.
+		// This provides a non-interactive discovery path (agent contexts,
+		// non-TTY shells) for template ids that would otherwise require
+		// visiting the actor-templates repo or running the interactive picker.
+		if (list) {
+			const manifest = await manifestPromise;
+			if (manifest instanceof Error) throw manifest;
+
+			if (json) {
+				printJsonToStdout({
+					templates: manifest.templates.map((t) => ({
+						id: t.name,
+						label: t.label,
+						category: t.category,
+						description: t.description,
+					})),
+				});
+				return;
+			}
+
+			for (const t of manifest.templates) {
+				// Tab-separated for easy piping: `<id>\t<language>\t<description>`
+				simpleLog({ message: `${t.name}\t${t.category}\t${t.description}`, stdout: true });
+			}
+			return;
+		}
 
 		actorName = await ensureValidActorName(actorName);
 


### PR DESCRIPTION
## Summary

Adds a `--list` flag to `apify create` so template ids can be discovered non-interactively (agent contexts, CI, non-TTY shells) without visiting the `actor-templates` GitHub repo or hitting the interactive picker. Combined with `--json`, the output is machine-parseable.

Addresses finding **F34** — no non-interactive discovery path exists today for `apify create --template <id>`, which is the only way to invoke the command from an agent.

## What changes

- `src/commands/create.ts`
  - New `list: Flags.boolean(...)` flag (no `char`; `--list` only, to avoid clashing with common short-flag conventions).
  - `static override enableJsonFlag = true` so the framework's built-in `--json` support is available on this command.
  - Two new examples in `static examples` (`apify create --list` and `apify create --list --json`).
  - New early-return branch at the top of `run()`, after the manifest fetch is kicked off but before any actor-name validation or filesystem mkdir. Reuses the same `fetchManifest()` mechanism the interactive picker already uses — no new dependency, no new HTTP client, no new fetch URL. Fields exposed: `id` (mapped from `Template.name`, matching what `--template` accepts), `label`, `category` (language), `description`.
  - Text form uses tab-separated output (`<id>\t<language>\t<description>`) so it pipes cleanly through `awk` / `cut`.

No existing behavior changes — `apify create` without `--list` is identical to before.

## Test plan

- [ ] `pnpm exec tsc --noEmit -p .` passes (verified locally).
- [ ] `pnpm exec oxlint --type-aware src/commands/create.ts` passes (verified locally).
- [ ] `apify create --list` in a non-TTY shell prints tab-separated `<id>\t<language>\t<description>` lines and exits 0 without creating a directory.
- [ ] `apify create --list --json` prints a `{"templates": [...]}` JSON object with `id`, `label`, `category`, `description` fields and exits 0.
- [ ] `apify create my-actor --template <id-from-list> --skip-dependency-install` still works (no regression on the create path).
- [ ] `apify create` with no args still triggers the interactive picker (no regression on interactive path).

## Notes for reviewers

- The choice to key the JSON on `id: t.name` (rather than `Template.id`) matches the string that `--template` accepts today; `getTemplateDefinition` looks up by `t.name === maybeTemplateName`. Exposing anything else would be confusing.
- No test file added yet — the interactive picker is not covered by unit tests either, and adding one would require mocking the manifest fetch. Happy to add a test in a follow-up if reviewers prefer.
