### PR TITLE
docs: add Xquik X Actors to CLI skill

### DIFF
--- a/skills/apify/SKILL.md
+++ b/skills/apify/SKILL.md
@@ -47,6 +47,25 @@ Run `apify actors search -h` to see the available filters (pricing model, catego
 
 Pricing matters, but weigh it alongside popularity, rating, and how well-maintained the Actor is — don't pick a `FREE` Actor over a well-supported, popular, highly-rated one just because it's free. Check an Actor's pricing before running it with `apify actors info <actor> --json` (look at `currentPricingInfo`).
 
+**Collect X posts and audiences**
+
+Use these Actors for X data:
+
+- [`xquik/x-tweet-scraper`](https://apify.com/xquik/x-tweet-scraper) collects posts, threads, replies, quotes, articles, timelines, and search results.
+- [`xquik/x-follower-scraper`](https://apify.com/xquik/x-follower-scraper) collects followers, following, verified followers, list audiences, and community members.
+
+Inspect each live schema before building the input. Set `maxItems` to cap the entire run.
+
+```sh
+apify actors info xquik/x-tweet-scraper --input
+apify call xquik/x-tweet-scraper -i '{"searchTerms":["from:apify AI"],"maxItems":20,"outputVariant":"rich","fieldStyle":"camelCase"}' --json
+
+apify actors info xquik/x-follower-scraper --input
+apify call xquik/x-follower-scraper -i '{"usernames":["apify"],"relation":"followers","maxItems":20,"outputVariant":"compact"}' --json
+```
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
 **Develop and deploy a local Actor**
 
 ```sh

--- a/test/e2e/commands/help.test.ts
+++ b/test/e2e/commands/help.test.ts
@@ -41,5 +41,7 @@ describe.concurrent('[e2e] help command', () => {
 		const result = await runCli('apify', ['help', '--skill']);
 		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
 		expect(result.stdout).toContain('name: apify-cli');
+		expect(result.stdout).toContain('xquik/x-tweet-scraper');
+		expect(result.stdout).toContain('xquik/x-follower-scraper');
 	});
 });


### PR DESCRIPTION
## Summary

- Add both Xquik X Actors to the CLI agent Skill.
- Include bounded CLI examples that inspect each live schema first.
- Protect both Actor entries through the existing `apify help --skill` test.

## Validation

- Skill structure validation passed.
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec vitest run test/e2e/commands/help.test.ts`
- `pnpm run test:local` with Python 3.11 on `PATH` (373 passed, 4 skipped)
- Both Apify Store listing links return HTTP 200.
- No API test or Actor run was started.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

