### PR TITLE
feat: warn rental Actor publishers about the rental model sunset

### DIFF
--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -17,6 +17,7 @@ import { trackEvent } from '../hooks/telemetry/trackEvent.js';
 import { checkAndUpdateLastCommand } from '../hooks/telemetry/useTelemetryState.js';
 import { useCLIMetadata } from '../hooks/useCLIMetadata.js';
 import { ProjectLanguage, useCwdProject } from '../hooks/useCwdProject.js';
+import { useRentalSunsetNotice } from '../hooks/useRentalSunsetNotice.js';
 import { error } from '../outputs.js';
 import type { ArgTag, TaggedArgBuilder } from './args.js';
 import { CommandError, CommandErrorCode } from './CommandError.js';
@@ -263,6 +264,8 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 	protected skipTelemetry = false;
 
+	protected skipNotices = false;
+
 	public constructor(entrypoint: string, commandString: string, aliasUsed: string, subcommandAliasUsed?: string) {
 		this.entrypoint = entrypoint;
 		this.commandString = commandString;
@@ -419,6 +422,10 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 				this.telemetryData.wasRetried = await checkAndUpdateLastCommand(this.commandString);
 
 				await trackEvent('cli_command', this.telemetryData);
+			}
+
+			if (!this.skipNotices) {
+				await useRentalSunsetNotice();
 			}
 		}
 	}
@@ -961,6 +968,9 @@ export async function internalRunCommand<Cmd extends typeof BuiltApifyCommand>(
 
 	// eslint-disable-next-line dot-notation
 	instance['skipTelemetry'] = true;
+
+	// eslint-disable-next-line dot-notation
+	instance['skipNotices'] = true;
 
 	// eslint-disable-next-line dot-notation
 	await instance['_run'](rawObject);

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -424,7 +424,9 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 				await trackEvent('cli_command', this.telemetryData);
 			}
 
-			if (!this.skipNotices) {
+			// A notice stacked on top of an error message is noise the user did not ask for, and it
+			// would also make an interrupted command wait on the Store lookup before exiting.
+			if (!this.skipNotices && !process.exitCode) {
 				await useRentalSunsetNotice();
 			}
 		}

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -26,6 +26,16 @@ export const EMPTY_LOCAL_CONFIG = {
 
 export const CHECK_VERSION_EVERY_MILLIS = 24 * 60 * 60 * 1000; // Once a day
 
+export const CHECK_RENTAL_ACTORS_EVERY_MILLIS = 24 * 60 * 60 * 1000; // Once a day
+
+export const RENTAL_SUNSET_NOTICE_EVERY_MILLIS = 24 * 60 * 60 * 1000; // Once a day
+
+/**
+ * Rental Actors are fully retired on this date, so there is nothing left to warn about afterwards.
+ * Old CLI versions keep running for a long time, so the notice expires on its own.
+ */
+export const RENTAL_SUNSET_NOTICE_UNTIL = Date.UTC(2026, 9, 1); // 2026-10-01
+
 // Signals representing user-initiated interruption that long-running commands
 // should react to (aborting platform jobs, forwarding to local subprocesses).
 export const INTERRUPT_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];

--- a/src/lib/hooks/useLocalState.ts
+++ b/src/lib/hooks/useLocalState.ts
@@ -22,7 +22,7 @@ export interface LocalStateV1 {
 	};
 	rentalSunset?: {
 		lastChecked: number;
-		username?: string;
+		username: string;
 		rentalActorCount: number;
 		lastNotifiedAt?: number;
 	};

--- a/src/lib/hooks/useLocalState.ts
+++ b/src/lib/hooks/useLocalState.ts
@@ -20,6 +20,12 @@ export interface LocalStateV1 {
 		lastChecked: number;
 		lastVersion?: string;
 	};
