### PR TITLE
fix(cli): read stdin lazily so open pipes don't hang the CLI

### DIFF
--- a/src/commands/actor/push-data.ts
+++ b/src/commands/actor/push-data.ts
@@ -1,7 +1,7 @@
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
 import { APIFY_STORAGE_TYPES, getApifyStorageClient, getDefaultStorageId } from '../../lib/actor.js';
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
+import { readStdin } from '../../lib/commands/read-stdin.js';
 import { error } from '../../lib/outputs.js';
 
 export class ActorPushDataCommand extends ApifyCommand<typeof ActorPushDataCommand> {
@@ -34,7 +34,7 @@ export class ActorPushDataCommand extends ApifyCommand<typeof ActorPushDataComma
 	async run() {
 		const { item: _item } = this.args;
 
-		const item = _item || cachedStdinInput;
+		const item = _item || (await readStdin());
 
 		if (!item) {
 			error({ message: 'No item was provided.' });

--- a/src/commands/datasets/push-items.ts
+++ b/src/commands/datasets/push-items.ts
@@ -1,9 +1,9 @@
 import type { ApifyApiError } from 'apify-client';
 import chalk from 'chalk';
 
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
+import { readStdin } from '../../lib/commands/read-stdin.js';
 import { tryToGetDataset } from '../../lib/commands/storages.js';
 import { error, success } from '../../lib/outputs.js';
 import { getLoggedClientOrThrow } from '../../lib/utils.js';
@@ -55,7 +55,7 @@ export class DatasetsPushDataCommand extends ApifyCommand<typeof DatasetsPushDat
 
 		let parsedData: Record<string, unknown> | Record<string, unknown>[];
 
-		const item = _item || cachedStdinInput;
+		const item = _item || (await readStdin());
 
 		if (!item) {
 			error({ message: 'No items were provided.' });

--- a/src/entrypoints/_shared.ts
+++ b/src/entrypoints/_shared.ts
@@ -11,15 +11,12 @@ import type { BuiltApifyCommand } from '../lib/command-framework/apify-command.j
 import { commandRegistry, internalRunCommand } from '../lib/command-framework/apify-command.js';
 import { CommandError } from '../lib/command-framework/CommandError.js';
 import { renderMainHelpMenu } from '../lib/command-framework/help.js';
-import { readStdin } from '../lib/commands/read-stdin.js';
 import { SUPPORTED_NODEJS_VERSION } from '../lib/consts.js';
 import { useCLIMetadata } from '../lib/hooks/useCLIMetadata.js';
 import { shouldSkipVersionCheck } from '../lib/hooks/useCLIVersionCheck.js';
 import { useCommandSuggestions } from '../lib/hooks/useCommandSuggestions.js';
 import { error } from '../lib/outputs.js';
 import { cliDebugPrint } from '../lib/utils/cliDebugPrint.js';
-
-export const cachedStdinInput = await readStdin();
 
 const cliMetadata = useCLIMetadata();
 

--- a/src/lib/command-framework/CommandError.ts
+++ b/src/lib/command-framework/CommandError.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
+import { peekStdin } from '../commands/read-stdin.js';
 import { useCLIMetadata } from '../hooks/useCLIMetadata.js';
 import type { BuiltApifyCommand } from './apify-command.js';
 import { selectiveRenderHelpForCommand } from './help.js';
@@ -218,7 +218,7 @@ export class CommandError extends Error {
 					'',
 					`- CLI version: \`${cliMetadata.fullVersionString}\``,
 					`- CLI debug logs (process.env.APIFY_CLI_DEBUG): ${process.env.APIFY_CLI_DEBUG ? 'Enabled' : 'Disabled'}`,
-					`- Stdin data? ${cachedStdinInput ? 'Yes' : 'No'}`,
+					`- Stdin data? ${peekStdin() ? 'Yes' : 'No'}`,
 				].join('\n');
 			}
 		}

--- a/src/lib/command-framework/CommandError.ts
+++ b/src/lib/command-framework/CommandError.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
+import { peekStdin } from '../commands/read-stdin.js';
 import { useCLIMetadata } from '../hooks/useCLIMetadata.js';
 import type { BuiltApifyCommand } from './apify-command.js';
 import { selectiveRenderHelpForCommand } from './help.js';
@@ -225,7 +225,7 @@ export class CommandError extends Error {
 					'',
 					`- CLI version: \`${cliMetadata.fullVersionString}\``,
 					`- CLI debug logs (process.env.APIFY_CLI_DEBUG): ${process.env.APIFY_CLI_DEBUG ? 'Enabled' : 'Disabled'}`,
-					`- Stdin data? ${cachedStdinInput ? 'Yes' : 'No'}`,
+					`- Stdin data? ${peekStdin() ? 'Yes' : 'No'}`,
 				].join('\n');
 			}
 		}

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -9,7 +9,7 @@ import indentString from 'indent-string';
 import widestLine from 'widest-line';
 import wrapAnsi from 'wrap-ansi';
 
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
+import { readStdin } from '../commands/read-stdin.js';
 import { keepStdoutClean } from '../exec.js';
 import { detectAiAgent, detectCi, detectIsInteractive } from '../hooks/telemetry/detectEnvironment.js';
 import type { TrackEventMap } from '../hooks/telemetry/trackEvent.js';
