### PR TITLE
feat(push): warn on npm --omit=dev + tsc build script (typescript compilation trap)

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
 
@@ -119,6 +119,70 @@ export function resolvePushOutcome(buildStatus: string): PushOutcome {
 				errorMessage: `Build finished with unexpected status "${buildStatus}"`,
 			};
 	}
+}
+
+// Best-effort pre-upload check for a common TypeScript packaging trap: a
+// single-stage Dockerfile that runs `npm install --omit=dev` (or
+// `--production`) and a package.json build script that shells out to `tsc`,
+// while `typescript` sits in devDependencies. The platform-side Docker build
+// will fail because tsc is dropped before `npm run build` runs. This is a
+// warning only — the source of truth is the platform build.
+export function detectOmitDevTscTrap(cwd: string): string | null {
+	const dockerfileCandidates = [join(cwd, '.actor', 'Dockerfile'), join(cwd, 'Dockerfile')];
+	let dockerfileContent: string | null = null;
+	for (const candidate of dockerfileCandidates) {
+		if (existsSync(candidate)) {
+			try {
+				dockerfileContent = readFileSync(candidate, 'utf8');
+				break;
+			} catch {
+				// unreadable — ignore, this check is best-effort
+			}
+		}
+	}
+	if (!dockerfileContent) return null;
+
+	// Match `npm ci|install|i` followed anywhere on the same command by
+	// `--omit=dev` or `--production` (with optional `=true`). Line-based to
+	// avoid crossing RUN boundaries. Backslash continuations are handled by
+	// checking each logical `\` -joined chunk.
+	const commandChunks = dockerfileContent
+		.replace(/\\\n/g, ' ') // fold backslash-continuations onto one line
+		.split('\n');
+	const dropsDevDeps = commandChunks.some(
+		(line) => /\bnpm\s+(ci|install|i)\b/.test(line) && /(--omit[= ]dev|--production(?:[= ]true)?)/.test(line),
+	);
+	if (!dropsDevDeps) return null;
+
+	// package.json lookup
+	const packageJsonPath = join(cwd, 'package.json');
+	if (!existsSync(packageJsonPath)) return null;
+	let pkg: {
+		scripts?: Record<string, string>;
+		dependencies?: Record<string, string>;
+		devDependencies?: Record<string, string>;
+	};
+	try {
+		pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+	} catch {
+		// malformed package.json — not our problem to diagnose here
+		return null;
+	}
+
+	const buildScript = pkg.scripts?.build ?? '';
+	// Match a standalone `tsc` invocation (not `tsc-alias`, `tsconfig`, etc.).
+	const buildUsesTsc = /(^|[\s&|;])tsc($|[\s&|;])/.test(buildScript);
+	if (!buildUsesTsc) return null;
+
+	const tsInDev = !!pkg.devDependencies?.typescript;
+	const tsInProd = !!pkg.dependencies?.typescript;
+	if (!tsInDev || tsInProd) return null;
+
+	return [
+		'npm --omit=dev drops typescript (in devDependencies); the build stage needs tsc.',
+		'Either (a) use a multi-stage Dockerfile where the build stage installs devDeps then',
+		'copies dist/ to the runtime stage, or (b) drop --omit=dev.',
+	].join('\n  ');
 }
 
 export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
@@ -325,6 +389,14 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 		const actorClient = apifyClient.actor(actorId);
 
 		info({ message: `Deploying Actor '${actorConfig!.name}' to Apify.` });
+
+		// Best-effort local sanity check: warn (never block) if the Dockerfile
+		// drops devDependencies before running a tsc-based build script. See
+		// detectOmitDevTscTrap for the full heuristic.
+		const trapWarning = detectOmitDevTscTrap(cwd);
+		if (trapWarning) {
+			warning({ message: trapWarning });
+		}
 
 		const filesSize = await sumFilesSizeInBytes(filePathsToPush, cwd);
 

--- a/test/local/commands/push.test.ts
+++ b/test/local/commands/push.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { ACTOR_JOB_STATUSES } from '@apify/consts';
 
