### PR TITLE
fix: validate actors search choice flags

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -698,7 +698,9 @@ DESCRIPTION
 USAGE
   $ apify actors search [query] [--category <value>]
                         [--json] [--limit <value>] [--offset <value>]
-                        [--pricing-model <value>] [--sort-by <value>]
+                        [--pricing-model
+                        FREE|FLAT_PRICE_PER_MONTH|PRICE_PER_DATASET_ITEM|PAY_PER_EVENT]
+                        [--sort-by relevance|popularity|newest|lastUpdate]
                         [--username <value>]
 
 ARGUMENTS
@@ -706,18 +708,22 @@ ARGUMENTS
          or readme.
 
 FLAGS
-      --category=<value>       Filter by category (e.g.
-                               AI).
-      --json                   Format the command output as
-                               JSON.
-      --limit=<value>          Maximum number of results to
-                               return.
-      --offset=<value>         Number of results to skip
-                               for pagination.
-      --pricing-model=<value>  Filter by pricing model.
-      --sort-by=<value>        Sort order for the results.
-      --username=<value>       Filter by Actor author
-                               username.
+      --category=<value>        Filter by category (e.g.
+                                AI).
+      --json                    Format the command output
+                                as JSON.
+      --limit=<value>           Maximum number of results
+                                to return.
+      --offset=<value>          Number of results to skip
+                                for pagination.
+      --pricing-model=<option>  Filter by pricing model.
+                                <options:
+                                FREE|FLAT_PRICE_PER_MONTH|PRICE_PER_DATASET_ITEM|PAY_PER_EVENT>
+      --sort-by=<option>        Sort order for the
+                                results.
+                                <options: relevance|popularity|newest|lastUpdate>
+      --username=<value>        Filter by Actor author
+                                username.
 ```
 
 ##### `apify actors rm`

--- a/src/commands/actors/search.ts
+++ b/src/commands/actors/search.ts
@@ -67,7 +67,7 @@ export class ActorsSearchCommand extends ApifyCommand<typeof ActorsSearchCommand
 	static override flags = {
 		'sort-by': Flags.string({
 			description: 'Sort order for the results.',
-			options: ['relevance', 'popularity', 'newest', 'lastUpdate'],
+			choices: ['relevance', 'popularity', 'newest', 'lastUpdate'],
 			default: 'relevance',
 		}),
 		category: Flags.string({
@@ -78,7 +78,7 @@ export class ActorsSearchCommand extends ApifyCommand<typeof ActorsSearchCommand
 		}),
 		'pricing-model': Flags.string({
 			description: 'Filter by pricing model.',
-			options: ['FREE', 'FLAT_PRICE_PER_MONTH', 'PRICE_PER_DATASET_ITEM', 'PAY_PER_EVENT'],
+			choices: ['FREE', 'FLAT_PRICE_PER_MONTH', 'PRICE_PER_DATASET_ITEM', 'PAY_PER_EVENT'],
 		}),
 		limit: Flags.integer({
 			description: 'Maximum number of results to return.',

--- a/src/lib/command-framework/CommandError.ts
+++ b/src/lib/command-framework/CommandError.ts
@@ -201,6 +201,13 @@ export class CommandError extends Error {
 				);
 			}
 
+			case CommandErrorCode.APIFY_INVALID_CHOICE: {
+				const flagName = `--${this.metadata.flag}`;
+				const choices = this.metadata.choices as string;
+
+				return chalk.gray(`Invalid value for flag ${chalk.white.bold(flagName)}. Expected one of: ${choices}`);
+			}
+
 			default: {
 				const cliMetadata = useCLIMetadata();
 

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -495,7 +495,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 			}
 
 			// If you have a flag a, with alias b, and you pass --a and --b, it's not allowed
-			const matchingFlags = allMatchers.filter((matcher) => rawFlags[matcher]);
+			const matchingFlags = allMatchers.filter((matcher) => Object.hasOwn(rawFlags, matcher));
 
 			if (matchingFlags.length > 1) {
 				throw new CommandError({
@@ -593,7 +593,7 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 			// Validate choices
 			if (
 				// We have the flag
-				this.flags[camelCasedName] &&
+				this.flags[camelCasedName] != null &&
 				// And we have a list of choices
 				builderData.choices &&
 				// And the flag is not one of the choices


### PR DESCRIPTION
- Fixes #1322 by changing `actors search` restricted flags from `options` to `choices` so CLI validation runs.
- Validates provided choice flags even when the value is an empty string.
- Adds a user-facing invalid-choice error message and regenerates CLI reference docs.

Checks:
- `pnpm run lint`
- `pnpm run format`
- `pnpm run build`
- `pnpm run test:local`