@@ -368,7 +368,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 							this.args[camelCasedName] = String(rawArg);
 
 							if (rawArg === '-' && builderData.stdin) {
-								this.args[camelCasedName] = this._handleStdin(builderData.stdin);
+								this.args[camelCasedName] = await this._handleStdin(builderData.stdin);
 							}
 
 							if (builderData.catchAll) {
@@ -389,7 +389,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 			return;
 		}
 
-		this._parseFlags(rawFlags, rawTokens);
+		await this._parseFlags(rawFlags, rawTokens);
 
 		try {
 			await this.run();
@@ -464,7 +464,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 		return flagKey;
 	}
 
-	private _parseFlags(rawFlags: ParseResult['values'], rawTokens: ParseResult['tokens']) {
+	private async _parseFlags(rawFlags: ParseResult['values'], rawTokens: ParseResult['tokens']) {
 		if (!this.ctor.flags) {
 			return;
 		}
@@ -594,7 +594,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 							flagThatUsedStdin = baseFlagName;
 
-							this.flags[camelCasedName] = this._handleStdin(builderData.stdin);
+							this.flags[camelCasedName] = await this._handleStdin(builderData.stdin);
 						}
 
 						break;
@@ -719,12 +719,14 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 		});
 	}
 
-	private _handleStdin(mode: StdinMode) {
+	private async _handleStdin(mode: StdinMode) {
+		const input = await readStdin();
+
 		switch (mode) {
 			case StdinMode.Stringified:
-				return (cachedStdinInput?.toString('utf8') ?? '').trim();
+				return (input?.toString('utf8') ?? '').trim();
 			default:
-				return cachedStdinInput;
+				return input;
 		}
 	}
 

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -9,7 +9,7 @@ import indentString from 'indent-string';
 import widestLine from 'widest-line';
 import wrapAnsi from 'wrap-ansi';
 
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
+import { readStdin } from '../commands/read-stdin.js';
 import { detectAiAgent, detectCi, detectIsInteractive } from '../hooks/telemetry/detectEnvironment.js';
 import type { TrackEventMap } from '../hooks/telemetry/trackEvent.js';
 import { trackEvent } from '../hooks/telemetry/trackEvent.js';
@@ -360,7 +360,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 							this.args[camelCasedName] = String(rawArg);
 
 							if (rawArg === '-' && builderData.stdin) {
-								this.args[camelCasedName] = this._handleStdin(builderData.stdin);
+								this.args[camelCasedName] = await this._handleStdin(builderData.stdin);
 							}
 
 							if (builderData.catchAll) {
@@ -381,7 +381,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 			return;
 		}
 
-		this._parseFlags(rawFlags, rawTokens);
+		await this._parseFlags(rawFlags, rawTokens);
 
 		try {
 			await this.run();
@@ -450,7 +450,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 		return flagKey;
 	}
 
-	private _parseFlags(rawFlags: ParseResult['values'], rawTokens: ParseResult['tokens']) {
+	private async _parseFlags(rawFlags: ParseResult['values'], rawTokens: ParseResult['tokens']) {
 		if (!this.ctor.flags) {
 			return;
 		}
@@ -580,7 +580,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 							flagThatUsedStdin = baseFlagName;
 
-							this.flags[camelCasedName] = this._handleStdin(builderData.stdin);
+							this.flags[camelCasedName] = await this._handleStdin(builderData.stdin);
 						}
 
 						break;
@@ -705,12 +705,14 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 		});
 	}
 