-import { resolvePushOutcome } from '../../../src/commands/actors/push.js';
+import { detectOmitDevTscTrap, resolvePushOutcome } from '../../../src/commands/actors/push.js';
 import { CommandExitCodes } from '../../../src/lib/consts.js';
 
 describe('resolvePushOutcome', () => {
@@ -35,5 +39,113 @@ describe('resolvePushOutcome', () => {
 		expect(resolvePushOutcome(ACTOR_JOB_STATUSES.TIMING_OUT).errorMessage).toBe('Build is timing out');
 		expect(resolvePushOutcome(ACTOR_JOB_STATUSES.TIMED_OUT).errorMessage).toBe('Build timed out');
 		expect(resolvePushOutcome(ACTOR_JOB_STATUSES.FAILED).errorMessage).toBe('Build failed');
+	});
+});
+
+describe('detectOmitDevTscTrap', () => {
+	function makeProject(files: Record<string, string>): string {
+		const root = mkdtempSync(join(tmpdir(), 'apify-cli-push-trap-'));
+		for (const [rel, content] of Object.entries(files)) {
+			const abs = join(root, rel);
+			mkdirSync(join(abs, '..'), { recursive: true });
+			writeFileSync(abs, content);
+		}
+		return root;
+	}
+
+	test('warns when Dockerfile omits dev deps and build uses tsc with typescript only in devDependencies', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install --omit=dev\nCMD ["node", "dist/main.js"]\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).toMatch(/npm --omit=dev/);
+	});
+
+	test('warns for .actor/Dockerfile as well', () => {
+		const root = makeProject({
+			'.actor/Dockerfile': 'FROM node:20\nRUN npm ci --omit=dev\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc -p tsconfig.build.json' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).not.toBeNull();
+	});
+
+	test('also recognizes --production as dev-drop flag', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install --production\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).not.toBeNull();
+	});
+
+	test('does not warn when typescript is also in dependencies (already available at build time)', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install --omit=dev\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc' },
+				dependencies: { typescript: '^5.0.0' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).toBeNull();
+	});
+
+	test('does not warn when Dockerfile does not drop dev deps', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).toBeNull();
+	});
+
+	test('does not warn when build script does not use tsc', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install --omit=dev\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsdown' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).toBeNull();
+	});
+
+	test('does not confuse tsc-alias / tsconfig-paths for a tsc invocation', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install --omit=dev\n',
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc-alias' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).toBeNull();
+	});
+
+	test('returns null when there is no Dockerfile', () => {
+		const root = makeProject({
+			'package.json': JSON.stringify({
+				scripts: { build: 'tsc' },
+				devDependencies: { typescript: '^5.0.0' },
+			}),
+		});
+		expect(detectOmitDevTscTrap(root)).toBeNull();
+	});
+
+	test('returns null when package.json is missing or malformed', () => {
+		const root = makeProject({
+			Dockerfile: 'FROM node:20\nRUN npm install --omit=dev\n',
+			'package.json': '{ this is not valid json',
+		});
+		expect(detectOmitDevTscTrap(root)).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Add a pre-upload sanity check in `apify push` that warns (never blocks) when the project's Dockerfile drops devDependencies before running a `tsc`-based build. This is one of the most common "worked locally, fails on the platform" traps for TypeScript Actors, and the platform build error (`tsc: not found`) gives no hint that the fix is on the Dockerfile side.

## What changes

- `src/commands/actors/push.ts`
  - New exported helper `detectOmitDevTscTrap(cwd)` — pure function, returns a warning message or `null`. Handles both `.actor/Dockerfile` and `./Dockerfile`, folds backslash line-continuations, matches both `--omit=dev` and `--production`, and refuses to fire on `tsc-alias`, `tsdown`, or when `typescript` is duplicated into `dependencies`.
  - The `run()` handler calls it right after the "Deploying Actor" log line and emits the message through the existing yellow `warning()` output helper (goes to stderr). Push proceeds either way.
- `test/local/commands/push.test.ts`
  - Nine unit cases covering positive matches and the four falsy-signal guards (typescript in both, no `--omit`, non-`tsc` build, missing Dockerfile / malformed package.json).

Design notes:

- Warning only, never a validation error — the platform's Docker build is still authoritative, and we don't want a heuristic to block anyone.
- All file access is guarded with `existsSync` + `try/catch` so a missing or unreadable Dockerfile / package.json silently no-ops.
- The `tsc` regex is a word-boundary-ish match `(^|[\s&|;])tsc($|[\s&|;])` so we don't false-positive on `tsc-alias`, `tsconfig-paths`, `tsdown`, etc.

## Test plan

- [x] `oxlint --type-aware` clean on `push.ts` and `push.test.ts`
- [x] `tsc --noEmit -p .` clean
- [x] Standalone repro of the 9 test cases (positive/negative matrix) all pass
- [ ] Manual: run `apify push` in a project with a single-stage `--omit=dev` Dockerfile + `tsc` build script and confirm the yellow warning appears before the upload phase
- [ ] Manual: run `apify push` in a well-configured multi-stage project and confirm no warning fires

## Related — coordinated remediation stack

Four defense layers, each covering a different failure mode:

- [`apify/actor-templates`](https://github.com/apify/actor-templates) — ts-* Dockerfiles ship a multi-stage build (already in master via [#592](https://github.com/apify/actor-templates/pull/592), Dec 2025). Users of `apify create -t ts-*` cannot hit the trap.
- **This PR** — `apify push` preflight warning when a Dockerfile has `--omit=dev` before `npm run build` that invokes `tsc`.
- [`apify/apify-cli#1261`](https://github.com/apify/apify-cli/pull/1261) — `apify create` forces `--include=dev` + `NODE_ENV=development` on the post-scaffold install, so `apify run` works locally.
- [`apify/apify-docs#2716`](https://github.com/apify/apify-docs/pull/2716) — docs callout on the Source-code page for the direct-`docker build` / search-fallback case.

---

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._