### PR TITLE
feat(push): print a next-step hint after a successful build

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -549,6 +549,21 @@ Skipping push. Use --force to override.`,
 			return;
 		}
 
+		// After a successful build, guide the caller to the next step. `apify push`
+		// deploys but does not run — users (and agents driving the CLI) frequently
+		// read the Actor URL as "job done" and stop there without ever invoking
+		// the Actor. A short hint block removes that ambiguity.
+		const actorSlug = `${userInfo.username || userInfo.id}/${actorConfig!.name}`;
+		const nextStepsLines =
+			outcome.ok && buildStatus === ACTOR_JOB_STATUSES.SUCCEEDED
+				? [
+						'',
+						'Next: run it once to verify the build.',
+						`  apify call ${actorSlug}                   # blocks and prints run summary`,
+						`  apify actors start ${actorSlug}           # non-blocking`,
+					]
+				: [];
+
 		const lines = [
 			`Apify push result: ${outcome.resultLabel}`,
 			'',
@@ -562,6 +577,7 @@ Skipping push. Use --force to override.`,
 			`Actor URL: ${actorUrl}`,
 			`Build URL: ${buildUrl}`,
 			...(outcome.errorMessage && logTail.length ? ['', 'Reason:', ...logTail] : []),
+			...nextStepsLines,
 		];
 		simpleLog({ stdout: true, message: lines.join('\n') });
 


### PR DESCRIPTION
## Summary

`apify push` deploys but does **not** run. Today the success block ends with:

```
Actor URL: https://console.apify.com/actors/<slug>
Build URL: https://console.apify.com/actors/<slug>#/builds/<n>
```

Users (and agents driving the CLI) frequently read that as "job done" and stop there without ever invoking the Actor. That's fine when the intent was purely "build and hand off to Console", but it's the wrong default for a first-time deploy where the whole point is to confirm the Actor works end-to-end.

This PR appends a short next-steps block below the URLs, only on `buildStatus === SUCCEEDED`, pointing at the two commands the user almost certainly wants next:

```
Next: run it once to verify the build.
  apify call <username>/<actor>            # blocks and prints run summary
  apify actors start <username>/<actor>    # non-blocking
```

The block is suppressed on failed / aborted / timed-out builds (where it would be noise) and in `--json` mode (which keeps its existing machine-readable envelope).

## Rationale

New Actor developers — and agents scripting the flow — tend to treat the printed Console URL as the terminal state. The CLI already knows the Actor's fully-qualified slug at this point; showing the two commands that run it costs one small block and closes the "build vs. run" cognitive gap.

## Follow-ups (not in this PR)

A `--run` flag on `apify push` that auto-invokes `apify call` after a successful build is a natural next step, and could be added on top of this without changing the hint block. Left out here to keep the diff surgical.

## Test plan

- [ ] `apify push` on a healthy Actor prints the two next-step lines below `Build URL:`
- [ ] `apify push` on a failing build (e.g. Dockerfile that exits non-zero) does **not** print the next-step block
- [ ] `apify push --json` output is byte-for-byte unchanged from before this PR
- [ ] The slug in the hint matches `apify call` and `apify actors start`'s expected argument shape

Surfaced during an evaluation of Apify surfaces for agent-driven Actor development.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>