### PR TITLE
ci(release): wait for checks on the pinned commit, not the branch ref

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -35,7 +35,7 @@ jobs:
         steps:
             - uses: lewagon/wait-on-check-action@v1.8.0
               with:
-                  ref: ${{ github.ref }}
+                  ref: ${{ github.sha }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   check-regexp: (Build|Lint.*|(Local|API) Tests.*|Python Support.*|Docs build)
                   wait-interval: 5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
             - uses: lewagon/wait-on-check-action@v1.8.0
               if: ${{ steps.check_skip.outputs.skipped == 'false' }}
               with:
-                  ref: ${{ github.ref }}
+                  ref: ${{ github.sha }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   check-regexp: (Build|(Local|API) Tests.*|Python Support.*|Docs build)
                   wait-interval: 5


### PR DESCRIPTION
## What

Pin `ref` to `${{ github.sha }}` in the `wait-on-check-action` step of `release.yaml` and `pre_release.yaml`. Was `${{ github.ref }}`.

## Why

`wait-on-check-action` re-resolves a branch ref on every poll. During [release run 29018416283](https://github.com/apify/apify-cli/actions/runs/29018416283) the pre-release workflow (queued ahead in the same `release` concurrency group) pushed its `chore(release): ... [skip ci]` commit to master mid-run. The release's wait step then resolved `refs/heads/master` to that new commit, which has no code checks (`[skip ci]`), and died with:

```
The requested check was never run against this ref, exiting...
```

All downstream jobs `need` that job, so the whole release skipped. Re-runs fail the same way, since master keeps pointing at the `[skip ci]` commit.

The workflow's own `[skip ci]` guard didn't catch it because it inspects the pinned `github.sha` while the wait watched the moving branch — two steps, two different commits.

## Fix

Watch the same pinned commit the guard inspects. Release dispatched right after a merge now survives master moving underneath it, and re-runs work.
