### PR TITLE
feat: configurable API and Console base URLs via env vars

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,3 +82,42 @@ To upgrade Apify CLI to the latest version, run:
 ```bash
 apify upgrade
 ```
+
+## Environment variables
+
+By default, the CLI talks to the production Apify API (`https://api.apify.com`) and Apify Console
+(`https://console.apify.com`). You can point it at a different instance — e.g. a local or staging
+deployment — using the following environment variables. This is independent of the Actor-level
+environment variables described in [Environment variables for Actors](./vars.md).
+
+| Variable                      | Purpose                                                              | Default                     |
+| ----------------------------- | -------------------------------------------------------------------- | --------------------------- |
+| `APIFY_API_BASE_URL`           | The Apify API base URL used by CLI commands.                        | `https://api.apify.com`     |
+| `APIFY_CLIENT_BASE_URL`        | Legacy fallback for the API base URL, kept for backward compatibility. | —                            |
+| `APIFY_API_PUBLIC_BASE_URL`    | The globally accessible API base URL, forwarded to the client. Independent of `APIFY_API_BASE_URL` — setting one does not change the other's default. | `https://api.apify.com` |
+| `APIFY_CONSOLE_BASE_URL`       | The Apify Console base URL (origin only) used for every link the CLI prints or opens. | `https://console.apify.com` |
+
+### API base URL precedence
+
+An explicit command flag/option (where a command accepts one) always wins, followed by the environment
+variables, followed by the built-in default:
+
+```text
+explicit flag/option > APIFY_API_BASE_URL > APIFY_CLIENT_BASE_URL > https://api.apify.com
+```
+
+`APIFY_API_PUBLIC_BASE_URL` follows the same shape (`explicit option > APIFY_API_PUBLIC_BASE_URL >
+default`) but is resolved independently of `APIFY_API_BASE_URL` — the two never affect each other's
+default.
+
+### Console base URL
+
+`APIFY_CONSOLE_BASE_URL` should be an origin only (e.g. `http://localhost:3000`), not a full URL with
+a path — the CLI appends the relevant path or fragment (e.g. `/actors/<id>`, `#/builds/<n>`) itself.
+
+### Login and localhost
+
+When `apify login` resolves the Console base to a localhost address (e.g. because
+`APIFY_CONSOLE_BASE_URL` is set to a local Console instance) and no API base is otherwise specified,
+the API defaults to `http://localhost:3333` so a local Console can authenticate against a local API.
+Setting `APIFY_API_BASE_URL` (or, where supported, an explicit flag) always overrides this default.

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -17,7 +17,12 @@ import { createHmacSignature } from '@apify/utilities';
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
 import { Flags } from '../../lib/command-framework/flags.js';
-import { CommandExitCodes, DEPRECATED_LOCAL_CONFIG_NAME, LOCAL_CONFIG_PATH } from '../../lib/consts.js';
+import {
+	CommandExitCodes,
+	DEPRECATED_LOCAL_CONFIG_NAME,
+	getConsoleBaseUrl,
+	LOCAL_CONFIG_PATH,
+} from '../../lib/consts.js';
 import { sumFilesSizeInBytes } from '../../lib/files.js';
 import { useAbortJobOnSignal } from '../../lib/hooks/useAbortJobOnSignal.js';
 import { useActorConfig } from '../../lib/hooks/useActorConfig.js';
@@ -506,7 +511,7 @@ Skipping push. Use --force to override.`,
 		const buildStatus = build.status as string;
 		const outcome = resolvePushOutcome(buildStatus);
 
-		const actorUrl = `https://console.apify.com${redirectUrlPart}/actors/${build.actId}`;
+		const actorUrl = `${getConsoleBaseUrl()}${redirectUrlPart}/actors/${build.actId}`;
 		const buildUrl = `${actorUrl}#/builds/${build.buildNumber}`;
 
 		// Surface the tail of the build log as the failure reason. Best-effort:

--- a/src/commands/actors/start.ts
+++ b/src/commands/actors/start.ts
@@ -9,7 +9,7 @@ import { Flags } from '../../lib/command-framework/flags.js';
 import { consoleRunUrl } from '../../lib/commands/agent-output.js';
 import { getInputOverride } from '../../lib/commands/resolve-input.js';
 import { runActorOrTaskOnCloud, SharedRunOnCloudFlags } from '../../lib/commands/run-on-cloud.js';
