### PR TITLE
feat(actors): add `apify actors exists`, `ls --name-only`, and improve push name-collision UX

### DIFF
--- a/src/commands/actors/_index.ts
+++ b/src/commands/actors/_index.ts
@@ -1,6 +1,7 @@
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { ActorsBuildCommand } from './build.js';
 import { ActorsCallCommand } from './call.js';
+import { ActorsExistsCommand } from './exists.js';
 import { ActorsInfoCommand } from './info.js';
 import { ActorsLsCommand } from './ls.js';
 import { ActorsPullCommand } from './pull.js';
@@ -29,6 +30,7 @@ export class ActorsIndexCommand extends ApifyCommand<typeof ActorsIndexCommand> 
 		ActorsPullCommand,
 		ActorsLsCommand,
 		ActorsInfoCommand,
+		ActorsExistsCommand,
 		ActorsCallCommand,
 		ActorsBuildCommand,
 	];

--- a/src/commands/actors/exists.ts
+++ b/src/commands/actors/exists.ts
@@ -1,0 +1,105 @@
+import process from 'node:process';
+
+import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
+import { Args } from '../../lib/command-framework/args.js';
+import { Flags } from '../../lib/command-framework/flags.js';
+import { info, simpleLog } from '../../lib/outputs.js';
+import { getLoggedClientOrThrow, getLocalUserInfo, printJsonToStdout } from '../../lib/utils.js';
+
+// Exit code 1 = the name is available (not taken). Chosen so that a pure
+// `apify actors exists foo && echo taken || echo free` shell idiom works
+// without extra flags, matching the convention of tools like `test`, `grep`,
+// and `gh repo view`.
+const NOT_FOUND_EXIT_CODE = 1;
+
+export class ActorsExistsCommand extends ApifyCommand<typeof ActorsExistsCommand> {
+	static override name = 'exists' as const;
+
+	static override description =
+		`Check whether an Actor exists on the Apify platform.\n` +
+		`Exits 0 if the Actor exists (name is taken), 1 if not.\n` +
+		`Intended for scripting a pre-flight check before 'apify push' so callers can pick a free name without triggering a duplicate-name error.`;
+
+	static override examples = [
+		{
+			description: 'Check whether a name in your own namespace is available.',
+			command: 'apify actors exists my-crawler',
+		},
+		{
+			description: 'Check a fully qualified Actor identifier.',
+			command: 'apify actors exists apify/hello-world',
+		},
+		{
+			description: 'Use in a shell script to avoid a name collision.',
+			command: 'apify actors exists my-crawler || apify push',
+		},
+	];
+
+	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-actors-exists';
+
+	static override enableJsonFlag = true;
+
+	static override args = {
+		actorId: Args.string({
+			description:
+				'Actor name (short "my-crawler" — resolved in the logged-in user\'s namespace) ' +
+				'or fully qualified "<username>/<name>" identifier, or Actor ID.',
+			required: true,
+		}),
+	};
+
+	static override flags = {
+		quiet: Flags.boolean({
+			char: 'q',
+			description: 'Suppress the human-readable message; only the exit code is meaningful.',
+			default: false,
+		}),
+	};
+
+	async run() {
+		const { actorId } = this.args;
+		const { quiet, json } = this.flags;
+
+		const apifyClient = await getLoggedClientOrThrow();
+
+		// Resolve short names ("my-crawler") to "<username>/my-crawler" so callers
+		// can query their own namespace without repeating their username.
+		let lookupId = actorId;
+		if (!actorId.includes('/') && !/^[A-Za-z0-9]{17}$/.test(actorId)) {
+			const userInfo = await getLocalUserInfo();
+			const usernameOrId = userInfo.username || userInfo.id;
+			lookupId = `${usernameOrId}/${actorId}`;
+		}
+
+		const actor = await apifyClient.actor(lookupId).get();
+
+		if (json) {
+			printJsonToStdout({
+				exists: Boolean(actor),
+				query: actorId,
+				resolvedId: lookupId,
+				actor: actor ? { id: actor.id, name: actor.name, username: actor.username, title: actor.title } : null,
+			});
+			if (!actor) process.exitCode = NOT_FOUND_EXIT_CODE;
+			return;
+		}
+
+		if (actor) {
+			if (!quiet) {
+				info({
+					stdout: true,
+					message: `Actor "${actor.username}/${actor.name}" exists (id=${actor.id}).`,
+				});
+			}
+			return;
+		}
+
+		process.exitCode = NOT_FOUND_EXIT_CODE;
+		if (!quiet) {
+			simpleLog({
+				stdout: true,
+				message: `Actor "${lookupId}" does not exist.`,
+			});
+		}
+	}
+}

--- a/src/commands/actors/ls.ts
+++ b/src/commands/actors/ls.ts
@@ -133,12 +133,17 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 			description: 'Sort Actors in descending order.',
 			default: false,
 		}),