-	private _handleStdin(mode: StdinMode) {
+	private async _handleStdin(mode: StdinMode) {
+		const input = await readStdin();
+
 		switch (mode) {
 			case StdinMode.Stringified:
-				return (cachedStdinInput?.toString('utf8') ?? '').trim();
+				return (input?.toString('utf8') ?? '').trim();
 			default:
-				return cachedStdinInput;
+				return input;
 		}
 	}
 

--- a/src/lib/commands/read-stdin.ts
+++ b/src/lib/commands/read-stdin.ts
@@ -2,10 +2,32 @@ import { once } from 'node:events';
 
 import { useStdin } from '../hooks/useStdin.js';
 
-export async function readStdin() {
-	const dataRef = await useStdin();
+let readPromise: Promise<Buffer | undefined> | undefined;
+let readResult: Buffer | undefined;
 
-	const { hasData, waitDelay, stream } = dataRef;
+/**
+ * Reads stdin to its end, at most once per process. Callers must only call this when the command
+ * actually wants stdin data — a pipe that stays open never ends, so this waits for as long as the
+ * writer keeps it open (#1206).
+ */
+export async function readStdin() {
+	readPromise ??= _readStdin().then((data) => {
+		readResult = data;
+		return data;
+	});
+
+	return readPromise;
+}
+
+/**
+ * Stdin data read so far, without triggering a read. For diagnostics only.
+ */
+export function peekStdin() {
+	return readResult;
+}
+
+async function _readStdin() {
+	const { hasData, waitDelay, stream } = await useStdin();
 
 	if (!hasData) {
 		return;
@@ -45,10 +67,7 @@ export async function readStdin() {
 		}
 	} finally {
 		// Stop reading from stdin so its open handle can't keep the event loop (and
-		// the CLI) alive after the command finishes (#1206). This only helps when the
-		// await above settles ('end' or the no-data abort). A writer that sends data
-		// but never closes stdin still hangs up there; that needs the lazy stdin
-		// reading discussed in #1206.
+		// the CLI) alive after the command finishes (#1206).
 		stream.off('data', onData);
 		stream.pause();
 	}
@@ -56,9 +75,6 @@ export async function readStdin() {
 	if (timeout) {
 		clearTimeout(timeout);
 	}
-
-	// Mark further uses of useStdin / readStdin as having no more data since we've read it all
-	dataRef.hasData = false;
 
 	const concat = Buffer.concat(bufferChunks);
 

--- a/src/lib/commands/read-stdin.ts
+++ b/src/lib/commands/read-stdin.ts
@@ -2,16 +2,32 @@ import { once } from 'node:events';
 
 import { useStdin } from '../hooks/useStdin.js';
 
+/**
+ * How long an implicit read waits for stdin to say something. Long enough for a writer that has to
+ * fetch or compute its first bytes, short enough that a pipe with nothing behind it does not look
+ * like a hang.
+ */
+const IMPLICIT_STDIN_IDLE_TIMEOUT_MILLIS = 2_000;
+
 let readPromise: Promise<Buffer | undefined> | undefined;
 let readResult: Buffer | undefined;
 
+export interface ReadStdinOptions {
+	/**
+	 * Stop at the first quiet gap instead of waiting for the writer to close stdin. Set it where
+	 * stdin is a fallback the user never asked for, so the command cannot hang on a pipe it merely
+	 * inherited (#1206). Leave it off for an explicit `-`, which waits for as long as the writer
+	 * wants, the way `cat` does.
+	 */
+	implicit?: boolean;
+}
+
 /**
- * Reads stdin to its end, at most once per process. Callers must only call this when the command
- * actually wants stdin data — a pipe that stays open never ends, so this waits for as long as the
- * writer keeps it open (#1206).
+ * Reads stdin, at most once per process. Call it only when the command actually wants stdin data.
+ * The first call decides the options; later ones reuse its result.
  */
-export async function readStdin() {
-	readPromise ??= _readStdin().then((data) => {
+export async function readStdin(options: ReadStdinOptions = {}) {
+	readPromise ??= _readStdin(options).then((data) => {
 		readResult = data;
 		return data;
 	});
@@ -20,18 +36,24 @@ export async function readStdin() {
 }
 
 /**
- * Stdin data read so far, without triggering a read. For diagnostics only.
+ * Stdin data from a completed read, without starting one. Undefined until a read finishes. For
+ * diagnostics only.
  */
 export function peekStdin() {
 	return readResult;
 }
 
-async function _readStdin() {
+async function _readStdin({ implicit }: ReadStdinOptions) {
 	const { hasData, waitDelay, stream } = await useStdin();
 
 	if (!hasData) {
 		return;
 	}
+
+	// `waitDelay` guards the first byte on a socket, and nothing else. An implicit read needs more
+	// than that: an inherited pipe may send nothing at all, and may stay open after it does, so
+	// waiting for the end of the stream never finishes (#1206).
+	const idleTimeout = implicit ? IMPLICIT_STDIN_IDLE_TIMEOUT_MILLIS : waitDelay;
 
 	const bufferChunks: Buffer[] = [];
 
@@ -39,19 +61,31 @@ async function _readStdin() {
 
 	let timeout: NodeJS.Timeout | null = null;
 
-	if (waitDelay) {
-		timeout = setTimeout(() => {
-			controller.abort();
-		}, waitDelay).unref();
-	}
+	const armTimeout = () => {
+		if (idleTimeout) {
+			timeout = setTimeout(() => controller.abort(), idleTimeout).unref();
+		}
+	};
+
+	const disarmTimeout = () => {
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = null;
+		}
+	};
+
+	armTimeout();
 
 	const onData = (chunk: Buffer) => {
 		bufferChunks.push(chunk);
 
-		// If we got some data already, we can clear the timeout, as we will get more
-		if (timeout) {
-			clearTimeout(timeout);
-			timeout = null;
+		disarmTimeout();
+
+		// An implicit read has no other way to tell that the writer is done, so every chunk restarts
+		// the clock. An explicit one waits for the real end of the stream, and its deadline only ever
+		// guarded the first byte.
+		if (implicit) {
+			armTimeout();
 		}
 	};
 
@@ -62,7 +96,9 @@ async function _readStdin() {
 	} catch (error) {
 		const casted = error as Error;
 
-		if (casted.name === 'AbortError') {
+		// An explicit read that runs out its deadline saw nothing at all, so it has nothing to give
+		// back. An implicit one keeps whatever arrived before stdin went quiet.
+		if (casted.name === 'AbortError' && !implicit) {
 			return;
 		}
 	} finally {
@@ -72,9 +108,7 @@ async function _readStdin() {
 		stream.pause();
 	}
 
-	if (timeout) {
-		clearTimeout(timeout);
-	}
+	disarmTimeout();
 
 	const concat = Buffer.concat(bufferChunks);
 

--- a/src/lib/commands/resolve-input.ts
+++ b/src/lib/commands/resolve-input.ts
@@ -4,10 +4,10 @@ import process from 'node:process';
 
 import mime from 'mime';
 
-import { cachedStdinInput } from '../../entrypoints/_shared.js';
 import { CommandExitCodes } from '../consts.js';
 import { error } from '../outputs.js';
 import { getLocalInput } from '../utils.js';
+import { readStdin } from './read-stdin.js';
 
 interface InputOverrideOptions {
 	schemaHint?: string;
@@ -59,7 +59,7 @@ export async function getInputOverride(
 
 	if (!inputFlag && !inputFileFlag) {
 		// Try reading stdin
-		const stdin = cachedStdinInput;
+		const stdin = await readStdin();
 
 		if (stdin) {
 			try {

--- a/src/lib/commands/resolve-input.ts
+++ b/src/lib/commands/resolve-input.ts
@@ -58,8 +58,9 @@ export async function getInputOverride(
 	const { schemaHint } = options;
 
 	if (!inputFlag && !inputFileFlag) {
-		// Try reading stdin
-		const stdin = await readStdin();
+		// Nobody asked for stdin here, so it must not block: this command is reachable with a pipe
+		// it only inherited from whatever spawned it.
+		const stdin = await readStdin({ implicit: true });
 
 		if (stdin) {
 			try {

--- a/src/lib/hooks/user-confirmations/_stdinCheckWrapper.ts
+++ b/src/lib/hooks/user-confirmations/_stdinCheckWrapper.ts
@@ -39,11 +39,13 @@ export function stdinCheckWrapper<Fn extends (...args: any[]) => any>(
 	}: StdinCheckWrapperOptions = {},
 ): (...args: NewFunctionArgs<Fn>) => Promise<Awaited<ReturnType<Fn>>> {
 	return async (input, ...rest) => {
-		const { isTTY, hasData } = await useStdin();
+		const { isTTY } = await useStdin();
 
 		const casted = input as StdinCheckWrapperInput<Awaited<ReturnType<Fn>>>;
 
-		if (isCI || (!isTTY && !hasData)) {
+		// Prompts need a terminal to read the answer from. Piped stdin is command input, not an
+		// answer source — before stdin became lazy (#1206) it was always drained by then anyway.
+		if (isCI || !isTTY) {
 			if (typeof casted.providedConfirmFromStdin === 'undefined') {
 				throw new Error(
 					casted.errorMessageForStdin ??

--- a/src/lib/hooks/user-confirmations/_stdinCheckWrapper.ts
+++ b/src/lib/hooks/user-confirmations/_stdinCheckWrapper.ts
@@ -47,11 +47,13 @@ export function stdinCheckWrapper<Fn extends (...args: any[]) => any>(
 	}: StdinCheckWrapperOptions = {},
 ): (...args: NewFunctionArgs<Fn>) => Promise<Awaited<ReturnType<Fn>>> {
 	return async (input, ...rest) => {
-		const { isTTY, hasData } = await useStdin();
+		const { isTTY } = await useStdin();
 
 		const casted = input as StdinCheckWrapperInput<Awaited<ReturnType<Fn>>>;
 
-		if (isCI || (!isTTY && !hasData)) {
+		// Prompts need a terminal to read the answer from. Piped stdin is command input, not an
+		// answer source — before stdin became lazy (#1206) it was always drained by then anyway.
+		if (isCI || !isTTY) {
 			if (typeof casted.providedConfirmFromStdin === 'undefined') {
 				throw new Error(casted.errorMessageForStdin ?? errorMessageForStdin);
 			}

--- a/test/e2e/commands/stdin-held-open.test.ts
+++ b/test/e2e/commands/stdin-held-open.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, rm } from 'node:fs/promises';
+import { mkdir, open, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -87,5 +87,87 @@ describe('[e2e] stdin held open (#1206)', () => {
 			await handle.close();
 			await rm(fifo, { force: true });
 		}
+	});
+
+	// The tests above stop at the project check, ~100 lines before `apify run` resolves its input.
+	// A real project gets that far, and there `run` reads stdin when `--input` is missing — the last
+	// path that still hung on a named pipe.
+	const createFifoActor = async (name: string) => {
+		const dir = path.join(emptyDir, name);
+
+		await mkdir(path.join(dir, '.actor'), { recursive: true });
+		await writeFile(
+			path.join(dir, '.actor', 'actor.json'),
+			JSON.stringify({ actorSpecification: 1, name, version: '0.0', buildTag: 'latest' }),
+		);
+		await writeFile(
+			path.join(dir, 'package.json'),
+			JSON.stringify({ name, version: '0.0.1', type: 'module', scripts: { start: 'node main.js' } }),
+		);
+		// Records the input the CLI handed over, so the test can read it back from disk. Going through
+		// a file rather than stdout keeps this independent of how the package manager forwards output.
+		await writeFile(
+			path.join(dir, 'main.js'),
+			[
+				"import { readFile, writeFile } from 'node:fs/promises';",
+				"import path from 'node:path';",
+				"import process from 'node:process';",
+				"const store = path.join(process.env.APIFY_LOCAL_STORAGE_DIR ?? 'storage', 'key_value_stores', 'default');",
+				"const key = process.env.ACTOR_INPUT_KEY ?? 'INPUT';",
+				"const input = await readFile(path.join(store, `${key}.json`), 'utf8').catch(() => 'null');",
+				"await writeFile('SEEN_INPUT.json', input);",
+			].join('\n'),
+		);
+
+		return dir;
+	};
+
+	const runWithFifoStdin = async (cwd: string, write?: string) => {
+		const fifo = path.join(cwd, 'stdin.fifo');
+		await execa('mkfifo', [fifo]);
+
+		// `r+` keeps a writer attached for the whole test, so the pipe never reaches EOF even after
+		// the data below is written.
+		const handle = await open(fifo, 'r+');
+
+		try {
+			if (write) {
+				await handle.write(write);
+			}
+
+			return await execa('node', [DistApify, 'run'], {
+				cwd,
+				reject: false,
+				timeout: EXIT_DEADLINE_MS,
+				stdin: handle.fd,
+				env: {
+					APIFY_CLI_DISABLE_TELEMETRY: '1',
+					APIFY_CLI_SKIP_UPDATE_CHECK: '1',
+					APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE: '1',
+					APIFY_DISABLE_KEYRING: '1',
+				},
+			});
+		} finally {
+			await handle.close();
+			await rm(fifo, { force: true });
+		}
+	};
+
+	it.skipIf(process.platform === 'win32')('runs a real project when its named pipe stays silent', async () => {
+		const actorDir = await createFifoActor('silent-pipe-actor');
+
+		const result = await runWithFifoStdin(actorDir);
+
+		expect(result.timedOut, `stderr: ${result.stderr}`).toBe(false);
+		expect(await readFile(path.join(actorDir, 'SEEN_INPUT.json'), 'utf8')).toBe('null');
+	});
+
+	it.skipIf(process.platform === 'win32')('uses what a named pipe sent, then stops waiting for more', async () => {
+		const actorDir = await createFifoActor('talking-pipe-actor');
+
+		const result = await runWithFifoStdin(actorDir, '{"fromStdin":true}');
+
+		expect(result.timedOut, `stderr: ${result.stderr}`).toBe(false);
+		expect(JSON.parse(await readFile(path.join(actorDir, 'SEEN_INPUT.json'), 'utf8'))).toEqual({ fromStdin: true });
 	});
 });

--- a/test/e2e/commands/stdin-held-open.test.ts
+++ b/test/e2e/commands/stdin-held-open.test.ts
@@ -1,5 +1,6 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, open, rm } from 'node:fs/promises';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import { execa } from 'execa';
@@ -54,5 +55,37 @@ describe('[e2e] stdin held open (#1206)', () => {
 		// handle and would mask the regression.
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toContain('Actor is of an unknown format');
+	});
+
+	// A named pipe is the harsher case: unlike the socket a spawned child gets, it has no wait
+	// deadline, so the old eager startup read blocked forever and the command never even ran.
+	// Opening the FIFO read-write keeps a writer attached, so it never reaches EOF, with no
+	// second process to manage. Windows has no mkfifo.
+	it.skipIf(process.platform === 'win32')('exits on its own when stdin is a named pipe with no writer', async () => {
+		const fifo = path.join(emptyDir, 'stdin.fifo');
+		await execa('mkfifo', [fifo]);
+
+		const handle = await open(fifo, 'r+');
+
+		try {
+			const result = await execa('node', [DistApify, 'run'], {
+				cwd: emptyDir,
+				reject: false,
+				timeout: EXIT_DEADLINE_MS,
+				stdin: handle.fd,
+				env: {
+					APIFY_CLI_DISABLE_TELEMETRY: '1',
+					APIFY_CLI_SKIP_UPDATE_CHECK: '1',
+					APIFY_DISABLE_KEYRING: '1',
+				},
+			});
+
+			expect(result.timedOut, `stderr: ${result.stderr}`).toBe(false);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain('Actor is of an unknown format');
+		} finally {
+			await handle.close();
+			await rm(fifo, { force: true });
+		}
 	});
 });


### PR DESCRIPTION
> [!NOTE]
> **TL;DR** — The CLI read stdin at startup for every command, so a pipe that stays open hung it forever. Now it only reads stdin when a command wants it, and a read nobody asked for gives up when the pipe goes quiet.

Closes #1206.

### The startup read

`_shared.ts` read stdin at module scope (`export const cachedStdinInput = await readStdin()`), so every command blocked on stdin whether or not it uses it. #1294 fixed the socket case (a spawned child's `stdio: 'pipe'`), but a named pipe has no wait deadline — the read never ended and the command never even ran, so 1.8.0 still hangs with no output at all:

```bash
sleep 60 | apify --version   # 1.8.0: hangs, no output
```

Read stdin only where it's asked for: a `-` arg/flag, `apify run` without `--input`, `push-data`/`push-items` without an item arg. `readStdin()` memoizes, since stdin can only be drained once.

Confirmations keyed off `hasData`, which the eager read flipped to false after draining. Without that read it stays true, so `apify <confirm-cmd> < /dev/null` would try to prompt on a non-TTY — gated on `isTTY` instead.

### The implicit read

That left one path still hanging. `apify run` without `--input` falls back to stdin, and waited there for an end a named pipe never reaches. `actors call` and `actors start` share it. Two ways to hang:

```bash
apify run < /some/fifo                          # nothing ever sent
(printf '{"a":1}'; sleep 30) | apify run        # sent, then held open
```

A read the user never asked for now stops at the first quiet gap: each chunk restarts a 2s clock, and when stdin goes silent the CLI uses what arrived. An explicit `-` is unchanged — it waits for the writer to close, the way `cat` does.

**Trade-off:** a writer slower than ~2.5s to its first byte is now ignored (`curl slow-endpoint | apify run`). Truncation mid-stream stays loud, since the JSON fails to parse. 2s is a judgement call, not a derived number.

### Verification

Measured against a build of master and a build of this branch.

| stdin | command | before | after |
|---|---|---|---|
| open pipe, no data | `--version` | hang, no output | 405 ms |
| open pipe, with data | `--version` | hang, no output | 654 ms |
| closed pipe | `--version` | exits | exits |
| spawn `stdio: 'pipe'` (#1294's case) | `--version` | exits | exits |
| open pipe, silent | `run` in a project | hang | 2621 ms, no input |
| open pipe, sends then holds | `run` in a project | hang | 2619 ms, input used |
| writer delays 0 / 1 / 2 s, then closes | `run` in a project | input used | input used |
| writer delays 4 s, then closes | `run` in a project | input used | input dropped, 2603 ms |

Three new e2e cases, all skipped on Windows (no `mkfifo`). Each fails on the pre-fix build at the 15s deadline and passes after:

- FIFO on stdin, empty dir — the startup read
- FIFO on stdin, real project, silent — the implicit read
- FIFO on stdin, real project, sends then holds open — asserts the Actor received the input

`pnpm run test:local` green (540 passed). `pnpm run test:e2e:local` green (44 passed). No dependency or install-size change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