-import { LOCAL_CONFIG_PATH } from '../../lib/consts.js';
+import { getConsoleBaseUrl, LOCAL_CONFIG_PATH } from '../../lib/consts.js';
 import { simpleLog } from '../../lib/outputs.js';
 import { getLocalConfig, getLocalUserInfo, getLoggedClientOrThrow, printJsonToStdout } from '../../lib/utils.js';
 import { ActorsCallCommand } from './call.js';
@@ -141,7 +141,7 @@ export class ActorsStartCommand extends ApifyCommand<typeof ActorsStartCommand> 
 				waited: false,
 				actor: {
 					id: actorId,
-					url: `https://console.apify.com/actors/${actorId}`,
+					url: `${getConsoleBaseUrl()}/actors/${actorId}`,
 				},
 				run: {
 					id: run.id,

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -12,19 +12,22 @@ import { cryptoRandomObjectId } from '@apify/utilities';
 
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Flags } from '../../lib/command-framework/flags.js';
-import { AUTH_FILE_PATH } from '../../lib/consts.js';
+import { AUTH_FILE_PATH, getConsoleBaseUrl } from '../../lib/consts.js';
 import { getBackend } from '../../lib/credentials.js';
 import { updateUserId } from '../../lib/hooks/telemetry/useTelemetryState.js';
 import { useMaskedInput } from '../../lib/hooks/user-confirmations/useMaskedInput.js';
 import { useSelectFromList } from '../../lib/hooks/user-confirmations/useSelectFromList.js';
 import { error, info, success } from '../../lib/outputs.js';
-import { getLocalUserInfo, getLoggedClient, tildify } from '../../lib/utils.js';
+import { getLocalUserInfo, getLoggedClient, resolveLoginApiBaseUrl, tildify } from '../../lib/utils.js';
 
-const CONSOLE_BASE_URL = 'https://console.apify.com/settings/integrations';
-// const CONSOLE_BASE_URL = 'http://localhost:3000/settings/integrations';
+// `getConsoleBaseUrl()` resolves to the origin only (e.g. from `APIFY_CONSOLE_BASE_URL`); the
+// `/settings/integrations` path is appended here rather than baked into the env-driven origin.
+const CONSOLE_BASE_URL = `${getConsoleBaseUrl()}/settings/integrations`;
 const CONSOLE_URL_ORIGIN = new URL(CONSOLE_BASE_URL).origin;
 
-const API_BASE_URL = CONSOLE_BASE_URL.includes('localhost') ? 'http://localhost:3333' : undefined;
+// Preserves the historical "Console on localhost implies API on :3333" workflow, but always
+// overridable by an explicit `APIFY_API_BASE_URL` (or, further up the chain, an explicit flag).
+const API_BASE_URL = resolveLoginApiBaseUrl(CONSOLE_URL_ORIGIN);
 
 // Not really checked right now, but it might come useful if we ever need to do some breaking changes
 const API_VERSION = 'v1';