+		'name-only': Flags.boolean({
+			description:
+				'Print one "<username>/<name>" per line and skip the table/hydration. Useful for scripting (e.g. detecting name collisions before `apify push`).',
+			default: false,
+		}),
 	};
 
 	static override enableJsonFlag = true;
 
 	async run() {
-		const { desc, limit, offset, my, json } = this.flags;
+		const { desc, limit, offset, my, json, nameOnly } = this.flags;
 
 		const client = await getLoggedClientOrThrow();
 
@@ -150,11 +155,27 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 				return;
 			}
 
+			if (nameOnly) {
+				// Nothing to print; exit cleanly so scripts can rely on empty output.
+				return;
+			}
+
 			info({
 				message: my ? "You don't have any Actors yet!" : 'There are no recent Actors used by you.',
 				stdout: true,
 			});
 
+			return;
+		}
+
+		// --name-only short-circuits before the per-actor hydration Promise.all,
+		// which fetches an extra Actor + runs list for every row. That work is
+		// wasted when a caller only needs the identifiers.
+		if (nameOnly && !json) {
+			simpleLog({
+				stdout: true,
+				message: rawActorList.items.map((a) => `${a.username}/${a.name}`).join('\n'),
+			});
 			return;
 		}
 

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -285,6 +285,15 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 			actor = (await apifyClient.actor(`${usernameOrId}/${actorConfig!.name}`).get())!;
 			if (actor) {
 				actorId = actor.id;
+				// Previously this branch silently reused the existing Actor, which
+				// looked identical in the CLI output to creating a new one. When a
+				// user (or an agent) intended to create a fresh Actor and forgot
+				// they had already used that name, their prior version would be
+				// overwritten without any visible signal. Log it explicitly so the
+				// destination is obvious in the transcript.
+				info({
+					message: `Updating existing Actor ${usernameOrId}/${actorConfig!.name} (id=${actor.id}).`,
+				});
 			} else {
 				const { templates } = await fetchManifest();
 				const actorTemplate = templates.find((t) => t.name === actorConfig!.template);
@@ -310,7 +319,32 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 					newActor.actorStandby = { isEnabled: true };
 				}
 
-				actor = await apifyClient.actors().create(newActor);
+				try {
+					actor = await apifyClient.actors().create(newActor);
+				} catch (err) {
+					// The pre-flight `apify.actor("<user>/<name>").get()` above misses
+					// two cases: (1) the name is reserved / conflicts with a global
+					// Actor (e.g. `apify/hello-world`); (2) a race where a parallel
+					// process claimed the name between the `.get()` and the create.
+					// The raw API error is opaque ("Actor name is already used"), so
+					// rewrite it with actionable next steps.
+					const message = (err as Error)?.message ?? String(err);
+					const looksLikeNameConflict =
+						/already\s+us(ed|es)/i.test(message) ||
+						/name\s+is\s+not\s+available/i.test(message) ||
+						/duplicate/i.test(message);
+					if (looksLikeNameConflict) {
+						throw new Error(
+							`Cannot create Actor "${actorConfig!.name}": the name is unavailable on the Apify platform (${message}).\n` +
+								`Next steps:\n` +
+								`  - Rename the Actor: edit the "name" field in ${LOCAL_CONFIG_PATH} and run 'apify push' again.\n` +
+								`  - Push to an existing Actor: 'apify push <actor-id-or-username/name>'.\n` +
+								`  - List names you already own: 'apify actors ls --my --name-only'.\n` +
+								`  - Check whether a name is free: 'apify actors exists <name>'.`,
+						);
+					}
+					throw err;
+				}
 				actorId = actor.id;
 				isActorCreatedNow = true;
 				info({ message: `Created Actor with name ${actorConfig!.name} on Apify.` });


### PR DESCRIPTION
## Summary

Adds two small, scripting-friendly primitives for asking "is this Actor name available?" and improves the CLI transcript when `apify push` reuses an existing Actor or fails on a name conflict.

