### PR TITLE
Rename auto-applied `t-dx` label to `t-builders`

### DIFF
--- a/.github/workflows/issue_labeling.yaml
+++ b/.github/workflows/issue_labeling.yaml
@@ -13,7 +13,7 @@ jobs:
             issues: write
 
         steps:
-            # Add the "t-dx" label to all new issues
+            # Add the "t-builders" label to all new issues
             - uses: actions/github-script@v9
               with:
                   script: |
@@ -21,5 +21,5 @@ jobs:
                         issue_number: context.issue.number,
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        labels: ["t-dx"]
+                        labels: ["t-builders"]
                       })


### PR DESCRIPTION
The Builders team issue label was renamed from `t-dx` to `t-builders`. This updates the new-issue auto-labeling workflow to apply the current label so new issues stop getting the stale `t-dx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)