### PR TITLE
feat(push): accept --yes / --no-prompt / -y as aliases for --force

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -181,6 +181,25 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 			default: false,
 			required: false,
 		}),
+		// Aliases for --force. Agents frequently confabulate npm/apt-style skip-confirmation flags
+		// (--yes, -y, --no-prompt, --no-interactive) instead of Apify's --force. Accept them all so
+		// the command does what the user obviously meant rather than failing with "Unknown flag".
+		yes: Flags.boolean({
+			char: 'y',
+			description: 'Alias for --force. Accepted so npm/apt-style `--yes` / `-y` work with `apify push`.',
+			default: false,
+			required: false,
+		}),
+		'no-prompt': Flags.boolean({
+			description: 'Alias for --force. Accepted so `--no-prompt` works with `apify push`.',
+			default: false,
+			required: false,
+		}),
+		'no-interactive': Flags.boolean({
+			description: 'Alias for --force. Accepted so `--no-interactive` works with `apify push`.',
+			default: false,
+			required: false,
+		}),
 		dir: Flags.string({
 			description: 'Directory where the Actor is located.',
 			required: false,
@@ -346,8 +365,12 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 				}, 0);
 				const actorModifiedMs = client?.modifiedAt.valueOf();
 
+				// npm/apt-style skip-confirmation flags are treated as aliases for --force.
+				const skipStalenessCheck =
+					this.flags.force || this.flags.yes || this.flags.noPrompt || this.flags.noInteractive;
+
 				if (
-					!this.flags.force &&
+					!skipStalenessCheck &&
 					actorModifiedMs &&
 					mostRecentModifiedFileMs < actorModifiedMs &&
 					(actorConfig?.name || forceActorId)


### PR DESCRIPTION
## Summary

`apify push` already has `--force` to override the "your local files are older than the remote" check. But agents (and users coming from npm / apt / yum / most CLI ecosystems) reflexively type `--yes`, `-y`, `--no-prompt`, or `--no-interactive` instead — and today those all fail with "Unknown flag". That failure is misleading: `--force` exists and is exactly what they meant. This PR accepts all four as aliases for `--force`, additive and behavior-preserving.

Cross-reference: finding F25 in the agentic-actor-development sweep.

## What changes

In `src/commands/actors/push.ts`:

- Add three new top-level boolean flags: `yes` (with `char: 'y'`), `no-prompt`, and `no-interactive`. Each is documented as an alias for `--force`.
- In `run()`, OR them together with `this.flags.force` when deciding whether to skip the "remote is newer than local" staleness check.
- No changes to `--force` itself. Users who already pass `--force` see identical behavior.

### Why not `aliases: [...]` on `--force`?

The command-framework's `Flags.boolean({ aliases: [...] })` does work — but only for names that don't start with `no-`. The framework configures node's `parseArgs` with `allowNegative: true`, and node then consumes `--no-prompt` as negation of a hypothetical `prompt` flag before checking whether `no-prompt` was registered as its own option. Verified with a small parseArgs smoke script. The command-framework's own convention for `--no-*` flags is to declare them as top-level keys literally starting with `no-` (the framework strips the prefix at registration time and re-inverts the value on read), so this PR follows that path.

`--yes` could have been added as an `aliases: ['yes']` entry on `--force`, but then it couldn't get its own `char: 'y'` short form. Keeping all four as sibling top-level flags is symmetric and keeps `-y` available.

## Test plan

- [ ] `apify push --yes` behaves the same as `apify push --force` (skips the "remote is newer" check).
- [ ] `apify push -y` behaves the same as `apify push --force`.
- [ ] `apify push --no-prompt` behaves the same as `apify push --force`.
- [ ] `apify push --no-interactive` behaves the same as `apify push --force`.
- [ ] `apify push --force` continues to work unchanged.
- [ ] `apify push --help` renders the new flags in the help output.
- [ ] `tsc --noEmit` and `oxlint --type-aware` clean on the changed file (verified locally).