- **New:** `apify actors exists <name>` — exits `0` if the Actor exists, `1` if not. Accepts a short name (resolved in the logged-in user's namespace), a fully qualified `<username>/<name>`, or an Actor ID. `--json` emits `{ exists, query, resolvedId, actor }`.
- **New flag:** `apify actors ls --name-only` — prints one `<username>/<name>` per line and short-circuits before the per-row hydration `Promise.all` (which normally fetches an extra `.get()` + runs list per row for the table). Composes with `--my`, `--limit`, `--offset`, `--desc`.
- **`apify push` transcript when the Actor already exists in your namespace:** previously silent — now emits `Info: Updating existing Actor <username>/<name> (id=…).`
- **`apify push` error when `POST /v2/acts` fails on a duplicate/reserved name:** the raw API message (e.g. `Actor name is already used`) is rewritten with actionable next steps.

## Motivation

`apify actors ls --my` and `apify push` are the entry points people reach for when scripting Actor management (CI pipelines, template scaffolders, agent-driven tooling). Two workflows are awkward today:

### 1. "Is this name free?" has no first-class answer

`apify actors ls --my` prints a decorated table (Runs / Last run / Build columns) that is hard to grep and, per row, does an extra `apifyClient.actor(id).get()` + runs list fetch just for the display. Callers scripting a collision check end up reaching for the raw REST API instead — e.g.

```bash
curl -sH "Authorization: Bearer $APIFY_TOKEN" \
  'https://api.apify.com/v2/acts?my=1&limit=100' \
  | jq -r '.data.items[].name'
```

With this PR:

```bash
apify actors ls --my --name-only
# apify-user/my-crawler
# apify-user/hello-world

apify actors exists my-crawler && echo taken || echo free
```

And the canonical scripted "create only if free" pattern becomes:

```bash
apify actors exists my-crawler || apify push
```

### 2. `apify push` is silent when it reuses an existing Actor

The relevant branch in `src/commands/actors/push.ts` today (before this PR) is:

```ts
actor = (await apifyClient.actor(`${usernameOrId}/${actorConfig!.name}`).get())!;
if (actor) {
    actorId = actor.id;
    // <-- no log emitted; identical-looking to the "create" branch below
} else {
    ...
    actor = await apifyClient.actors().create(newActor);
    info({ message: `Created Actor with name ${actorConfig!.name} on Apify.` });
}
```

If a user (or an automated pipeline) forgets they have already used a given name in their namespace, the push silently overwrites the previously deployed Actor with no visible signal. After this PR the transcript shows explicitly:

```
Info: Updating existing Actor apify-user/my-crawler (id=E2jjCZBezvAZnX8Rb).
Info: Deploying Actor 'my-crawler' to Apify.
```

### 3. `POST /v2/acts` duplicate-name errors are opaque

The pre-flight `apify.actor("<user>/<name>").get()` doesn't catch (a) reserved / conflicting names, or (b) a race where a parallel process claimed the name between the `.get()` and the `.create()`. When that happens the surfaced error is the raw API message with no next step:

```
Error: Actor name is already used
```

After this PR:

```
Error: Cannot create Actor "my-crawler": the name is unavailable on the Apify platform (Actor name is already used).
Next steps:
  - Rename the Actor: edit the "name" field in .actor/actor.json and run 'apify push' again.
  - Push to an existing Actor: 'apify push <actor-id-or-username/name>'.
  - List names you already own: 'apify actors ls --my --name-only'.
  - Check whether a name is free: 'apify actors exists <name>'.
```

## Design notes

- **Exit-code convention for `exists`:** `0` = exists (name is taken), `1` = not found. Chosen so a bare `apify actors exists foo && echo taken` idiom works without extra flags, matching `test`, `grep`, `gh repo view`, `kubectl get`.
- **Short-name resolution in `exists`:** if the argument has no `/` and doesn't look like an Actor ID (`/^[A-Za-z0-9]{17}$/`), it's resolved as `<logged-in-user>/<name>`, so `apify actors exists my-crawler` targets the user's own namespace by default.
- **`--name-only` short-circuits before hydration:** the existing `ls` code path awaits a per-row `apifyClient.actor(id).get()` + runs list for the table. When the caller only needs identifiers, that work is wasted (and can be slow for `--limit 100`), so `--name-only` returns straight from `apifyClient.actors().list()`.
- **Error rewrite in `push` is defensive:** the name-conflict detection matches on `already used`, `not available`, or `duplicate` in the error message. If the pattern doesn't match, the original error is re-thrown unchanged.

## Test plan

- [ ] `apify actors ls --my --name-only` prints `<username>/<name>` lines and exits `0`.
- [ ] `apify actors ls --my --name-only` with zero Actors prints nothing and exits `0`.
- [ ] `apify actors ls --my --name-only --json` still returns the JSON payload (the flag is a no-op under `--json`).
- [ ] `apify actors exists <name-you-own>` → exit `0`, prints `Actor "<user>/<name>" exists (id=…).`.
- [ ] `apify actors exists <name-that-does-not-exist>` → exit `1`, prints `Actor "<user>/<name>" does not exist.`.
- [ ] `apify actors exists <name> --json` → exit `0`/`1` and JSON with `exists: true/false`.
- [ ] `apify actors exists apify/hello-world` resolves the fully-qualified name (doesn't prepend the logged-in username).
- [ ] `apify push` in a directory whose `.actor/actor.json` names an Actor the user already owns prints `Info: Updating existing Actor …`.
- [ ] `apify push` where `POST /v2/acts` fails with a duplicate-name response prints the rewritten error with the four suggested next steps.
- [ ] `pnpm tsc --noEmit` passes.

## Files changed

- `src/commands/actors/exists.ts` — new command.
- `src/commands/actors/ls.ts` — add `--name-only` flag; short-circuit before hydration.
- `src/commands/actors/push.ts` — emit `Info: Updating existing Actor …`; rewrite name-conflict errors with actionable next steps.
- `src/commands/actors/_index.ts` — register `ActorsExistsCommand`.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._