### PR TITLE
feat(push): auto-normalize SemVer versions in actor.json to MAJOR.MINOR

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -42,6 +42,36 @@ const DEFAULT_RUN_OPTIONS = {
 };
 const DEFAULT_ACTOR_VERSION_NUMBER = '0.0';
 
+// Actor versions on the platform are MAJOR.MINOR (both non-negative integers).
+// TODO: import from @apify/consts / apify-shared-js once the shared regex lands
+// (see apify-shared-js #655).
+const MAJOR_MINOR_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+// Matches SemVer-style versions we can safely rewrite to MAJOR.MINOR — i.e.
+// non-negative integers for MAJOR and MINOR, with an optional PATCH, optional
+// pre-release identifiers (`-beta`, `-rc.1`), and optional build metadata
+// (`+build.7`). Leading zeros on numeric identifiers are rejected (per SemVer)
+// so we don't silently rewrite something we don't understand.
+//   1.0.0            -> 1.0
+//   0.0.1            -> 0.0
+//   1.0.0-beta       -> 1.0
+//   2.3.4-rc.1+abc   -> 2.3
+const NORMALIZABLE_SEMVER_REGEX =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/**
+ * If `raw` is a SemVer-style string that the platform would reject (e.g. `1.0.0`,
+ * `0.0.1-beta`), return the equivalent MAJOR.MINOR pair the platform accepts.
+ * Returns `undefined` if the input is already MAJOR.MINOR (no rewrite needed)
+ * or if it's not a shape we're willing to auto-normalize.
+ */
+export function normalizeToMajorMinor(raw: string): string | undefined {
+	if (MAJOR_MINOR_VERSION_REGEX.test(raw)) return undefined;
+	const match = NORMALIZABLE_SEMVER_REGEX.exec(raw);
+	if (!match) return undefined;
+	return `${match[1]}.${match[2]}`;
+}
+
 // It would be better to use `version-0.0` or similar,
 // or even have no default tag, but the platform complains when
 // Actor does not have a build with a `latest` tag, so until
@@ -258,7 +288,26 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 		let isActorCreatedNow = false;
 
 		// User can override Actor version and build tag, attributes in localConfig will remain same.
-		const version = this.flags.version || (actorConfig?.version as string | undefined) || DEFAULT_ACTOR_VERSION_NUMBER;
+		let version = this.flags.version || (actorConfig?.version as string | undefined) || DEFAULT_ACTOR_VERSION_NUMBER;
+
+		// Auto-normalize SemVer-style versions (`1.0.0`, `0.0.1-beta`) to the
+		// MAJOR.MINOR shape the platform accepts. Node/npm scaffolding defaults
+		// to three-part SemVer, and the `version` field in actor.json is
+		// frequently copied from `package.json` — without this the upload
+		// succeeds but the subsequent build is rejected with a cryptic 400.
+		// We only rewrite versions we can unambiguously read as SemVer; other
+		// invalid inputs (e.g. `latest`, `v1`) fall through to the strict
+		// validator below.
+		const normalizedVersion = normalizeToMajorMinor(version);
+		if (normalizedVersion !== undefined) {
+			warning({
+				message:
+					`Actor version '${version}' is not the strict MAJOR.MINOR format the platform expects; ` +
+					`auto-normalizing to '${normalizedVersion}' for this upload. ` +
+					`Update the \`version\` field in ${LOCAL_CONFIG_PATH} to '${normalizedVersion}' to make this permanent.`,
+			});
+			version = normalizedVersion;
+		}
 
 		let buildTag = this.flags.buildTag || (actorConfig?.buildTag as string | undefined);
 


### PR DESCRIPTION
## Summary

The `version` field in `actor.json` is frequently copied straight from `package.json` (or written from muscle memory) as three-part SemVer — `0.0.1`, `1.0.0`, `1.0.0-beta`. The platform requires strict `MAJOR.MINOR` and rejects everything else during the build admission step, after the source files have already been uploaded and a build slot has been spent. The error surface is a cryptic 400 that the user learns nothing from; every retry burns a build.

[#1245](https://github.com/apify/apify-cli/pull/1245) added a **strict** client-side guard that fails fast on any non-`MAJOR.MINOR` version. That's an improvement, but the failure still forces a manual round-trip to edit `actor.json` and re-run `push` — often on a first-time deploy where the developer (or an agent driving the CLI) doesn't yet know what Apify's version format is.

This change is **complementary**: before the strict validator runs, detect SemVer-shaped versions we can unambiguously read (`MAJOR.MINOR.PATCH`, optional pre-release identifiers, optional build metadata) and rewrite them to `MAJOR.MINOR` for the current upload, with a warning that tells the developer what happened and points at the field to edit for a permanent fix. Non-SemVer garbage (`latest`, `v1`, etc.) falls through to the strict validator unchanged, so this doesn't paper over inputs the CLI can't safely interpret.

## Behaviour

| `actor.json` `version` | Effect |
|---|---|
| `0.0.1` | WARN + auto-normalized to `0.0` for this upload; strict validator sees `0.0` and passes |
| `1.0.0-beta` | WARN + auto-normalized to `1.0` |
| `2.3.4-rc.1+build.7` | WARN + auto-normalized to `2.3` |
| `0.0` (already valid) | no rewrite, no warning |
| `latest`, `v1` (not SemVer) | unchanged; strict validator rejects with a pointed message |

Example warning:

```
WARN: Actor version '0.0.1' is not the strict MAJOR.MINOR format the platform expects;
      auto-normalizing to '0.0' for this upload.
      Update the `version` field in .actor/actor.json to '0.0' to make this permanent.
```

## Rationale

Developers scaffolding an Actor from scratch — especially in Node ecosystems, where `npm init` writes three-part SemVer by default — trip on this on their very first `apify push`. The docs mention `MAJOR.MINOR` but it's buried; without an early-and-friendly CLI translation, the developer learns nothing from a 400 error minutes into the flow. This PR lets `push` educate + proceed rather than educate + fail.

The strict validator from [#1245](https://github.com/apify/apify-cli/pull/1245) is intentionally preserved (behind this normalization step) so we still fail fast on inputs the CLI can't unambiguously interpret.

## Test plan

- [ ] `apify push` with `actor.json` `version: "0.0.1"` prints the WARN and completes a successful build against a fresh Actor
- [ ] `apify push` with `actor.json` `version: "1.0.0-beta"` normalizes to `1.0`
- [ ] `apify push` with `actor.json` `version: "0.0"` (already valid) prints no warning
- [ ] `apify push` with `actor.json` `version: "latest"` still fails fast at the strict validator with the existing pointed message (regression check for [#1245](https://github.com/apify/apify-cli/pull/1245))
- [ ] `apify push -v 0.0.1` (flag override) also gets normalized
- [ ] `apify push --json` still returns the JSON envelope with the normalized `versionNumber`

Surfaced during an evaluation of Apify surfaces for agent-driven Actor development.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>