@@ -227,7 +230,7 @@ export class AuthLoginCommand extends ApifyCommand<typeof AuthLoginCommand> {
 			info({ message: `Opening Apify Console at "${consoleUrl.href}"...` });
 			await open(consoleUrl.href);
 		} else {
-			console.log('Enter your Apify API token. You can find it at https://console.apify.com/settings/integrations');
+			console.log(`Enter your Apify API token. You can find it at ${CONSOLE_BASE_URL}`);
 
 			const tokenAnswer = await useMaskedInput({ message: 'token:' });
 			await tryToLogin(tokenAnswer);

--- a/src/commands/builds/info.ts
+++ b/src/commands/builds/info.ts
@@ -4,6 +4,7 @@ import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
 import { prettyPrintBytes } from '../../lib/commands/pretty-print-bytes.js';
 import { prettyPrintStatus } from '../../lib/commands/pretty-print-status.js';
+import { getConsoleBaseUrl } from '../../lib/consts.js';
 import { error, simpleLog } from '../../lib/outputs.js';
 import { DurationFormatter, getLoggedClientOrThrow, printJsonToStdout, TimestampFormatter } from '../../lib/utils.js';
 
@@ -103,7 +104,7 @@ export class BuildsInfoCommand extends ApifyCommand<typeof BuildsInfoCommand> {
 
 		message.push('');
 
-		const url = `https://console.apify.com/actors/${build.actId}/builds/${build.buildNumber}`;
+		const url = `${getConsoleBaseUrl()}/actors/${build.actId}/builds/${build.buildNumber}`;
 
 		message.push(`${chalk.blue('View in Apify Console')}: ${url}`);
 

--- a/src/commands/runs/info.ts
+++ b/src/commands/runs/info.ts
@@ -7,6 +7,7 @@ import { Flags } from '../../lib/command-framework/flags.js';
 import { prettyPrintBytes } from '../../lib/commands/pretty-print-bytes.js';
 import { prettyPrintStatus } from '../../lib/commands/pretty-print-status.js';
 import { CompactMode, ResponsiveTable } from '../../lib/commands/responsive-table.js';
+import { getConsoleBaseUrl } from '../../lib/consts.js';
 import { error, simpleLog } from '../../lib/outputs.js';
 import {
 	getLoggedClientOrThrow,
@@ -258,9 +259,10 @@ export class RunsInfoCommand extends ApifyCommand<typeof RunsInfoCommand> {
 
 		message.push('');
 
-		const url = `https://console.apify.com/actors/${run.actId}/runs/${run.id}`;
-		const datasetUrl = `https://console.apify.com/storage/datasets/${run.defaultDatasetId}`;
-		const keyValueStoreUrl = `https://console.apify.com/storage/key-value-stores/${run.defaultKeyValueStoreId}`;
+		const consoleBaseUrl = getConsoleBaseUrl();
+		const url = `${consoleBaseUrl}/actors/${run.actId}/runs/${run.id}`;
+		const datasetUrl = `${consoleBaseUrl}/storage/datasets/${run.defaultDatasetId}`;
+		const keyValueStoreUrl = `${consoleBaseUrl}/storage/key-value-stores/${run.defaultKeyValueStoreId}`;
 
 		message.push(`${chalk.blue('Export results')}: ${datasetUrl}`);
 		message.push(`${chalk.blue('View saved items')}: ${keyValueStoreUrl}`);

--- a/src/lib/commands/agent-output.ts
+++ b/src/lib/commands/agent-output.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 
 import { ACTOR_JOB_TERMINAL_STATUSES } from '@apify/consts';
 
-import { CommandExitCodes } from '../consts.js';
+import { CommandExitCodes, getConsoleBaseUrl } from '../consts.js';
 
 export type TerminalStatus = 'SUCCEEDED' | 'FAILED' | 'ABORTED' | 'TIMED-OUT';
 
@@ -96,15 +96,15 @@ export async function fetchLogTail(apifyClient: ApifyClient, jobId: string, maxL
 }
 
 export function consoleRunUrl(actorId: string, runId: string): string {
-	return `https://console.apify.com/actors/${actorId}/runs/${runId}`;
+	return `${getConsoleBaseUrl()}/actors/${actorId}/runs/${runId}`;
 }
 
 export function consoleBuildUrl(actorId: string, buildNumber: string): string {
-	return `https://console.apify.com/actors/${actorId}#/builds/${buildNumber}`;
+	return `${getConsoleBaseUrl()}/actors/${actorId}#/builds/${buildNumber}`;
 }
 
 export function consoleDatasetUrl(datasetId: string): string {
-	return `https://console.apify.com/storage/datasets/${datasetId}`;
+	return `${getConsoleBaseUrl()}/storage/datasets/${datasetId}`;
 }
 
 function statusColor(status: string): string {

--- a/src/lib/commands/run-result.ts
+++ b/src/lib/commands/run-result.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 
 import { ACTOR_JOB_STATUSES } from '@apify/consts';
 
-import { CommandExitCodes } from '../consts.js';
+import { CommandExitCodes, getConsoleBaseUrl } from '../consts.js';
 import { simpleLog } from '../outputs.js';
 import { printJsonToStdout } from '../utils.js';
 
@@ -20,18 +20,16 @@ const OPERATION_LABELS: Record<RunResultOperation, string> = {
 /** How many trailing log lines to surface as the failure reason. */
 const LOG_TAIL_LINES = 10;
 
-const CONSOLE_BASE_URL = 'https://console.apify.com';
-
 function actorUrl(actorId: string) {
-	return `${CONSOLE_BASE_URL}/actors/${actorId}`;
+	return `${getConsoleBaseUrl()}/actors/${actorId}`;
 }
 
 export function runUrl(actorId: string, runId: string) {
-	return `${CONSOLE_BASE_URL}/actors/${actorId}/runs/${runId}`;
+	return `${getConsoleBaseUrl()}/actors/${actorId}/runs/${runId}`;
 }
 
 function datasetUrl(datasetId: string) {
-	return `${CONSOLE_BASE_URL}/storage/datasets/${datasetId}`;
+	return `${getConsoleBaseUrl()}/storage/datasets/${datasetId}`;
 }
 
 function isSucceeded(run: ActorRun): boolean {

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -67,6 +67,22 @@ export const APIFY_CLIENT_DEFAULT_HEADERS: Record<string, string> = {
 	...(githubActionsRunUrl && { 'X-Apify-Github-Actions-Run-Url': githubActionsRunUrl }),
 };
 
+export const DEFAULT_CONSOLE_BASE_URL = 'https://console.apify.com';
+
+/**
+ * Resolves the Apify Console base URL (origin only), following the precedence:
+ * `APIFY_CONSOLE_BASE_URL` (if set) > the default `https://console.apify.com`.
+ *
+ * Every place the CLI prints or opens a Console link should compose its path/fragment onto this
+ * origin rather than hardcoding `https://console.apify.com`, so `APIFY_CONSOLE_BASE_URL` reaches
+ * all of them uniformly.
+ */
+export const getConsoleBaseUrl = (): string => {
+	const envValue = process.env.APIFY_CONSOLE_BASE_URL;
+
+	return envValue ? envValue.replace(/\/+$/, '') : DEFAULT_CONSOLE_BASE_URL;
+};
+
 export const MINIMUM_SUPPORTED_PYTHON_VERSION = '3.9.0';
 
 export const PYTHON_VENV_PATH = '.venv';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -138,14 +138,48 @@ const resolveToken = async (existingToken?: string): Promise<string | undefined>
 type CJSAxiosHeaders = import('axios', { with: { 'resolution-mode': 'require' } }).AxiosRequestConfig['headers'];
 
 /**
+ * Resolves the API base URL following the precedence: explicit flag/option > `APIFY_API_BASE_URL` >
+ * `APIFY_CLIENT_BASE_URL` (existing, lower-priority fallback) > the `apify-client` default.
+ */
+export const resolveApiBaseUrl = (explicitApiBaseUrl?: string): string | undefined =>
+	explicitApiBaseUrl || process.env.APIFY_API_BASE_URL || process.env.APIFY_CLIENT_BASE_URL || undefined;
+
+/**
+ * Resolves the public API base URL following the precedence: explicit flag/option >
+ * `APIFY_API_PUBLIC_BASE_URL` > the `apify-client` default. Independent of the API base URL.
+ */
+export const resolveApiPublicBaseUrl = (explicitApiPublicBaseUrl?: string): string | undefined =>
+	explicitApiPublicBaseUrl || process.env.APIFY_API_PUBLIC_BASE_URL || undefined;
+
+/**
+ * Resolves the API base URL the `login` command should default to. When the resolved Console origin
+ * is a localhost address and no API base URL env var (`APIFY_API_BASE_URL` or the legacy
+ * `APIFY_CLIENT_BASE_URL`) is set, the API defaults to `http://localhost:3333` so a local Console can
+ * authenticate against a local API. Any env override (or, further up the chain, an explicit flag/option)
+ * always wins over this default.
+ */
+export const resolveLoginApiBaseUrl = (
+	consoleOrigin: string,
+	envApiBaseUrl: string | undefined = resolveApiBaseUrl(),
+): string | undefined => {
+	if (envApiBaseUrl) return undefined;
+	return consoleOrigin.includes('localhost') ? 'http://localhost:3333' : undefined;
+};
+
+/**
  * Returns options for ApifyClient
  */
-export const getApifyClientOptions = async (token?: string, apiBaseUrl?: string): Promise<ApifyClientOptions> => {
+export const getApifyClientOptions = async (
+	token?: string,
+	apiBaseUrl?: string,
+	publicApiBaseUrl?: string,
+): Promise<ApifyClientOptions> => {
 	const resolvedToken = await resolveToken(token);
 
 	return {
 		token: resolvedToken,
-		baseUrl: apiBaseUrl || process.env.APIFY_CLIENT_BASE_URL,
+		baseUrl: resolveApiBaseUrl(apiBaseUrl),
+		publicBaseUrl: resolveApiPublicBaseUrl(publicApiBaseUrl),
 		requestInterceptors: [
 			(config) => {
 				config.headers ??= new AxiosHeaders() as CJSAxiosHeaders;
@@ -586,7 +620,8 @@ export const outputJobLog = async ({
 	apifyClient?: ApifyClient;
 }) => {
 	const { id: logId, status } = job;
-	const client = apifyClient || new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
+	const client =
+		apifyClient ?? new ApifyClient({ baseUrl: resolveApiBaseUrl(), publicBaseUrl: resolveApiPublicBaseUrl() });
 
 	// In case job was already done just output log
 	if (ACTOR_JOB_TERMINAL_STATUSES.includes(status as never)) {

--- a/test/local/lib/consts.test.ts
+++ b/test/local/lib/consts.test.ts
@@ -1,6 +1,34 @@
+import { getConsoleBaseUrl } from '../../../src/lib/consts.js';
 import { inputFileRegExp } from '../../../src/lib/input-key.js';
 
 describe('Consts', () => {
+	describe('getConsoleBaseUrl', () => {
+		const originalConsoleBaseUrl = process.env.APIFY_CONSOLE_BASE_URL;
+
+		afterEach(() => {
+			if (originalConsoleBaseUrl === undefined) {
+				delete process.env.APIFY_CONSOLE_BASE_URL;
+			} else {
+				process.env.APIFY_CONSOLE_BASE_URL = originalConsoleBaseUrl;
+			}
+		});
+
+		it('defaults to the production Console URL when unset', () => {
+			delete process.env.APIFY_CONSOLE_BASE_URL;
+			expect(getConsoleBaseUrl()).toBe('https://console.apify.com');
+		});
+
+		it('uses APIFY_CONSOLE_BASE_URL when set', () => {
+			process.env.APIFY_CONSOLE_BASE_URL = 'http://localhost:3000';
+			expect(getConsoleBaseUrl()).toBe('http://localhost:3000');
+		});
+
+		it('strips a trailing slash from the env value so path composition does not double up', () => {
+			process.env.APIFY_CONSOLE_BASE_URL = 'http://localhost:3000/';
+			expect(getConsoleBaseUrl()).toBe('http://localhost:3000');
+		});
+	});
+
 	describe('inputFileRegExp', () => {
 		const testValues = [
 			{

--- a/test/local/lib/utils.test.ts
+++ b/test/local/lib/utils.test.ts
@@ -1,14 +1,42 @@
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import type { ActorRun } from 'apify-client';
 import axios from 'axios';
 
 import { execWithLog } from '../../../src/lib/exec.js';
 import { ensureFolderExistsSync } from '../../../src/lib/files.js';
 import { inputFileRegExp } from '../../../src/lib/input-key.js';
-import { createActZip, downloadAndUnzip, getActorLocalFilePaths } from '../../../src/lib/utils.js';
+import {
+	createActZip,
+	downloadAndUnzip,
+	getActorLocalFilePaths,
+	getApifyClientOptions,
+	outputJobLog,
+	resolveApiBaseUrl,
+	resolveApiPublicBaseUrl,
+	resolveLoginApiBaseUrl,
+} from '../../../src/lib/utils.js';
+import { useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
 import { useTempPath } from '../../__setup__/hooks/useTempPath.js';
 import { withRetries } from '../../__setup__/hooks/withRetries.js';
+
+// `outputJobLog`'s fallback-client-construction site (when no `apifyClient` is passed) constructs
+// a real `ApifyClient` directly. Spy on the constructor (keeping every other export real) so we can
+// assert on the options it's called with, without needing a live client / network stream.
+const { apifyClientCtorSpy } = vi.hoisted(() => ({ apifyClientCtorSpy: vi.fn() }));
+
+vi.mock('apify-client', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('apify-client')>();
+	return {
+		...actual,
+		ApifyClient: class {
+			constructor(options: unknown) {
+				apifyClientCtorSpy(options);
+			}
+		},
+	};
+});
 
 const TEST_DIR = 'my-test-dir';
 const FOLDERS = ['my_test', 'my_test/test_in_test', 'my_next_test', '.dot_test'];
@@ -26,6 +54,149 @@ const FILES_IN_IGNORED_DIR = ['test_to_ignore/in_test_ignore.js'];
 const FILES_TO_IGNORE = ['ignored_module.js'];
 
 describe('Utils', () => {
+	describe('API base URL resolution', () => {
+		const originalEnv = {
+			APIFY_API_BASE_URL: process.env.APIFY_API_BASE_URL,
+			APIFY_CLIENT_BASE_URL: process.env.APIFY_CLIENT_BASE_URL,
+			APIFY_API_PUBLIC_BASE_URL: process.env.APIFY_API_PUBLIC_BASE_URL,
+		};
+
+		afterEach(() => {
+			for (const [key, value] of Object.entries(originalEnv)) {
+				if (value === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = value;
+				}
+			}
+		});
+
+		describe('resolveApiBaseUrl', () => {
+			it('resolves to undefined (client default) with nothing set', () => {
+				delete process.env.APIFY_API_BASE_URL;
+				delete process.env.APIFY_CLIENT_BASE_URL;
+				expect(resolveApiBaseUrl()).toBeUndefined();
+			});
+
+			it('uses APIFY_API_BASE_URL when no explicit value is given', () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				expect(resolveApiBaseUrl()).toBe('http://a.test');
+			});
+
+			it('an explicit value wins over APIFY_API_BASE_URL', () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				expect(resolveApiBaseUrl('http://explicit.test')).toBe('http://explicit.test');
+			});
+
+			it('APIFY_API_BASE_URL wins over APIFY_CLIENT_BASE_URL', () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				process.env.APIFY_CLIENT_BASE_URL = 'http://b.test';
+				expect(resolveApiBaseUrl()).toBe('http://a.test');
+			});
+
+			it('falls back to APIFY_CLIENT_BASE_URL when APIFY_API_BASE_URL is unset', () => {
+				delete process.env.APIFY_API_BASE_URL;
+				process.env.APIFY_CLIENT_BASE_URL = 'http://b.test';
+				expect(resolveApiBaseUrl()).toBe('http://b.test');
+			});
+
+			it('follows the full precedence chain: explicit > APIFY_API_BASE_URL > APIFY_CLIENT_BASE_URL > default', () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				process.env.APIFY_CLIENT_BASE_URL = 'http://b.test';
+				expect(resolveApiBaseUrl('http://explicit.test')).toBe('http://explicit.test');
+			});
+		});
+
+		describe('resolveApiPublicBaseUrl', () => {
+			it('resolves to undefined (client default) with nothing set', () => {
+				delete process.env.APIFY_API_PUBLIC_BASE_URL;
+				expect(resolveApiPublicBaseUrl()).toBeUndefined();
+			});
+
+			it('uses APIFY_API_PUBLIC_BASE_URL when no explicit value is given', () => {
+				process.env.APIFY_API_PUBLIC_BASE_URL = 'http://pub.test';
+				expect(resolveApiPublicBaseUrl()).toBe('http://pub.test');
+			});
+
+			it('an explicit value wins over APIFY_API_PUBLIC_BASE_URL', () => {
+				process.env.APIFY_API_PUBLIC_BASE_URL = 'http://pub.test';
+				expect(resolveApiPublicBaseUrl('http://explicit.test')).toBe('http://explicit.test');
+			});
+
+			it('is independent of APIFY_API_BASE_URL', () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				delete process.env.APIFY_API_PUBLIC_BASE_URL;
+				expect(resolveApiBaseUrl()).toBe('http://a.test');
+				expect(resolveApiPublicBaseUrl()).toBeUndefined();
+			});
+		});
+
+		describe('resolveLoginApiBaseUrl', () => {
+			it('defaults to :3333 when the Console origin is localhost and no env override is set', () => {
+				delete process.env.APIFY_API_BASE_URL;
+				delete process.env.APIFY_CLIENT_BASE_URL;
+				expect(resolveLoginApiBaseUrl('http://localhost:3000', undefined)).toBe('http://localhost:3333');
+			});
+
+			it('does not apply the :3333 default when the Console origin is not localhost', () => {
+				delete process.env.APIFY_API_BASE_URL;
+				delete process.env.APIFY_CLIENT_BASE_URL;
+				expect(resolveLoginApiBaseUrl('https://console.apify.com', undefined)).toBeUndefined();
+			});
+
+			it('is overridden by APIFY_API_BASE_URL even when the Console origin is localhost', () => {
+				expect(resolveLoginApiBaseUrl('http://localhost:3000', 'http://other.test')).toBeUndefined();
+			});
+
+			it('is overridden by the legacy APIFY_CLIENT_BASE_URL even when the Console origin is localhost', () => {
+				delete process.env.APIFY_API_BASE_URL;
+				process.env.APIFY_CLIENT_BASE_URL = 'http://legacy.test';
+				expect(resolveLoginApiBaseUrl('http://localhost:3000', undefined)).toBeUndefined();
+			});
+		});
+
+		describe('getApifyClientOptions', () => {
+			// getApifyClientOptions() resolves a token from stored credentials when none is passed,
+			// so isolate it from the real ~/.apify auth file / OS keyring, matching other tests that
+			// exercise credential-reading code paths.
+			useAuthSetup();
+
+			it('forwards the resolved API base URL and public base URL', async () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				process.env.APIFY_API_PUBLIC_BASE_URL = 'http://pub.test';
+				const options = await getApifyClientOptions();
+				expect(options.baseUrl).toBe('http://a.test');
+				expect(options.publicBaseUrl).toBe('http://pub.test');
+			});
+
+			it('an explicit apiBaseUrl argument wins over the env var', async () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				const options = await getApifyClientOptions(undefined, 'http://explicit.test');
+				expect(options.baseUrl).toBe('http://explicit.test');
+			});
+		});
+
+		describe('outputJobLog fallback client construction', () => {
+			beforeEach(() => {
+				apifyClientCtorSpy.mockClear();
+			});
+
+			it('constructs the fallback ApifyClient with the resolved base URL and public base URL when no apifyClient is given', async () => {
+				process.env.APIFY_API_BASE_URL = 'http://a.test';
+				process.env.APIFY_API_PUBLIC_BASE_URL = 'http://pub.test';
+
+				// A terminal job status with APIFY_NO_LOGS_IN_TESTS set (set globally by vitest.config.ts)
+				// makes outputJobLog return right after constructing the fallback client, with no network I/O.
+				await outputJobLog({ job: { id: 'test-job-id', status: 'SUCCEEDED' } as unknown as ActorRun });
+
+				expect(apifyClientCtorSpy).toHaveBeenCalledWith({
+					baseUrl: 'http://a.test',
+					publicBaseUrl: 'http://pub.test',
+				});
+			});
+		});
+	});
+
 	describe('createActZip()', () => {
 		const { tmpPath, joinPath, beforeAllCalls, afterAllCalls } = useTempPath(TEST_DIR, {
 			create: true,


### PR DESCRIPTION
## Description
The Apify Console URL was hardcoded across many commands (8 sites), and the API base URL could only be overridden through the older `APIFY_CLIENT_BASE_URL` variable. Local, staging, and custom-port setups were awkward, and there was no way to redirect Console links at all.

- **API base URL:** explicit flag > `APIFY_API_BASE_URL` > `APIFY_CLIENT_BASE_URL` (kept as a lower-priority fallback for existing users) > default.
- **Public API base URL:** forwarded from `APIFY_API_PUBLIC_BASE_URL` (independent of the API base) via the same `getApifyClientOptions` chokepoint, so a locally-pointed CLI reaches a local public API.
- **Console URL:** every printed/opened Console link is composed from a single `APIFY_CONSOLE_BASE_URL` resolver (origin only, default `https://console.apify.com`), preserving each link's own path and fragment (e.g. `/settings/integrations`, `#/builds/`).
- **Preserved workflow:** the login "Console on localhost ⇒ API on `localhost:3333`" default still applies, but is now overridable by any API-base env var (`APIFY_API_BASE_URL` or the legacy `APIFY_CLIENT_BASE_URL`) or an explicit flag.

Ports are just part of the URL. **Setting nothing reproduces today's behavior exactly.**

### Context

This is one of three sibling PRs applying the API / public-API env-var contract across the Apify clients and CLI. Separate repos, no overlapping files:

- apify-cli (this PR): apify/apify-cli#1275
- apify-client-js: apify/apify-client-js#967
- apify-client-python: apify/apify-client-python#948