+	rentalSunset?: {
+		lastChecked: number;
+		username?: string;
+		rentalActorCount: number;
+		lastNotifiedAt?: number;
+	};
 }
 
 function migrateStateV0ToV1(state: LocalState) {

--- a/src/lib/hooks/useRentalSunsetNotice.ts
+++ b/src/lib/hooks/useRentalSunsetNotice.ts
@@ -25,7 +25,9 @@ const DEFAULT_API_BASE_URL = 'https://api.apify.com';
 /** The notice runs after the command the user actually asked for, so the lookup gets one short attempt. */
 const STORE_LOOKUP_TIMEOUT_MILLIS = 3_000;
 
-const APIFY_DISCORD_URL = 'https://discord.gg/crawlee-apify-801163717915574323';
+const APIFY_DISCORD_URL = 'https://apify.com/discord';
+
+const PAY_PER_EVENT_MIGRATION_URL = 'https://blog.apify.com/migrating-to-pay-per-event-pricing/';
 
 export interface RentalSunsetGateInput {
 	now: number;
@@ -77,7 +79,11 @@ export function renderRentalSunsetNotice(rentalActorCount: number) {
 		`  ${chalk.bold('April 1, 2026')}     Publishing new rental Actors and pricing changes on existing ones were disabled.`,
 		`  ${chalk.bold('October 1, 2026')}   Rental Actors are fully retired. All remaining Actors move to pay-per-usage pricing.`,
 		'',
-		`For more information, visit the ${chalk.cyan('#project-rentals')} channel on Apify Discord:`,
+		`Switch your ${actorWord} to pay-per-event before October 1 to keep control over what you charge.`,
+		`This guide walks through picking events, setting prices, and shipping the change:`,
+		`  ${chalk.cyan(PAY_PER_EVENT_MIGRATION_URL)}`,
+		'',
+		`Questions? Ask in the ${chalk.cyan('#project-rentals')} channel on Apify Discord:`,
 		`  ${chalk.cyan(APIFY_DISCORD_URL)}`,
 		'',
 		chalk.dim('To silence this notice, set APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE=1.'),

--- a/src/lib/hooks/useRentalSunsetNotice.ts
+++ b/src/lib/hooks/useRentalSunsetNotice.ts
@@ -1,0 +1,197 @@
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+import chalk from 'chalk';
+import { isCI } from 'ci-info';
+
+import {
+	AUTH_FILE_PATH,
+	CHECK_RENTAL_ACTORS_EVERY_MILLIS,
+	RENTAL_SUNSET_NOTICE_EVERY_MILLIS,
+	RENTAL_SUNSET_NOTICE_UNTIL,
+} from '../consts.js';
+import { simpleLog, warning } from '../outputs.js';
+import type { AuthJSON } from '../types.js';
+import { cliDebugPrint } from '../utils/cliDebugPrint.js';
+import { useCLIMetadata } from './useCLIMetadata.js';
+import { type LatestState, updateLocalState, useLocalState } from './useLocalState.js';
+
+const RENTAL_PRICING_MODEL = 'FLAT_PRICE_PER_MONTH';
+
+const DEFAULT_API_BASE_URL = 'https://api.apify.com';
+
+const APIFY_DISCORD_URL = 'https://discord.gg/crawlee-apify-801163717915574323';
+
+export interface RentalSunsetGateInput {
+	now: number;
+	isCi: boolean;
+	skipEnvValue?: string;
+	lastNotifiedAt?: number;
+}
+
+/**
+ * Decides whether the rental sunset notice should be suppressed. Kept pure so the gating rules can
+ * be tested without touching the network or the local state file.
+ */
+export function shouldSkipRentalSunsetNotice({ now, isCi, skipEnvValue, lastNotifiedAt }: RentalSunsetGateInput) {
+	if (skipEnvValue && !['0', 'false'].includes(skipEnvValue)) {
+		return true;
+	}
+
+	// The notice is aimed at a human reading their terminal, printing it into CI logs is just noise.
+	if (isCi) {
+		return true;
+	}
+
+	if (now >= RENTAL_SUNSET_NOTICE_UNTIL) {
+		return true;
+	}
+
+	if (lastNotifiedAt && now - lastNotifiedAt < RENTAL_SUNSET_NOTICE_EVERY_MILLIS) {
+		return true;
+	}
+
+	return false;
+}
+
+export function renderRentalSunsetNotice(rentalActorCount: number) {
+	const actorWord = rentalActorCount === 1 ? 'rental Actor' : 'rental Actors';
+
+	return [
+		chalk.bold('Rental model sunset'),
+		'',
+		`You have ${rentalActorCount} ${actorWord} published in Apify Store. Apify is sunsetting the rental pricing model.`,
+		'The following changes are scheduled for 2026:',
+		'',
+		`  ${chalk.bold('April 1')}    You can no longer publish new rental Actors or change pricing on existing ones.`,
+		`  ${chalk.bold('October 1')}  Rental Actors are fully retired. All remaining Actors are migrated to pay-per-usage pricing.`,
+		'',
+		`For more information, visit the ${chalk.cyan('#project-rentals')} channel on Apify Discord:`,
+		`  ${chalk.cyan(APIFY_DISCORD_URL)}`,
+		'',
+	].join('\n');
+}
+
+/**
+ * Reads the logged in username straight from auth.json instead of going through `getLocalUserInfo`,
+ * which resolves the token from the OS keyring and would trigger a keychain prompt on commands that
+ * do not need authentication at all.
+ */
+async function getLocalUsername() {
+	try {
+		const raw = await readFile(AUTH_FILE_PATH(), 'utf-8');
+
+		return (JSON.parse(raw) as AuthJSON).username;
+	} catch {
+		return undefined;
+	}
+}
+
+async function fetchRentalActorCount(username: string) {
+	const metadata = useCLIMetadata();
+
+	const url = new URL('/v2/store', process.env.APIFY_CLIENT_BASE_URL || DEFAULT_API_BASE_URL);
+	url.searchParams.set('username', username);
+	url.searchParams.set('pricingModel', RENTAL_PRICING_MODEL);
+	// We only need the `total`, not the Actors themselves.
+	url.searchParams.set('limit', '1');
+
+	const res = await fetch(url, {
+		headers: {
+			'User-Agent': `Apify CLI/${metadata.version} (https://github.com/apify/apify-cli)`,
+		},
+		signal: AbortSignal.timeout(3_000),
+	});
+
+	if (!res.ok) {
+		cliDebugPrint('useRentalSunsetNotice', 'Failed to fetch rental Actors', { statusCode: res.status });
+
+		return null;
+	}
+
+	const body = (await res.json()) as { data?: { total?: number } };
+
+	return body.data?.total ?? 0;
+}
+
+async function resolveRentalActorCount(state: LatestState, username: string, now: number) {
+	const cached = state.rentalSunset;
+
+	const cacheIsUsable =
+		cached && cached.username === username && now - cached.lastChecked < CHECK_RENTAL_ACTORS_EVERY_MILLIS;
+
+	if (cacheIsUsable) {
+		return cached.rentalActorCount;
+	}
+
+	const rentalActorCount = await fetchRentalActorCount(username);
+
+	if (rentalActorCount === null) {
+		return cached?.username === username ? cached.rentalActorCount : null;
+	}
+
+	updateLocalState(state, (stateToUpdate) => {
+		stateToUpdate.rentalSunset = {
+			...stateToUpdate.rentalSunset,
+			lastChecked: now,
+			username,
+			rentalActorCount,
+		};
+	});
+
+	return rentalActorCount;
+}
+
+/**
+ * Warns users who publish rental Actors in Apify Store that the rental pricing model is going away.
+ * Runs after every command, but only prints once a day and only checks the API once a day.
+ *
+ * Never throws - a broken notice must not break the command the user actually asked for.
+ */
+export async function useRentalSunsetNotice() {
+	try {
+		const now = Date.now();
+		const state = useLocalState();
+
+		if (
+			shouldSkipRentalSunsetNotice({
+				now,
+				isCi: isCI,
+				skipEnvValue: process.env.APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE,
+				lastNotifiedAt: state.rentalSunset?.lastNotifiedAt,
+			})
+		) {
+			return;
+		}
+
+		const username = await getLocalUsername();
+
+		if (!username) {
+			cliDebugPrint('useRentalSunsetNotice', 'Not logged in, skipping the check');
+
+			return;
+		}
+
+		const rentalActorCount = await resolveRentalActorCount(state, username, now);
+
+		if (!rentalActorCount) {
+			return;
+		}
+
+		const latestState = useLocalState();
+
+		updateLocalState(latestState, (stateToUpdate) => {
+			stateToUpdate.rentalSunset = {
+				lastChecked: latestState.rentalSunset?.lastChecked ?? now,
+				username,
+				rentalActorCount,
+				lastNotifiedAt: now,
+			};
+		});
+
+		simpleLog({ message: '' });
+		warning({ message: renderRentalSunsetNotice(rentalActorCount) });
+	} catch (err) {
+		cliDebugPrint('useRentalSunsetNotice', 'Failed to run the rental sunset check', err);
+	}
+}

--- a/src/lib/hooks/useRentalSunsetNotice.ts
+++ b/src/lib/hooks/useRentalSunsetNotice.ts
@@ -1,10 +1,12 @@
 import { readFile } from 'node:fs/promises';
 import process from 'node:process';
 
+import axios from 'axios';
 import chalk from 'chalk';
 import { isCI } from 'ci-info';
 
 import {
+	APIFY_CLIENT_DEFAULT_HEADERS,
 	AUTH_FILE_PATH,
 	CHECK_RENTAL_ACTORS_EVERY_MILLIS,
 	RENTAL_SUNSET_NOTICE_EVERY_MILLIS,
@@ -20,20 +22,22 @@ const RENTAL_PRICING_MODEL = 'FLAT_PRICE_PER_MONTH';
 
 const DEFAULT_API_BASE_URL = 'https://api.apify.com';
 
+/** The notice runs after the command the user actually asked for, so the lookup gets one short attempt. */
+const STORE_LOOKUP_TIMEOUT_MILLIS = 3_000;
+
 const APIFY_DISCORD_URL = 'https://discord.gg/crawlee-apify-801163717915574323';
 
 export interface RentalSunsetGateInput {
 	now: number;
 	isCi: boolean;
 	skipEnvValue?: string;
-	lastNotifiedAt?: number;
 }
 
 /**
  * Decides whether the rental sunset notice should be suppressed. Kept pure so the gating rules can
  * be tested without touching the network or the local state file.
  */
-export function shouldSkipRentalSunsetNotice({ now, isCi, skipEnvValue, lastNotifiedAt }: RentalSunsetGateInput) {
+export function shouldSkipRentalSunsetNotice({ now, isCi, skipEnvValue }: RentalSunsetGateInput) {
 	if (skipEnvValue && !['0', 'false'].includes(skipEnvValue)) {
 		return true;
 	}
@@ -47,11 +51,19 @@ export function shouldSkipRentalSunsetNotice({ now, isCi, skipEnvValue, lastNoti
 		return true;
 	}
 
-	if (lastNotifiedAt && now - lastNotifiedAt < RENTAL_SUNSET_NOTICE_EVERY_MILLIS) {
-		return true;
+	return false;
+}
+
+/**
+ * The daily throttle is per account - logging in as somebody else must not inherit the previous
+ * user's "already warned today" timestamp.
+ */
+export function wasNotifiedRecently(cached: LatestState['rentalSunset'], username: string, now: number) {
+	if (!cached?.lastNotifiedAt || cached.username !== username) {
+		return false;
 	}
 
-	return false;
+	return now - cached.lastNotifiedAt < RENTAL_SUNSET_NOTICE_EVERY_MILLIS;
 }
 
 export function renderRentalSunsetNotice(rentalActorCount: number) {
@@ -61,13 +73,14 @@ export function renderRentalSunsetNotice(rentalActorCount: number) {
 		chalk.bold('Rental model sunset'),
 		'',
 		`You have ${rentalActorCount} ${actorWord} published in Apify Store. Apify is sunsetting the rental pricing model.`,
-		'The following changes are scheduled for 2026:',
 		'',
-		`  ${chalk.bold('April 1')}    You can no longer publish new rental Actors or change pricing on existing ones.`,
-		`  ${chalk.bold('October 1')}  Rental Actors are fully retired. All remaining Actors are migrated to pay-per-usage pricing.`,
+		`  ${chalk.bold('April 1, 2026')}     Publishing new rental Actors and pricing changes on existing ones were disabled.`,
+		`  ${chalk.bold('October 1, 2026')}   Rental Actors are fully retired. All remaining Actors move to pay-per-usage pricing.`,
 		'',
 		`For more information, visit the ${chalk.cyan('#project-rentals')} channel on Apify Discord:`,
 		`  ${chalk.cyan(APIFY_DISCORD_URL)}`,
+		'',
+		chalk.dim('To silence this notice, set APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE=1.'),
 		'',
 	].join('\n');
 }
@@ -87,59 +100,84 @@ async function getLocalUsername() {
 	}
 }
 
+/**
+ * Returns `null` for every kind of failed lookup - a refused or timed out request, a non-2xx status,
+ * or a 200 that is not a Store response. Callers need "we could not find out" to be a value rather
+ * than an exception, so that a stale count can still be used and the failure can still be cached.
+ */
 async function fetchRentalActorCount(username: string) {
 	const metadata = useCLIMetadata();
 
 	const url = new URL('/v2/store', process.env.APIFY_CLIENT_BASE_URL || DEFAULT_API_BASE_URL);
-	url.searchParams.set('username', username);
-	url.searchParams.set('pricingModel', RENTAL_PRICING_MODEL);
-	// We only need the `total`, not the Actors themselves.
-	url.searchParams.set('limit', '1');
 
-	const res = await fetch(url, {
-		headers: {
-			'User-Agent': `Apify CLI/${metadata.version} (https://github.com/apify/apify-cli)`,
-		},
-		signal: AbortSignal.timeout(3_000),
-	});
+	try {
+		// axios rather than `fetch`, so the lookup honors HTTP_PROXY/HTTPS_PROXY/NO_PROXY like every
+		// other request the CLI makes - Node's global fetch ignores them.
+		const { data } = await axios.get<{ data?: { total?: number } }>(url.href, {
+			params: {
+				username,
+				pricingModel: RENTAL_PRICING_MODEL,
+				// We only need the `total`, not the Actors themselves.
+				limit: 1,
+			},
+			timeout: STORE_LOOKUP_TIMEOUT_MILLIS,
+			headers: {
+				// Same origin headers every other CLI request to the Apify API carries, so this lookup is
+				// attributed like the rest of the CLI rather than as anonymous traffic.
+				...APIFY_CLIENT_DEFAULT_HEADERS,
+				'User-Agent': `Apify CLI/${metadata.version} (https://github.com/apify/apify-cli)`,
+			},
+		});
 
-	if (!res.ok) {
-		cliDebugPrint('useRentalSunsetNotice', 'Failed to fetch rental Actors', { statusCode: res.status });
+		// A 200 without a numeric `total` means something other than the Store answered (a captive
+		// portal, a proxy interstitial, a schema change). Treating it as zero would cache the notice away.
+		if (typeof data?.data?.total !== 'number') {
+			cliDebugPrint('useRentalSunsetNotice', 'Store response has no data.total', { body: data });
+
+			return null;
+		}
+
+		return data.data.total;
+	} catch (err) {
+		// Covers a refused or timed out request and, since axios rejects non-2xx by default, HTTP errors.
+		cliDebugPrint('useRentalSunsetNotice', 'Failed to look up rental Actors', err);
 
 		return null;
 	}
-
-	const body = (await res.json()) as { data?: { total?: number } };
-
-	return body.data?.total ?? 0;
 }
 
-async function resolveRentalActorCount(state: LatestState, username: string, now: number) {
-	const cached = state.rentalSunset;
+interface ResolvedRentalActorCount {
+	rentalActorCount: number;
+	/** When the Store was last actually queried. Carried over unchanged on a cache hit. */
+	lastChecked: number;
+	/** True when no request was made, so there is nothing new to persist. */
+	fromCache: boolean;
+}
 
-	const cacheIsUsable =
-		cached && cached.username === username && now - cached.lastChecked < CHECK_RENTAL_ACTORS_EVERY_MILLIS;
+async function resolveRentalActorCount(
+	cached: LatestState['rentalSunset'],
+	username: string,
+	now: number,
+): Promise<ResolvedRentalActorCount> {
+	const cachedForUser = cached?.username === username ? cached : undefined;
 
-	if (cacheIsUsable) {
-		return cached.rentalActorCount;
-	}
-
-	const rentalActorCount = await fetchRentalActorCount(username);
-
-	if (rentalActorCount === null) {
-		return cached?.username === username ? cached.rentalActorCount : null;
-	}
-
-	updateLocalState(state, (stateToUpdate) => {
-		stateToUpdate.rentalSunset = {
-			...stateToUpdate.rentalSunset,
-			lastChecked: now,
-			username,
-			rentalActorCount,
+	if (cachedForUser && now - cachedForUser.lastChecked < CHECK_RENTAL_ACTORS_EVERY_MILLIS) {
+		return {
+			rentalActorCount: cachedForUser.rentalActorCount,
+			lastChecked: cachedForUser.lastChecked,
+			fromCache: true,
 		};
-	});
+	}
 
-	return rentalActorCount;
+	const fetched = await fetchRentalActorCount(username);
+
+	// A failed lookup still counts as checked. Without that, every command would retry - and a
+	// connection that hangs instead of refusing costs the full request timeout each time.
+	return {
+		rentalActorCount: fetched ?? cachedForUser?.rentalActorCount ?? 0,
+		lastChecked: now,
+		fromCache: false,
+	};
 }
 
 /**
@@ -158,7 +196,6 @@ export async function useRentalSunsetNotice() {
 				now,
 				isCi: isCI,
 				skipEnvValue: process.env.APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE,
-				lastNotifiedAt: state.rentalSunset?.lastNotifiedAt,
 			})
 		) {
 			return;
@@ -172,22 +209,35 @@ export async function useRentalSunsetNotice() {
 			return;
 		}
 
-		const rentalActorCount = await resolveRentalActorCount(state, username, now);
-
-		if (!rentalActorCount) {
+		if (wasNotifiedRecently(state.rentalSunset, username, now)) {
 			return;
 		}
 
-		const latestState = useLocalState();
+		const { rentalActorCount, lastChecked, fromCache } = await resolveRentalActorCount(
+			state.rentalSunset,
+			username,
+			now,
+		);
 
-		updateLocalState(latestState, (stateToUpdate) => {
+		const shouldNotify = rentalActorCount > 0;
+
+		// Nothing was fetched and nothing will be printed, so the state file is already up to date.
+		if (fromCache && !shouldNotify) {
+			return;
+		}
+
+		updateLocalState(state, (stateToUpdate) => {
 			stateToUpdate.rentalSunset = {
-				lastChecked: latestState.rentalSunset?.lastChecked ?? now,
+				lastChecked,
 				username,
 				rentalActorCount,
-				lastNotifiedAt: now,
+				...(shouldNotify ? { lastNotifiedAt: now } : {}),
 			};
 		});
+
+		if (!shouldNotify) {
+			return;
+		}
 
 		simpleLog({ message: '' });
 		warning({ message: renderRentalSunsetNotice(rentalActorCount) });

--- a/test/e2e/__helpers__/run-cli.ts
+++ b/test/e2e/__helpers__/run-cli.ts
@@ -50,6 +50,7 @@ export async function runCli(
 		env: {
 			APIFY_CLI_DISABLE_TELEMETRY: '1',
 			APIFY_CLI_SKIP_UPDATE_CHECK: '1',
+			APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE: '1',
 			// Pin the file backend so e2e subprocesses don't share the host's OS keyring across tests.
 			APIFY_DISABLE_KEYRING: '1',
 			...options.env,

--- a/test/local/lib/rental-sunset-notice.test.ts
+++ b/test/local/lib/rental-sunset-notice.test.ts
@@ -127,6 +127,10 @@ describe('renderRentalSunsetNotice', () => {
 		expect(message).toContain('#project-rentals');
 	});
 
+	it('links the pay-per-event migration guide', () => {
+		expect(renderRentalSunsetNotice(3)).toContain('https://blog.apify.com/migrating-to-pay-per-event-pricing/');
+	});
+
 	it('says how to silence itself', () => {
 		expect(renderRentalSunsetNotice(3)).toContain('APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE=1');
 	});

--- a/test/local/lib/rental-sunset-notice.test.ts
+++ b/test/local/lib/rental-sunset-notice.test.ts
@@ -10,8 +10,10 @@ vitest.mock('ci-info', () => {
 	return { ...ciInfo, default: ciInfo };
 });
 
-const { AUTH_FILE_PATH, RENTAL_SUNSET_NOTICE_UNTIL, STATE_FILE_PATH } = await import('../../../src/lib/consts.js');
-const { renderRentalSunsetNotice, shouldSkipRentalSunsetNotice, useRentalSunsetNotice } =
+const { default: axios } = await import('axios');
+const { APIFY_CLIENT_DEFAULT_HEADERS, AUTH_FILE_PATH, RENTAL_SUNSET_NOTICE_UNTIL, STATE_FILE_PATH } =
+	await import('../../../src/lib/consts.js');
+const { renderRentalSunsetNotice, shouldSkipRentalSunsetNotice, useRentalSunsetNotice, wasNotifiedRecently } =
 	await import('../../../src/lib/hooks/useRentalSunsetNotice.js');
 
 const now = new Date('2026-05-01T00:00:00.000Z').getTime();
@@ -28,21 +30,40 @@ async function writeAuthFile(username: string | undefined) {
 	await writeFile(path, JSON.stringify({ id: 'user-id', username, token: 'apify_api_token' }));
 }
 
-async function readState() {
-	return JSON.parse(await readFile(STATE_FILE_PATH(), 'utf-8')) as {
-		rentalSunset?: { lastChecked: number; username?: string; rentalActorCount: number; lastNotifiedAt?: number };
-	};
+interface StoredRentalSunset {
+	lastChecked: number;
+	username: string;
+	rentalActorCount: number;
+	lastNotifiedAt?: number;
 }
 
+async function readState() {
+	return JSON.parse(await readFile(STATE_FILE_PATH(), 'utf-8')) as { rentalSunset?: StoredRentalSunset };
+}
+
+async function writeState(rentalSunset: StoredRentalSunset) {
+	const path = STATE_FILE_PATH();
+
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, JSON.stringify({ version: 1, rentalSunset }));
+}
+
+/** The hook looks the Store up through axios, so the spy goes on the same module instance it imports. */
 function mockStoreResponse(total: number) {
-	return vitest.spyOn(globalThis, 'fetch').mockImplementation(async () =>
-		Promise.resolve(
-			new Response(JSON.stringify({ data: { total, count: total ? 1 : 0, items: [] } }), {
-				status: 200,
-				headers: { 'Content-Type': 'application/json' },
-			}),
-		),
-	);
+	return vitest.spyOn(axios, 'get').mockResolvedValue({ data: { data: { total, count: total ? 1 : 0, items: [] } } });
+}
+
+/** A 200 whose body is not a Store response - a captive portal, a proxy interstitial, a schema change. */
+function mockNonStoreResponse(body: unknown) {
+	return vitest.spyOn(axios, 'get').mockResolvedValue({ data: body });
+}
+
+function mockRequestFailure() {
+	return vitest.spyOn(axios, 'get').mockRejectedValue(new Error('Request failed with status code 503'));
+}
+
+function requestConfig(spy: ReturnType<typeof mockStoreResponse>) {
+	return spy.mock.calls[0][1] as { params: Record<string, unknown>; headers: Record<string, string> };
 }
 
 beforeEach(() => {
@@ -63,7 +84,7 @@ describe('shouldSkipRentalSunsetNotice', () => {
 		expect(shouldSkipRentalSunsetNotice({ now, isCi: false })).toBe(false);
 	});
 
-	it('skips when the opt-out env var is set', () => {
+	it('skips only when the opt-out env var is truthy', () => {
 		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, skipEnvValue: '1' })).toBe(true);
 		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, skipEnvValue: 'false' })).toBe(false);
 		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, skipEnvValue: '0' })).toBe(false);
@@ -76,10 +97,23 @@ describe('shouldSkipRentalSunsetNotice', () => {
 	it('skips once rental Actors are retired', () => {
 		expect(shouldSkipRentalSunsetNotice({ now: RENTAL_SUNSET_NOTICE_UNTIL, isCi: false })).toBe(true);
 	});
+});
 
-	it('skips when the user was already notified within the last day', () => {
-		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, lastNotifiedAt: now - 1000 })).toBe(true);
-		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, lastNotifiedAt: now - day - 1000 })).toBe(false);
+describe('wasNotifiedRecently', () => {
+	const cached = { lastChecked: now, username: 'some-user', rentalActorCount: 2 };
+
+	it('is true within a day of the last notice', () => {
+		expect(wasNotifiedRecently({ ...cached, lastNotifiedAt: now - 1000 }, 'some-user', now)).toBe(true);
+		expect(wasNotifiedRecently({ ...cached, lastNotifiedAt: now - day - 1000 }, 'some-user', now)).toBe(false);
+	});
+
+	it('is false with no state at all, and when nobody was notified yet', () => {
+		expect(wasNotifiedRecently(undefined, 'some-user', now)).toBe(false);
+		expect(wasNotifiedRecently(cached, 'some-user', now)).toBe(false);
+	});
+
+	it('does not let one account suppress the notice for another', () => {
+		expect(wasNotifiedRecently({ ...cached, lastNotifiedAt: now - 1000 }, 'other-user', now)).toBe(false);
 	});
 });
 
@@ -88,9 +122,13 @@ describe('renderRentalSunsetNotice', () => {
 		const message = renderRentalSunsetNotice(3);
 
 		expect(message).toContain('You have 3 rental Actors published in Apify Store');
-		expect(message).toContain('April 1');
-		expect(message).toContain('October 1');
+		expect(message).toContain('April 1, 2026');
+		expect(message).toContain('October 1, 2026');
 		expect(message).toContain('#project-rentals');
+	});
+
+	it('says how to silence itself', () => {
+		expect(renderRentalSunsetNotice(3)).toContain('APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE=1');
 	});
 
 	it('uses singular wording for a single Actor', () => {
@@ -107,15 +145,29 @@ describe('useRentalSunsetNotice', () => {
 
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-		const requestedUrl = String(fetchSpy.mock.calls[0][0]);
-		expect(requestedUrl).toContain('username=some-user');
-		expect(requestedUrl).toContain('pricingModel=FLAT_PRICE_PER_MONTH');
+		expect(String(fetchSpy.mock.calls[0][0])).toContain('/v2/store');
+		expect(requestConfig(fetchSpy).params).toMatchObject({
+			username: 'some-user',
+			pricingModel: 'FLAT_PRICE_PER_MONTH',
+			limit: 1,
+		});
 
 		expect(logMessages.error.join('\n')).toContain('Rental model sunset');
 
 		expect(await readState()).toMatchObject({
 			rentalSunset: { username: 'some-user', rentalActorCount: 2, lastChecked: now, lastNotifiedAt: now },
 		});
+	});
+
+	it('identifies itself the same way as the rest of the CLI', async () => {
+		await writeAuthFile('some-user');
+		const fetchSpy = mockStoreResponse(2);
+
+		await useRentalSunsetNotice();
+
+		const { headers } = requestConfig(fetchSpy);
+		expect(headers['X-Apify-Request-Origin']).toBe(APIFY_CLIENT_DEFAULT_HEADERS['X-Apify-Request-Origin']);
+		expect(headers['User-Agent']).toContain('Apify CLI/');
 	});
 
 	it('stays quiet for users without rental Actors', async () => {
@@ -141,7 +193,7 @@ describe('useRentalSunsetNotice', () => {
 		expect(logMessages.error.join('\n')).not.toContain('Rental model sunset');
 	});
 
-	it('warns again a day later, using the cached count', async () => {
+	it('warns again a day later, re-checking the Store', async () => {
 		await writeAuthFile('some-user');
 		const fetchSpy = mockStoreResponse(2);
 
@@ -166,10 +218,76 @@ describe('useRentalSunsetNotice', () => {
 
 	it('stays quiet when the API call fails', async () => {
 		await writeAuthFile('some-user');
-		vitest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network is down'));
+		mockRequestFailure();
 
 		await expect(useRentalSunsetNotice()).resolves.toBeUndefined();
 
 		expect(logMessages.error.join('\n')).not.toContain('Rental model sunset');
+	});
+
+	it('does not retry a failing lookup on every command', async () => {
+		await writeAuthFile('some-user');
+		const fetchSpy = mockRequestFailure();
+
+		await useRentalSunsetNotice();
+		await useRentalSunsetNotice();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(await readState()).toMatchObject({ rentalSunset: { lastChecked: now, rentalActorCount: 0 } });
+	});
+
+	it('keeps warning from the cached count while the API is down', async () => {
+		await writeState({ lastChecked: now - day - 1000, username: 'some-user', rentalActorCount: 2 });
+		await writeAuthFile('some-user');
+		mockRequestFailure();
+
+		await useRentalSunsetNotice();
+
+		expect(logMessages.error.join('\n')).toContain('You have 2 rental Actors');
+	});
+
+	it('ignores a non-2xx response instead of caching a zero', async () => {
+		await writeState({ lastChecked: now - day - 1000, username: 'some-user', rentalActorCount: 2 });
+		await writeAuthFile('some-user');
+		mockRequestFailure();
+
+		await useRentalSunsetNotice();
+
+		expect(logMessages.error.join('\n')).toContain('You have 2 rental Actors');
+	});
+
+	it('ignores a 200 that is not a Store response instead of caching a zero', async () => {
+		await writeState({ lastChecked: now - day - 1000, username: 'some-user', rentalActorCount: 2 });
+		await writeAuthFile('some-user');
+		mockNonStoreResponse('<html>captive portal</html>');
+
+		await useRentalSunsetNotice();
+
+		expect(logMessages.error.join('\n')).toContain('You have 2 rental Actors');
+	});
+
+	it('does not let one account suppress the notice for the next one', async () => {
+		await writeState({ lastChecked: now, username: 'first-user', rentalActorCount: 2, lastNotifiedAt: now });
+		await writeAuthFile('second-user');
+		mockStoreResponse(5);
+
+		await useRentalSunsetNotice();
+
+		expect(logMessages.error.join('\n')).toContain('You have 5 rental Actors');
+		expect(await readState()).toMatchObject({
+			rentalSunset: { username: 'second-user', rentalActorCount: 5, lastNotifiedAt: now },
+		});
+	});
+
+	it('does not rewrite the state file on a quiet cache hit', async () => {
+		await writeState({ lastChecked: now, username: 'some-user', rentalActorCount: 0 });
+		await writeAuthFile('some-user');
+		const fetchSpy = mockStoreResponse(0);
+
+		const before = await readFile(STATE_FILE_PATH(), 'utf-8');
+		await useRentalSunsetNotice();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(await readFile(STATE_FILE_PATH(), 'utf-8')).toBe(before);
 	});
 });

--- a/test/local/lib/rental-sunset-notice.test.ts
+++ b/test/local/lib/rental-sunset-notice.test.ts
@@ -1,0 +1,175 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
+import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
+
+vitest.mock('ci-info', () => {
+	const ciInfo = { isCI: false, GITHUB_ACTIONS: false, id: undefined };
+
+	return { ...ciInfo, default: ciInfo };
+});
+
+const { AUTH_FILE_PATH, RENTAL_SUNSET_NOTICE_UNTIL, STATE_FILE_PATH } = await import('../../../src/lib/consts.js');
+const { renderRentalSunsetNotice, shouldSkipRentalSunsetNotice, useRentalSunsetNotice } =
+	await import('../../../src/lib/hooks/useRentalSunsetNotice.js');
+
+const now = new Date('2026-05-01T00:00:00.000Z').getTime();
+const day = 24 * 60 * 60 * 1000;
+
+useAuthSetup();
+
+const { logMessages } = useConsoleSpy();
+
+async function writeAuthFile(username: string | undefined) {
+	const path = AUTH_FILE_PATH();
+
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, JSON.stringify({ id: 'user-id', username, token: 'apify_api_token' }));
+}
+
+async function readState() {
+	return JSON.parse(await readFile(STATE_FILE_PATH(), 'utf-8')) as {
+		rentalSunset?: { lastChecked: number; username?: string; rentalActorCount: number; lastNotifiedAt?: number };
+	};
+}
+
+function mockStoreResponse(total: number) {
+	return vitest.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+		Promise.resolve(
+			new Response(JSON.stringify({ data: { total, count: total ? 1 : 0, items: [] } }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		),
+	);
+}
+
+beforeEach(() => {
+	// The suite-wide opt-out (see vitest.config.ts) keeps the rest of the tests from hitting the API,
+	// but this file is the one place that actually exercises the notice.
+	vitest.stubEnv('APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE', '');
+	vitest.useFakeTimers({ toFake: ['Date'] });
+	vitest.setSystemTime(now);
+});
+
+afterEach(() => {
+	vitest.useRealTimers();
+	vitest.restoreAllMocks();
+});
+
+describe('shouldSkipRentalSunsetNotice', () => {
+	it('does not skip for a regular interactive run', () => {
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: false })).toBe(false);
+	});
+
+	it('skips when the opt-out env var is set', () => {
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, skipEnvValue: '1' })).toBe(true);
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, skipEnvValue: 'false' })).toBe(false);
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, skipEnvValue: '0' })).toBe(false);
+	});
+
+	it('skips in CI', () => {
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: true })).toBe(true);
+	});
+
+	it('skips once rental Actors are retired', () => {
+		expect(shouldSkipRentalSunsetNotice({ now: RENTAL_SUNSET_NOTICE_UNTIL, isCi: false })).toBe(true);
+	});
+
+	it('skips when the user was already notified within the last day', () => {
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, lastNotifiedAt: now - 1000 })).toBe(true);
+		expect(shouldSkipRentalSunsetNotice({ now, isCi: false, lastNotifiedAt: now - day - 1000 })).toBe(false);
+	});
+});
+
+describe('renderRentalSunsetNotice', () => {
+	it('mentions both milestones and where to ask questions', () => {
+		const message = renderRentalSunsetNotice(3);
+
+		expect(message).toContain('You have 3 rental Actors published in Apify Store');
+		expect(message).toContain('April 1');
+		expect(message).toContain('October 1');
+		expect(message).toContain('#project-rentals');
+	});
+
+	it('uses singular wording for a single Actor', () => {
+		expect(renderRentalSunsetNotice(1)).toContain('You have 1 rental Actor published');
+	});
+});
+
+describe('useRentalSunsetNotice', () => {
+	it('warns users who have rental Actors in the store and caches the result', async () => {
+		await writeAuthFile('some-user');
+		const fetchSpy = mockStoreResponse(2);
+
+		await useRentalSunsetNotice();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		const requestedUrl = String(fetchSpy.mock.calls[0][0]);
+		expect(requestedUrl).toContain('username=some-user');
+		expect(requestedUrl).toContain('pricingModel=FLAT_PRICE_PER_MONTH');
+
+		expect(logMessages.error.join('\n')).toContain('Rental model sunset');
+
+		expect(await readState()).toMatchObject({
+			rentalSunset: { username: 'some-user', rentalActorCount: 2, lastChecked: now, lastNotifiedAt: now },
+		});
+	});
+
+	it('stays quiet for users without rental Actors', async () => {
+		await writeAuthFile('some-user');
+		mockStoreResponse(0);
+
+		await useRentalSunsetNotice();
+
+		expect(logMessages.error.join('\n')).not.toContain('Rental model sunset');
+	});
+
+	it('does not print again within a day, and does not hit the API either', async () => {
+		await writeAuthFile('some-user');
+		const fetchSpy = mockStoreResponse(2);
+
+		await useRentalSunsetNotice();
+		logMessages.error = [];
+
+		vitest.setSystemTime(now + day / 2);
+		await useRentalSunsetNotice();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(logMessages.error.join('\n')).not.toContain('Rental model sunset');
+	});
+
+	it('warns again a day later, using the cached count', async () => {
+		await writeAuthFile('some-user');
+		const fetchSpy = mockStoreResponse(2);
+
+		await useRentalSunsetNotice();
+		logMessages.error = [];
+
+		vitest.setSystemTime(now + day + 1000);
+		await useRentalSunsetNotice();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(logMessages.error.join('\n')).toContain('Rental model sunset');
+	});
+
+	it('does nothing when the user is not logged in', async () => {
+		const fetchSpy = mockStoreResponse(2);
+
+		await useRentalSunsetNotice();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(logMessages.error.join('\n')).not.toContain('Rental model sunset');
+	});
+
+	it('stays quiet when the API call fails', async () => {
+		await writeAuthFile('some-user');
+		vitest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network is down'));
+
+		await expect(useRentalSunsetNotice()).resolves.toBeUndefined();
+
+		expect(logMessages.error.join('\n')).not.toContain('Rental model sunset');
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
 		env: {
 			APIFY_CLI_DISABLE_TELEMETRY: '1',
 			APIFY_CLI_SKIP_UPDATE_CHECK: '1',
+			APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE: '1',
 			APIFY_NO_LOGS_IN_TESTS: '1',
 		},
 		retry: 3,


### PR DESCRIPTION
Closes #1344

Users with at least one rental Actor published in Apify Store get a notice after each CLI command:

<img width="828" height="298" alt="image" src="https://github.com/user-attachments/assets/91be94c3-7e93-492e-8963-f00e2d8ea417" />

- The notice names both milestones, then points at the pay-per-event migration guide (https://blog.apify.com/migrating-to-pay-per-event-pricing/) for the switch and at `#project-rentals` on Discord for questions.
- Runs from `ApifyCommand._run`'s `finally`, so it prints after the command's own output, in both entrypoints. Goes to stderr, so `--json` payloads stay clean.
- Detection: one unauthenticated `GET /v2/store?username=<you>&pricingModel=FLAT_PRICE_PER_MONTH&limit=1`. Username is read from `auth.json` directly — `getLocalUserInfo()` would hit the OS keyring and pop a keychain prompt on commands that need no auth.
- Printed at most once a day; the Store lookup is cached for a day in `~/.apify/state.json`. Skipped in CI, and auto-expires on 2026-10-01 so old CLI versions stop nagging after the migration. Never throws.
- Opt-out: `APIFY_CLI_SKIP_RENTAL_SUNSET_NOTICE=1` (also set suite-wide in `vitest.config.ts`).
