### PR TITLE
fix(run): clarify purge info + hint --input/--input-file on stored-input validation failure

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -271,7 +271,9 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 
 			if (crawleeVersion.isNone()) {
 				await Promise.all([purgeDefaultQueue(), purgeDefaultKeyValueStore(resolvedInputKey), purgeDefaultDataset()]);
-				info({ message: 'All default local stores were purged.' });
+				info({
+					message: `All default local stores were purged (the "${resolvedInputKey}" key-value store entry was preserved; pass --no-purge to keep everything).`,
+				});
 			}
 		}
 
@@ -546,7 +548,9 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 				if (inputOverride) {
 					errorHeader = `The input provided through the ${inputOverride.source} file is invalid. Please fix the following errors:\n`;
 				} else {
-					errorHeader = 'The input in your storage is invalid. Please fix the following errors:\n';
+					errorHeader =
+						'The input in your storage is invalid. Please fix the following errors' +
+						' (or override the stored input for this run with `--input \'{"...":"..."}\'` or `--input-file ./input.json`):\n';
 				}
 				break;
 		}


### PR DESCRIPTION
## Summary

Two small wording tweaks in `apify run` so users (and, in particular, agents driving the CLI) don't waste turns re-running with different flags trying to figure out what happened.

## Motivation

We repeatedly observed the following confusing flow when driving `apify run` in a project whose stored `INPUT.json` is missing a required field:

```
$ apify run
Info: All default local stores were purged.
Error: The input in your storage is invalid. Please fix the following errors:
  - Field productUrl is required
```

Two things are misleading here:

1. **The purge info message overstates what happened.** `purgeDefaultKeyValueStore` already preserves the resolved input key (see the `preserveRegExps` branch in `src/lib/utils.ts`), so `INPUT.json` is NOT wiped by `--purge`. The current message reads as if it was, which pushes people to try `--no-purge` next (which yields the same validation error, because the file was never gone in the first place).

2. **The validation error offers no way out.** Once the user has established the stored input is invalid, the natural next question is "how do I run it once with the missing field filled in?". The CLI does support this via `--input '{...}'` and `--input-file ./input.json`, and `validateAndStoreInput` writes the override to a temp key so the on-disk `INPUT.json` is not modified — but nothing in the error message points there.

## Change

- Clarify the purge info line to say the input key was preserved and point at `--no-purge` for full preservation.
- Extend the "The input in your storage is invalid" error header to mention `--input` and `--input-file` as a way to override the stored input for this run.

Behavior is otherwise unchanged — messaging only, no logic edits.

## Evidence (before)

```
Info: All default local stores were purged.
Error: The input in your storage is invalid. Please fix the following errors:
  - Field productUrl is required
```

## Evidence (after)

```
Info: All default local stores were purged (the "INPUT" key-value store entry was preserved; pass --no-purge to keep everything).
Error: The input in your storage is invalid. Please fix the following errors (or override the stored input for this run with `--input '{"...":"..."}'` or `--input-file ./input.json`):
  - Field productUrl is required
```

## Test plan

- [ ] `apify run` on a project with a valid `INPUT.json` — no message change (both lines only appear on the failing path).
- [ ] `apify run` on a project with an INPUT missing a required field — updated purge line + updated error header appear; INPUT.json on disk is untouched (already true today, this PR just tells the user that).
- [ ] `apify run --input '{"productUrl":"https://example.com"}'` on the same project — override path still used; error header (if it were to appear) is the existing `--input` variant, not the storage variant.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._