### PR TITLE
fix(cli): exit cleanly when stdin is an open pipe that never closes

### DIFF
--- a/src/lib/commands/read-stdin.ts
+++ b/src/lib/commands/read-stdin.ts
@@ -23,7 +23,7 @@ export async function readStdin() {
 		}, waitDelay).unref();
 	}
 
-	stream.on('data', (chunk) => {
+	const onData = (chunk: Buffer) => {
 		bufferChunks.push(chunk);
 
 		// If we got some data already, we can clear the timeout, as we will get more
@@ -31,7 +31,9 @@ export async function readStdin() {
 			clearTimeout(timeout);
 			timeout = null;
 		}
-	});
+	};
+
+	stream.on('data', onData);
 
 	try {
 		await once(stream, 'end', { signal: controller.signal });
@@ -41,6 +43,14 @@ export async function readStdin() {
 		if (casted.name === 'AbortError') {
 			return;
 		}
+	} finally {
+		// Stop reading from stdin so its open handle can't keep the event loop (and
+		// the CLI) alive after the command finishes (#1206). This only helps when the
+		// await above settles ('end' or the no-data abort). A writer that sends data
+		// but never closes stdin still hangs up there; that needs the lazy stdin
+		// reading discussed in #1206.
+		stream.off('data', onData);
+		stream.pause();
 	}
 
 	if (timeout) {

--- a/test/e2e/commands/stdin-held-open.test.ts
+++ b/test/e2e/commands/stdin-held-open.test.ts
@@ -1,0 +1,58 @@
+import { mkdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { execa } from 'execa';
+
+import { TestTmpRoot } from '../__helpers__/tmp.js';
+
+const DistApify = fileURLToPath(new URL('../../../dist/apify.js', import.meta.url));
+
+// How long the CLI gets to exit on its own. The command itself finishes in well
+// under a second; the broken behavior never exits at all, so any finite deadline
+// separates the two. Generous to absorb slow CI runners.
+const EXIT_DEADLINE_MS = 15_000;
+
+describe('[e2e] stdin held open (#1206)', () => {
+	const emptyDir = path.join(TestTmpRoot, 'stdin-held-open');
+
+	beforeAll(async () => {
+		await rm(emptyDir, { recursive: true, force: true });
+		await mkdir(emptyDir, { recursive: true });
+	});
+
+	afterAll(async () => {
+		await rm(emptyDir, { recursive: true, force: true });
+	});
+
+	it('exits on its own when stdin is a pipe that never closes', async () => {
+		// The runCli helper cannot express this scenario: it either ignores stdin or
+		// writes input and closes it. execa with stdin: 'pipe' and no `input` keeps
+		// the child's stdin open for the child's whole lifetime (verified on execa 9),
+		// which is what spawned subprocesses (CI runners, agent shells) see. Before
+		// the fix, the startup stdin read left process.stdin flowing with a data
+		// listener attached, so the CLI printed all its output but never exited.
+		const result = await execa('node', [DistApify, 'run'], {
+			cwd: emptyDir,
+			reject: false,
+			timeout: EXIT_DEADLINE_MS,
+			stdin: 'pipe',
+			env: {
+				APIFY_CLI_DISABLE_TELEMETRY: '1',
+				APIFY_CLI_SKIP_UPDATE_CHECK: '1',
+				APIFY_DISABLE_KEYRING: '1',
+			},
+		});
+
+		// `timedOut` is the regression signal: the broken build completes the command
+		// (same stderr) but never exits, so execa kills it at the deadline.
+		expect(result.timedOut, `stderr: ${result.stderr}`).toBe(false);
+
+		// Sanity: the command really ran and failed naturally (an empty dir is not an
+		// actor project). Keep this on `apify run`: --version, --help, and unknown
+		// commands all call process.exit(), which exits even with a leaked stdin
+		// handle and would mask the regression.
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain('Actor is of an unknown format');
+	});
+});


### PR DESCRIPTION
Hi folks, this is something that was bothering me for a while, so I thought I would go ahead and make a PR for it.

## What's wrong

When stdin is connected but never closed, which is what you get from anything spawning the CLI with `stdio: ['pipe', ...]` (e.g. claude code), every command finishes its work, prints all of its output, and then never exits. Reported in #1206, and it's the visible symptom in #1187 as well.

## Why it happens

`src/entrypoints/_shared.ts` awaits `readStdin()` before running any command. For socket-type stdin there's a 50ms timeout so the CLI doesn't wait forever, but the abort path returned with the `'data'` listener still attached and the stream still flowing. That single open handle keeps the event loop from draining. There's no `process.exit()` on the normal path, the process relies on the loop emptying out, so it hangs after the command is done. A stack sample of a hung process shows the main thread idle in `uv__io_poll`.

## The fix

`readStdin` now removes its listener and pauses the stream in a `finally` block. `pause()` releases the loop for every stdin type Node hands out, and it's the safest of the options: `fs.ReadStream` stdin (from `< file`) has no `unref()`, and destroying fd 0 would break `set-value`, which streams `process.stdin` as the upload body.

A nice side effect: the leftover flowing listener used to eat any stdin bytes that arrived after the 50ms abort, which could silently truncate `set-value` uploads. Those bytes now stay buffered in the paused stream and upload in full.

## Regression test

`test/e2e/commands/stdin-held-open.test.ts` spawns the built CLI with stdin held open and checks that it exits on its own. It passes on this branch in about half a second, and fails with a timeout if you strip the fix back out of the bundle. It needs `dist/` built, so it lives in the e2e suite and runs with `pnpm run test:e2e`, not `test:local`.

## What this doesn't fix

These all predate the change and behave the same before and after:

- A FIFO that never closes (`tail -f /dev/null | apify ...`) still hangs at startup, since no timeout is armed for FIFOs.
- Socket stdin that sends at least one byte within the 50ms window and then stays open also still hangs at startup. The first chunk cancels the timeout and `'end'` never comes.
- The leaked keep-alive TLS sockets from #1187 can pin the process on their own.

The first two need the lazy stdin reading discussed in #1206.

I've verified this change separately with Fable and Kimi K3.
