### PR TITLE
fix(create): quiet git-init, silence version-check warning, gate next-steps hint

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -19,6 +19,7 @@ import {
 import {
 	enhanceReadmeWithLocalSuffix,
 	ensureValidActorName,
+	findMissingRunnerBinary,
 	formatCreateSuccessMessage,
 	getTemplateDefinition,
 } from '../lib/create-utils.js';
@@ -343,9 +344,12 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 
 		if (!skipGitInit && !cwdHasGit) {
 			try {
+				// -c init.defaultBranch=main avoids the "using master as the initial
+				// branch" hint on Git 2.28+. -q silences the remaining "Initialized
+				// empty Git repository" line so scaffolding output stays compact.
 				await execWithLog({
 					cmd: 'git',
-					args: ['init'],
+					args: ['-c', 'init.defaultBranch=main', 'init', '-q'],
 					opts: { cwd: actFolderDir },
 				});
 			} catch (err) {
@@ -356,6 +360,11 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 		// Suggest install command if dependencies were not installed
 		const installCommandSuggestion = !dependenciesInstalled ? await getInstallCommandSuggestion(actFolderDir) : null;
 
+		// If we ran install but the start-script runner binary (tsx/ts-node/etc.)
+		// is missing from node_modules/.bin, dev dependencies were skipped. Warn
+		// so the Next-steps hint doesn't lead the user into `sh: tsx: not found`.
+		const missingRunnerBinary = dependenciesInstalled ? await findMissingRunnerBinary(actFolderDir) : null;
+
 		// Success message with extra empty line
 		simpleLog({ message: '' });
 		success({
@@ -365,6 +374,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 				postCreate: messages?.postCreate ?? null,
 				gitRepositoryInitialized: !skipGitInit && !cwdHasGit && gitInitResult.success,
 				installCommandSuggestion,
+				missingRunnerBinary,
 			}),
 		});
 

--- a/src/lib/create-utils.ts
+++ b/src/lib/create-utils.ts
@@ -1,4 +1,6 @@
 import { createWriteStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
 import { Separator } from '@inquirer/core';
@@ -9,7 +11,7 @@ import type { ChoicesType } from './hooks/user-confirmations/useSelectFromList.j
 import { useSelectFromList } from './hooks/user-confirmations/useSelectFromList.js';
 import { useUserInput } from './hooks/user-confirmations/useUserInput.js';
 import { warning } from './outputs.js';
-import { httpsGet, validateActorName } from './utils.js';
+import { getJsonFileContent, httpsGet, validateActorName } from './utils.js';
 
 const PROGRAMMING_LANGUAGES = ['JavaScript', 'TypeScript', 'Python'];
 
@@ -71,13 +73,31 @@ export function formatCreateSuccessMessage(params: {
 	postCreate?: string | null;
 	gitRepositoryInitialized?: boolean;
 	installCommandSuggestion?: string | null;
+	missingRunnerBinary?: string | null;
 }) {
-	const { actorName, dependenciesInstalled, postCreate, gitRepositoryInitialized, installCommandSuggestion } = params;
+	const {
+		actorName,
+		dependenciesInstalled,
+		postCreate,
+		gitRepositoryInitialized,
+		installCommandSuggestion,
+		missingRunnerBinary,
+	} = params;
 
 	let message = `✅ Actor '${actorName}' created successfully!`;
 
-	if (dependenciesInstalled) {
+	if (dependenciesInstalled && !missingRunnerBinary) {
 		message += `\n\nNext steps:\n\ncd "${actorName}"\napify run`;
+	} else if (missingRunnerBinary) {
+		// The install finished but the runner declared in package.json's start
+		// script is missing from node_modules/.bin — most commonly because
+		// NODE_ENV=production (or --omit=dev) caused npm to skip devDependencies.
+		// Point the user at that root cause instead of the misleading run hint,
+		// which would fail with "<runner>: not found".
+		message +=
+			`\n\n⚠️  Dev dependencies do not appear to be fully installed ` +
+			`(missing '${missingRunnerBinary}' in node_modules/.bin).` +
+			`\n\nNext steps:\n\ncd "${actorName}"\nnpm install --include=dev\napify run`;
 	} else {
 		const installLine = installCommandSuggestion || 'install dependencies with your package manager';
 		message += `\n\nNext steps:\n\ncd "${actorName}"\n${installLine}\napify run`;
@@ -94,6 +114,48 @@ export function formatCreateSuccessMessage(params: {
 	}
 
 	return message;
+}
+
+/**
+ * Detect the runner binary that the project's `npm start` script expects
+ * (e.g. `tsx`, `ts-node`) and check whether it landed in `node_modules/.bin`.
+ * Returns the runner name if it is expected but missing — a heuristic signal
+ * that devDependencies were skipped during install.
+ */
+export async function findMissingRunnerBinary(actorDir: string): Promise<string | null> {
+	const pkg = getJsonFileContent<{
+		scripts?: Record<string, string>;
+		devDependencies?: Record<string, string>;
+	}>(join(actorDir, 'package.json'));
+
+	if (!pkg?.scripts?.start) {
+		return null;
+	}
+
+	// First non-shell token of `start`. Skip env-var assignments like FOO=bar.
+	const tokens = pkg.scripts.start.split(/\s+/).filter((t) => t && !t.includes('='));
+	const runner = tokens[0];
+
+	if (!runner) {
+		return null;
+	}
+
+	// Absolute/relative paths and Node itself don't live in node_modules/.bin.
+	if (runner === 'node' || runner.startsWith('.') || runner.includes('/') || runner.includes('\\')) {
+		return null;
+	}
+
+	// Only flag runners the template declared as (dev)Dependencies — otherwise a
+	// missing binary is expected (system-provided command).
+	const declared = { ...pkg.devDependencies, ...(pkg as { dependencies?: Record<string, string> }).dependencies };
+	if (!Object.hasOwn(declared, runner)) {
+		return null;
+	}
+
+	const binPath = join(actorDir, 'node_modules', '.bin', runner);
+	const exists = await stat(binPath).catch(() => null);
+
+	return exists ? null : runner;
 }
 
 /**

--- a/src/lib/hooks/useCLIVersionCheck.ts
+++ b/src/lib/hooks/useCLIVersionCheck.ts
@@ -1,7 +1,6 @@
 import { gt } from 'semver';
 
 import { CHECK_VERSION_EVERY_MILLIS } from '../consts.js';
-import { warning } from '../outputs.js';
 import { cliDebugPrint } from '../utils/cliDebugPrint.js';
 import { useCLIMetadata } from './useCLIMetadata.js';
 import { type LatestState, updateLocalState, useLocalState } from './useLocalState.js';
@@ -58,15 +57,30 @@ async function getLatestVersion(state: LatestState) {
 		headers: {
 			'User-Agent': USER_AGENT,
 		},
+	}).catch((err) => {
+		cliDebugPrint('useCLIVersionCheck', 'Failed to fetch latest version', { error: (err as Error).message });
+		return null;
 	});
 
-	if (!res.ok) {
-		cliDebugPrint('useCLIVersionCheck', 'Failed to fetch latest version', {
-			statusCode: res.status,
-			body: await res.text(),
-		});
+	if (!res || !res.ok) {
+		if (res) {
+			cliDebugPrint('useCLIVersionCheck', 'Failed to fetch latest version', {
+				statusCode: res.status,
+				body: await res.text(),
+			});
+		}
 
-		warning({ message: 'Failed to fetch latest version of Apify CLI, using the cached version instead.' });
+		// The version check is a best-effort background courtesy — the CLI still
+		// works without it. Record the attempt so we honour the 24h debounce
+		// window even on failure (previously every subsequent command re-tried
+		// and re-printed a warning). We intentionally do not surface the failure
+		// to the user; transient network errors here are not actionable.
+		updateLocalState(state, (stateToUpdate) => {
+			stateToUpdate.versionCheck = {
+				lastChecked: Date.now(),
+				lastVersion: state.versionCheck?.lastVersion,
+			};
+		});
 
 		return null;
 	}


### PR DESCRIPTION
## Summary

Three small, closely related cosmetic-but-noisy defects in the CLI's user-facing output. All hit any first-time `apify create` user and any user running multiple `apify` commands in a row.

### 1. `apify create` emits ~13 lines of Git's "master branch" hint

Because `git init` runs with default flags, modern Git prints its multi-line advice about the initial branch name every time:

```
$ apify create my-actor -t ts-crawlee-playwright
...
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
Initialized empty Git repository in /.../my-actor/.git/
```

Fix: invoke `git -c init.defaultBranch=main init -q`. On Git 2.28+ the `-c` config overrides the default so no hint is printed, and `-q` silences the "Initialized empty Git repository" line. Older Git versions ignore the unknown config key and still work — the branch just happens to be `master` there.

### 2. Version-check warning fires on every invocation when the GitHub API trips

`useCLIVersionCheck` already debounces the *fetch* to 24h via `~/.apify/state.json`, but on failure it does **not** update `lastChecked`. That means whenever the GitHub API returns non-200 (rate limit / captive portal / transient DNS), every subsequent `apify` invocation retries the fetch and prints:

```
Warning: Failed to fetch latest version of Apify CLI, using the cached version instead.
```

I've seen 5+ of these in one script run. The warning also isn't actionable — nothing changes if the user reads it.

Fix:
- Update `lastChecked` even on failure, so the 24h debounce covers failed attempts too.
- Drop the user-facing warning; the failure remains visible via `APIFY_CLI_DEBUG`.
- Catch synchronous fetch errors (previously they would bubble up and crash the check silently but noisily).

### 3. Post-scaffold "Next steps: apify run" can point to a broken next step

For TypeScript templates whose `package.json` `start` script is `tsx main.ts`, the success message unconditionally says:

```
✅ Actor 'my-actor' created successfully!

Next steps:

cd "my-actor"
apify run
```

If devDependencies were skipped during install (`NODE_ENV=production` in CI, `npm ci --omit=dev`, or a Dockerfile that does `npm install --omit=dev` before the user runs the Actor), `apify run` fails immediately with:

```
sh: tsx: not found
```

Fix: after a Node install, read the runner named by `scripts.start`, check whether it resolves in `node_modules/.bin/`, and if it's declared as a dependency but missing, replace the run hint with:

```
⚠️  Dev dependencies do not appear to be fully installed (missing 'tsx' in node_modules/.bin).

Next steps:

cd "my-actor"
npm install --include=dev
apify run
```

The check is scoped to the runner declared in the template's own `package.json`, so it doesn't false-positive on system-provided commands (`node`, `python`, etc.).

## Files changed

- `src/commands/create.ts` — pass `-c init.defaultBranch=main -q` to `git init`; call the new helper before formatting the success message.
- `src/lib/create-utils.ts` — add `findMissingRunnerBinary`; extend `formatCreateSuccessMessage` with `missingRunnerBinary`.
- `src/lib/hooks/useCLIVersionCheck.ts` — record `lastChecked` on failure, drop the warning, catch fetch rejections.

## Test plan

- [x] Existing `test/local/commands/create.test.ts` passes (9/9).
- [x] `tsc --noEmit` clean.
- [x] `oxlint --type-aware` + `oxfmt --check` clean on the touched files.
- [ ] Manual: `apify create foo -t ts-crawlee-playwright` — success message has <3 lines of git output.
- [ ] Manual: run `apify create` while offline / with `Authorization: Bearer bogus` proxying `api.github.com` — no repeated "Failed to fetch latest version" warnings.
- [ ] Manual: `NODE_ENV=production apify create bar -t ts-crawlee-playwright` — success message points at `npm install --include=dev` instead of `apify run`.

---

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._