### PR TITLE
fix(api): warn when endpoint contains "?" to prevent silent shell truncation

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -56,6 +56,10 @@ DESCRIPTION
   The endpoint can be a relative path (e.g. "acts", "v2/acts", or "/v2/acts"); 
   the "v2/" prefix is added automatically if omitted.
 
+  Prefer --params to pass query parameters. If you must include a "?" inline, 
+  quote the whole endpoint so the shell does not treat "&" as a background 
+  operator.
+
   Use --list-endpoints to see all available API endpoints.
 
 USAGE

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -6,7 +6,7 @@ import { ApifyCommand, StdinMode } from '../lib/command-framework/apify-command.
 import { Args } from '../lib/command-framework/args.js';
 import { Flags } from '../lib/command-framework/flags.js';
 import { APIFY_CLIENT_DEFAULT_HEADERS, CommandExitCodes } from '../lib/consts.js';
-import { error, simpleLog } from '../lib/outputs.js';
+import { error, simpleLog, warning } from '../lib/outputs.js';
 import { getLoggedClientOrThrow } from '../lib/utils.js';
 
 const HTTP_METHODS: string[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
@@ -144,6 +144,8 @@ export class ApiCommand extends ApifyCommand<typeof ApiCommand> {
 		'Makes an authenticated HTTP request to the Apify API and prints the response.\n' +
 		'The endpoint can be a relative path (e.g. "acts", "v2/acts", or "/v2/acts"); ' +
 		'the "v2/" prefix is added automatically if omitted.\n\n' +
+		'Prefer --params to pass query parameters. If you must include a "?" inline, ' +
+		'quote the whole endpoint so the shell does not treat "&" as a background operator.\n\n' +
 		'Use --list-endpoints to see all available API endpoints.';
 
 	static override examples = [
@@ -287,6 +289,26 @@ export class ApiCommand extends ApifyCommand<typeof ApiCommand> {
 		if (!endpointArg) {
 			this.printHelp();
 			return;
+		}
+
+		// The endpoint arrives as a single argv entry. If the user typed something like
+		//   apify api /v2/acts?my=1&limit=100
+		// without quotes, the shell interpreted "&" as a background operator and the CLI
+		// only ever received "/v2/acts?my=1" — the rest was silently lost. We cannot see
+		// the missing "&" (the shell consumed it), but the leftover "?" in the endpoint
+		// is a strong signal that inline query params were being passed. Warn the user
+		// so the truncation is never silent, and point them at safer forms.
+		if (endpointArg.includes('?')) {
+			warning({
+				message:
+					'The endpoint contains a "?". If the command line was not fully quoted, ' +
+					'the shell may have silently dropped everything after an unquoted "&" or ' +
+					'expanded "?" as a glob. Prefer --params to pass query parameters, e.g.\n' +
+					`  ${chalk.cyan(`apify api /v2/acts -p '{"my":1,"limit":100}'`)}\n` +
+					'or quote the whole endpoint:\n' +
+					`  ${chalk.cyan(`apify api '/v2/acts?my=1&limit=100'`)}`,
+				stdout: false,
+			});
 		}
 
 		// Parse and validate --params before any I/O so bad input fails fast

--- a/test/local/commands/api.test.ts
+++ b/test/local/commands/api.test.ts
@@ -118,6 +118,27 @@ describe('apify api (local)', () => {
 		});
 	});
 
+	describe('inline query-string detection', () => {
+		it('should warn when the endpoint contains "?"', async () => {
+			await testRunCommand(ApiCommand, {
+				args_methodOrEndpoint: 'v2/acts?my=1&limit=100',
+			});
+
+			const combinedErrors = logMessages.error.join('\n');
+			expect(combinedErrors).toMatch(/endpoint contains a "\?"/i);
+			expect(combinedErrors).toMatch(/--params/);
+		});
+
+		it('should not warn when the endpoint has no "?"', async () => {
+			await testRunCommand(ApiCommand, {
+				args_methodOrEndpoint: 'v2/users/me',
+			});
+
+			const combinedErrors = logMessages.error.join('\n');
+			expect(combinedErrors).not.toMatch(/endpoint contains a "\?"/i);
+		});
+	});
+
 	describe('method handling', () => {
 		it('should error when positional method conflicts with --method flag', async () => {
 			await testRunCommand(ApiCommand, {


### PR DESCRIPTION
## Summary

Running `apify api` with an unquoted endpoint that contains a query string is silently truncated by the shell, so the CLI ends up hitting a different URL than the user intended. This PR detects the tell-tale `?` in the endpoint arg and emits a stderr warning pointing at two safe forms.

## Reproducer

```console
$ apify api /v2/acts?my=1&limit=100
```

The shell interprets `&` as the background operator, so the CLI process only receives `/v2/acts?my=1` in `argv`; `limit=100` is discarded. The request returns a much larger response than the caller expected (no `limit`), and there is no indication that anything was dropped. In practice this pushes users (and agents) to abandon `apify api` and fall back to raw `curl`, e.g.:

```
curl -s -H "Authorization: Bearer $APIFY_TOKEN" "https://api.apify.com/v2/acts?my=1&limit=100" | ...
```

`?` on its own can also be expanded by the shell as a glob if a matching filename happens to exist in the current directory.

## Fix

The CLI cannot see the missing `&` (the shell consumed it before `execve`), but the leftover `?` in the endpoint is a strong signal that inline query parameters were being passed. When the endpoint contains `?`, print a stderr warning with two concrete fixes:

```
Warning: The endpoint contains a "?". If the command line was not fully
quoted, the shell may have silently dropped everything after an unquoted "&"
or expanded "?" as a glob. Prefer --params to pass query parameters, e.g.
  apify api /v2/acts -p '{"my":1,"limit":100}'
or quote the whole endpoint:
  apify api '/v2/acts?my=1&limit=100'
```

The warning is stderr-only and does not change exit code or behavior, so this is fully backward-compatible for callers who already quote correctly. The same guidance is added to the command description so `apify api --help` teaches it too.

## Test plan

- [x] `apify api /v2/acts?my=1&limit=100` (unquoted) — stderr warning shown, request still proceeds.
- [x] `apify api '/v2/acts?my=1&limit=100'` — warning shown (same signal, same guidance), request proceeds correctly.
- [x] `apify api /v2/users/me` — no warning.
- [x] `apify api /v2/acts -p '{"my":1,"limit":100}'` — no warning; recommended form.
- [x] `pnpm test test/local/commands/api.test.ts` — new coverage in `describe('inline query-string detection', ...)` plus all existing api tests still pass (27/27).
- [x] `pnpm run update-docs` — `docs/reference.md` regenerated from the updated description; no stale content.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._