### PR TITLE
fix: correct fire-and-forget example in apify push --help

### DIFF
--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -145,8 +145,8 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 			command: 'apify push E2jjCZBezvAZnX8Rb --force',
 		},
 		{
-			description: 'Deploy without waiting for the build to finish.',
-			command: 'apify push --no-wait-for-finish',
+			description: 'Deploy without waiting for the build to finish (fire-and-forget).',
+			command: 'apify push --wait-for-finish=0',
 		},
 	];
 

--- a/test/local/lib/command-framework/help.test.ts
+++ b/test/local/lib/command-framework/help.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import stripAnsi from 'strip-ansi';
 
+import { ActorsPushCommand } from '../../../../src/commands/actors/push.js';
 import {
 	ApifyCommand,
 	type BuiltApifyCommand as _BuiltApifyCommand,
@@ -138,6 +139,14 @@ describe('Help rendering', () => {
 
 			expect(output).toContain('# Abort a running Actor gracefully.');
 			expect(output).toContain('$ apify runs abort <runId>');
+		});
+
+		test('renders a valid fire-and-forget example for apify push', () => {
+			registerCommandForHelpGeneration('apify', ActorsPushCommand);
+			const output = stripAnsi(renderHelpForCommand(ActorsPushCommand));
+
+			expect(output).toContain('$ apify push --wait-for-finish=0');
+			expect(output).not.toContain('--no-wait-for-finish');
 		});
 	});
 


### PR DESCRIPTION
## Summary

- The `--help` example showed `apify push --no-wait-for-finish`, but that flag was never registered and crashed with `Error: Unknown flag provided` (fixes #1342)
- The root cause: the custom CLI framework strips the `no-` prefix at `parseArgs` registration time, so a boolean `no-wait-for-finish` flag would collide with the existing `wait-for-finish` string flag — they cannot coexist
- The correct fire-and-forget form is `--wait-for-finish=0`, which is already documented in the flag's own description; the example now matches

## Changes

- `src/commands/actors/push.ts` — fix the broken example (2-line change)
- `test/local/lib/command-framework/help.test.ts` — regression test: asserts `--wait-for-finish=0` appears and `--no-wait-for-finish` does not

## Test plan

- [x] `pnpm vitest run test/local/lib/command-framework/help.test.ts` — 13 tests pass, including the new regression test `renders a valid fire-and-forget example for apify push`
- [x] `pnpm vitest run test/local/commands/push.test.ts` — 11 tests pass
- [x] `pnpm run test:local` — 491 tests pass, 4 skipped
- [x] `pnpm run format` — clean
- [x] `pnpm oxlint --type-aware src/commands/actors/push.ts test/local/lib/command-framework/help.test.ts` — 0 warnings, 0 errors
- [x] `git diff --check` — clean
- [x] `pnpm run dev:apify push --help` — correctly shows `$ apify push --wait-for-finish=0`