### PR TITLE
fix: actor set-value KEY with no value doesn't delete the record

### DIFF
--- a/src/commands/actor/set-value.ts
+++ b/src/commands/actor/set-value.ts
@@ -1,3 +1,4 @@
+import { cachedStdinInput } from '../../entrypoints/_shared.js';
 import { APIFY_STORAGE_TYPES, getApifyStorageClient, getDefaultStorageId } from '../../lib/actor.js';
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
@@ -56,7 +57,7 @@ export class ActorSetValueCommand extends ApifyCommand<typeof ActorSetValueComma
 		const { contentType = 'application/json; charset=utf-8' } = this.flags;
 
 		// NOTE: If user pass value as argument and data on stdin same time. We use the value from argument.
-		const recordValue = value || process.stdin;
+		const recordValue = value ?? cachedStdinInput;
 		const apifyClient = await getApifyStorageClient();
 		const storeClient = apifyClient.keyValueStore(getDefaultStorageId(APIFY_STORAGE_TYPES.KEY_VALUE_STORE));
 

--- a/test/e2e/commands/actor/set-value.test.ts
+++ b/test/e2e/commands/actor/set-value.test.ts
@@ -1,3 +1,6 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
 import { runCli } from '../../__helpers__/run-cli.js';
 import { createTestActor, removeTestActor, type TestActor } from '../../__helpers__/test-actor.js';
 
@@ -23,5 +26,34 @@ describe('[e2e] actor set-value', () => {
 			cwd: actor.dir,
 		});
 		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
+
+		const recordPath = path.join(actor.dir, 'storage', 'key_value_stores', 'default', 'MY_KEY.json');
+		await expect(readFile(recordPath, 'utf-8')).resolves.toBe('{"hello":"world"}');
+	});
+
+	it('deletes a value when no value or stdin is provided', async () => {
+		const recordPath = path.join(actor.dir, 'storage', 'key_value_stores', 'default', 'DELETE_ME.json');
+		const setResult = await runCli('apify', ['actor', 'set-value', 'DELETE_ME', '{"exists":true}'], {
+			cwd: actor.dir,
+		});
+		expect(setResult.exitCode, `stderr: ${setResult.stderr}`).toBe(0);
+		await expect(readFile(recordPath, 'utf-8')).resolves.toBe('{"exists":true}');
+
+		const deleteResult = await runCli('apify', ['actor', 'set-value', 'DELETE_ME'], {
+			cwd: actor.dir,
+		});
+		expect(deleteResult.exitCode, `stderr: ${deleteResult.stderr}`).toBe(0);
+		await expect(access(recordPath)).rejects.toThrow();
+	});
+
+	it('sets a value from stdin', async () => {
+		const result = await runCli('apify', ['actor', 'set-value', 'FROM_STDIN', '--content-type', 'text/plain'], {
+			cwd: actor.dir,
+			stdin: 'VALUE',
+		});
+		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
+
+		const recordPath = path.join(actor.dir, 'storage', 'key_value_stores', 'default', 'FROM_STDIN.txt');
+		await expect(readFile(recordPath, 'utf-8')).resolves.toBe('VALUE');
 	});
 });


### PR DESCRIPTION
Fixes #1193.

## What changed and why

- `src/commands/actor/set-value.ts`: replace `value || process.stdin` with `value ?? cachedStdinInput`
  - `||` coerced both `undefined` (omitted arg) and `""` (explicit empty) to the already-drained `process.stdin` stream, so the deletion check on lines 64–70 never fired
  - `??` (nullish coalescing) preserves `""` as a deletion sentinel and passes `undefined` through to `cachedStdinInput` for the piped-stdin case
  - `process.stdin` is drained by `readStdin()` at entrypoint load time; `cachedStdinInput` is the correct pre-buffered source (same pattern used by `actor push-data`)

- `test/e2e/commands/actor/set-value.test.ts`: add regression tests for the two broken cases
  - delete record when no value or stdin is provided
  - set record from piped stdin
  - strengthen existing set-value test to assert file content

## Regression introduced by

Commit `28959631` (#760, "move away from oclif") removed `ignoreStdin: true` from the args but did not update the `process.stdin` fallback to use `cachedStdinInput`.

## Install size impact

No new dependencies. `cachedStdinInput` is already exported from `src/entrypoints/_shared.ts`.