### PR TITLE
feat: surface `apify help --skill` in the main help menu

### DIFF
--- a/src/lib/command-framework/help.ts
+++ b/src/lib/command-framework/help.ts
@@ -196,19 +196,13 @@ export function renderMainHelpMenu(entrypoint: string) {
 		result.push('');
 	}
 
-	const learnMoreLines = [
+	result.push(
 		chalk.bold('LEARN MORE'),
 		`  Use '${entrypoint} <command> --help' for more information about a command.`,
 		`  Read the docs at https://docs.apify.com/cli.`,
-	];
-
-	if (entrypoint !== 'actor') {
-		learnMoreLines.push(
-			`  Run 'apify help --skill' to print the Apify CLI agent skill (guidance for driving 'apify' from agents).`,
-		);
-	}
-
-	result.push(...learnMoreLines, '');
+		`  Run '${entrypoint} help --skill' to print the Apify CLI agent skill (guidance for driving 'apify' from agents).`,
+		'',
+	);
 
 	result.push(
 		chalk.bold('TROUBLESHOOTING'),

--- a/src/lib/command-framework/help.ts
+++ b/src/lib/command-framework/help.ts
@@ -196,12 +196,19 @@ export function renderMainHelpMenu(entrypoint: string) {
 		result.push('');
 	}
 
-	result.push(
+	const learnMoreLines = [
 		chalk.bold('LEARN MORE'),
 		`  Use '${entrypoint} <command> --help' for more information about a command.`,
 		`  Read the docs at https://docs.apify.com/cli.`,
-		'',
-	);
+	];
+
+	if (entrypoint !== 'actor') {
+		learnMoreLines.push(
+			`  Run 'apify help --skill' to print the Apify CLI agent skill (guidance for driving 'apify' from agents).`,
+		);
+	}
+
+	result.push(...learnMoreLines, '');
 
 	result.push(
 		chalk.bold('TROUBLESHOOTING'),

--- a/test/local/lib/command-framework/help.test.ts
+++ b/test/local/lib/command-framework/help.test.ts
@@ -233,5 +233,17 @@ describe('Help rendering', () => {
 			expect(output).toContain('$ actor get-input');
 			expect(output).toContain("Use 'actor <command> --help'");
 		});
+
+		test('mentions apify help --skill for the apify entrypoint', () => {
+			const output = stripAnsi(renderMainHelpMenu('apify'));
+
+			expect(output).toContain('apify help --skill');
+		});
+
+		test('does not mention apify help --skill for the actor entrypoint', () => {
+			const output = stripAnsi(renderMainHelpMenu('actor'));
+
+			expect(output).not.toContain('help --skill');
+		});
 	});
 });

--- a/test/local/lib/command-framework/help.test.ts
+++ b/test/local/lib/command-framework/help.test.ts
@@ -234,16 +234,16 @@ describe('Help rendering', () => {
 			expect(output).toContain("Use 'actor <command> --help'");
 		});
 
-		test('mentions apify help --skill for the apify entrypoint', () => {
+		test('mentions help --skill for the apify entrypoint', () => {
 			const output = stripAnsi(renderMainHelpMenu('apify'));
 
-			expect(output).toContain('apify help --skill');
+			expect(output).toContain("Run 'apify help --skill'");
 		});
 
-		test('does not mention apify help --skill for the actor entrypoint', () => {
+		test('mentions help --skill for the actor entrypoint', () => {
 			const output = stripAnsi(renderMainHelpMenu('actor'));
 
-			expect(output).not.toContain('help --skill');
+			expect(output).toContain("Run 'actor help --skill'");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- `apify help --skill` prints the Apify CLI agent skill, but `HelpCommand` is `hidden`, so nothing pointed to it.
- Adds a `LEARN MORE` line in `renderMainHelpMenu` mentioning `apify help --skill`, shown only for the `apify` entrypoint (the skill is about driving `apify` from agents, so it doesn't apply to the `actor` runtime CLI).

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run format`
- [x] `pnpm run build`
- [x] `pnpm run test:local` (pre-existing failures in 2 Python-related tests are unrelated to this change — local Python is 3.9.6, tests require 3.11+)
- [x] Added unit tests asserting the line appears for `apify` and not for `actor`
- [x] Manually ran `node dist/apify.js help` and `node dist/actor.js help` to confirm output

Closes #1301