### PR TITLE
fix(create): force devDependency install; add missing-binary preflight in run

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -239,6 +239,28 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 						// For efficiency, don't install Puppeteer for templates that don't use it
 						const cmdArgs = ['install'];
 
+						// Force devDependencies to be installed even if the caller's
+						// NODE_ENV is "production" or they've configured npm to omit dev deps.
+						// Scaffolded projects rely on devDependencies (tsx, typescript, etc.)
+						// to be runnable via `apify run` immediately after `apify create`.
+						switch (runtime.pmName) {
+							case 'npm': {
+								if (gte(runtime.pmVersion!, '7.0.0')) {
+									cmdArgs.push('--include=dev');
+								} else {
+									cmdArgs.push('--no-production');
+								}
+								break;
+							}
+							case 'bun': {
+								// bun install skips devDependencies only when --production is passed;
+								// nothing to force by default, but we still override NODE_ENV below.
+								break;
+							}
+							default:
+							// pnpm / yarn / deno respect NODE_ENV; overriding it below is enough.
+						}
+
 						if (skipOptionalDeps) {
 							switch (runtime.pmName) {
 								case 'npm': {
@@ -263,10 +285,17 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 							}
 						}
 
+						// Override NODE_ENV so package managers that key devDependency
+						// installation off it (pnpm, yarn, bun, npm) still install
+						// devDependencies even when the parent shell has
+						// NODE_ENV=production set (common in Dockerfiles, CI, and shells
+						// that persist env from previous `apify push` invocations).
+						const installEnv = { ...process.env, NODE_ENV: 'development' };
+
 						await execWithLog({
 							cmd: runtime.pmPath!,
 							args: cmdArgs,
-							opts: { cwd: actFolderDir },
+							opts: { cwd: actFolderDir, env: installEnv },
 							overrideCommand: runtime.pmName,
 						});
 
@@ -343,11 +372,22 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 
 		if (!skipGitInit && !cwdHasGit) {
 			try {
-				await execWithLog({
-					cmd: 'git',
-					args: ['init'],
-					opts: { cwd: actFolderDir },
-				});
+				// Use -b main so newly scaffolded projects start on `main` regardless
+				// of the host's `init.defaultBranch` git config. Fall back to plain
+				// `git init` for older git versions that don't support -b.
+				try {
+					await execWithLog({
+						cmd: 'git',
+						args: ['init', '-b', 'main'],
+						opts: { cwd: actFolderDir },
+					});
+				} catch {
+					await execWithLog({
+						cmd: 'git',
+						args: ['init'],
+						opts: { cwd: actFolderDir },
+					});
+				}
 			} catch (err) {
 				gitInitResult = { success: false, error: err as Error };
 			}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -63,6 +63,61 @@ enum RunType {
 	Script = 2,
 }
 
+// Package managers / node runtimes that resolve their own subcommands and
+// therefore do not need a matching node_modules/.bin entry.
+const PREFLIGHT_SKIP_LEADING_TOKENS = new Set([
+	'node',
+	'npm',
+	'npx',
+	'pnpm',
+	'pnpx',
+	'yarn',
+	'bun',
+	'bunx',
+	'deno',
+	'sh',
+	'bash',
+	'zsh',
+	'python',
+	'python3',
+	'echo',
+	'true',
+	'false',
+]);
+
+/**
+ * Extracts the leading binary from an npm script command and returns it iff
+ * it looks like a local dependency binary that is expected to live in
+ * `<cwd>/node_modules/.bin/<name>` but does not. Returns `null` if we can't
+ * confidently determine that a binary is missing (unknown command shapes,
+ * absolute paths, node_modules/.bin present, etc.) — the preflight is meant
+ * to catch the common failure mode, not to second-guess arbitrary scripts.
+ */
+async function findMissingScriptBinary(cwd: string, script: string): Promise<string | null> {
+	if (!script) return null;
+
+	// Strip leading env-var assignments (e.g. `NODE_ENV=production tsx src/main.ts`).
+	const tokens = script.trim().split(/\s+/);
+	let idx = 0;
+	while (idx < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[idx])) {
+		idx += 1;
+	}
+	const leading = tokens[idx];
+	if (!leading) return null;
+
+	// Skip package managers, node/deno, shells, etc. — none of these are expected
+	// to be locally installed binaries.
+	if (PREFLIGHT_SKIP_LEADING_TOKENS.has(leading)) return null;
+
+	// If the script references an explicit path, we can't reliably infer a
+	// node_modules/.bin entry — skip the preflight to avoid false positives.
+	if (leading.includes('/') || leading.includes('\\') || leading.startsWith('.')) return null;
+
+	const binPath = join(cwd, 'node_modules', '.bin', leading);
+	const exists = existsSync(binPath) || existsSync(`${binPath}.cmd`) || existsSync(`${binPath}.exe`);
+	return exists ? null : leading;
+}
+
 export class RunCommand extends ApifyCommand<typeof RunCommand> {
 	static override name = 'run' as const;
 
@@ -396,6 +451,20 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 						if (!runtime.pmPath) {
 							throw new Error(
 								'No npm executable found! Please make sure your Node.js runtime has npm installed if you want to run package.json scripts locally.',
+							);
+						}
+
+						// Preflight: catch the common "sh: tsx: not found" failure mode
+						// where devDependencies were skipped (typically because the caller
+						// had NODE_ENV=production when running `npm install`). Emit an
+						// actionable error before spawning the package manager, instead of
+						// letting the child fail with a bare `sh: <bin>: not found`.
+						const missingBin = await findMissingScriptBinary(cwd, packageJsonObj.scripts[entrypoint]);
+						if (missingBin) {
+							throw new Error(
+								`"${missingBin}" was not found in node_modules/.bin. This usually means ` +
+									`devDependencies were skipped during install (e.g. NODE_ENV=production). ` +
+									`Run \`npm install --include=dev\` (or \`pnpm install --prod=false\`) and retry.`,
 							);
 						}
 


### PR DESCRIPTION
## Summary

When a caller has `NODE_ENV=production` set — a common state after `apify push` (which pushes an image whose Dockerfile installs with `--omit=dev`), inside a Docker build, or in a shell that persists env across commands — the `npm install` that `apify create` runs after unpacking the template inherits that env and skips `devDependencies`. TypeScript templates rely on `devDependencies` (`tsx`, `typescript`, etc.), so `apify run` on the resulting scaffold fails immediately with a bare `sh: tsx: not found`, even though the success banner of `apify create` still points at `apify run` as the next step.

This PR:

- Forces `--include=dev` on `npm install` and sets `NODE_ENV=development` in the child env for the post-scaffold install, so scaffolds are runnable regardless of the caller's environment (`src/commands/create.ts`).
- Adds a preflight in `apify run` that, for `npm run <script>` style entrypoints, checks whether the script's leading binary exists in `node_modules/.bin`. On miss, it emits an actionable error instead of leaving the user with the raw `sh: <bin>: not found` (`src/commands/run.ts`).
- Switches the post-create `git init` to `git init -b main` (with a fallback for older git), so scaffolded projects start on `main` regardless of the host's `init.defaultBranch` config.

## Reproducer

```console
$ NODE_ENV=production apify create tmp -t ts-empty
Info: Installing dependencies...
...
Success: Actor 'tmp' was created. To run it, run "cd tmp" and "apify run".

$ cd tmp
$ apify run
Run: npm run start
> tmp@0.0.1 start
> tsx src/main.ts
sh: tsx: not found
```

After this PR:

- The post-scaffold install produces a `node_modules` that contains `tsx`, so the reproducer above just works.
- Even if the user managed to arrive at a scaffold whose `devDependencies` were skipped, `apify run` now bails out early with:

  ```
  Error: "tsx" was not found in node_modules/.bin. This usually means devDependencies
  were skipped during install (e.g. NODE_ENV=production). Run `npm install --include=dev`
  (or `pnpm install --prod=false`) and retry.
  ```

## Test plan

- [ ] `NODE_ENV=production apify create tmp-node-env -t ts-empty` — resulting `node_modules/.bin` contains `tsx`.
- [ ] `apify run` in a scaffold whose `node_modules/.bin/tsx` has been deleted prints the new actionable error, not the raw `sh: tsx: not found`.
- [ ] `apify run` on an unaffected scaffold (start script is `node dist/main.js` etc.) is unchanged.
- [ ] `apify create` on a git repo host with `init.defaultBranch=trunk` still produces a scaffold initialised on `main`.

## Related — coordinated remediation stack

Four defense layers, each covering a different failure mode:

- [`apify/actor-templates`](https://github.com/apify/actor-templates) — ts-* Dockerfiles ship a multi-stage build (already in master via [#592](https://github.com/apify/actor-templates/pull/592), Dec 2025). Users of `apify create -t ts-*` cannot hit the trap.
- [`apify/apify-cli#1252`](https://github.com/apify/apify-cli/pull/1252) — `apify push` preflight warning when a Dockerfile has `--omit=dev` before `npm run build` that invokes `tsc`.
- **This PR** — `apify create` forces `--include=dev` + `NODE_ENV=development` on the post-scaffold install, so `apify run` works locally; plus a `node_modules/.bin` preflight in `apify run` to surface an actionable error if the trap fires anyway.
- [`apify/apify-docs#2716`](https://github.com/apify/apify-docs/pull/2716) — docs callout on the Source-code page for the direct-`docker build` / search-fallback case.

---

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._