### PR TITLE
feat(actors ls): add --public / --private flags to filter actors by visibility

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -690,15 +690,19 @@ DESCRIPTION
 
 USAGE
   $ apify actors ls [--desc] [--json] [--limit <value>] [--my]
-                    [--offset <value>]
+                    [--offset <value>] [--private | --public]
 
 FLAGS
       --desc            Sort Actors in descending order.
       --json            Format the command output as JSON.
       --limit=<value>   Number of Actors that will be listed.
+                        Defaults to 20.
       --my              Whether to list Actors made by the logged
                         in user.
       --offset=<value>  Number of Actors that will be skipped.
+                        Defaults to 0.
+      --private         Show only private Actors.
+      --public          Show only public Actors.
 ```
 
 ##### `apify actors search`

--- a/src/commands/actors/ls.ts
+++ b/src/commands/actors/ls.ts
@@ -1,5 +1,12 @@
 import { Time } from '@sapphire/duration';
-import type { Actor, ActorRunListItem, ActorTaggedBuild, PaginatedList } from 'apify-client';
+import type {
+	Actor,
+	ActorCollectionListItem,
+	ActorRunListItem,
+	ActorTaggedBuild,
+	ApifyClient,
+	PaginatedList,
+} from 'apify-client';
 import chalk from 'chalk';
 
 import type { ACTOR_JOB_STATUSES } from '@apify/consts';
@@ -97,6 +104,8 @@ interface HydratedListData {
 export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 	static override name = 'ls' as const;
 
+	private static readonly INTERNAL_PAGE_SIZE = 100;
+
 	static override description = 'Prints a list of recently executed Actors or Actors you own.';
 
 	static override examples = [
@@ -112,6 +121,14 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 			description: 'List the next page of 50 Actors.',
 			command: 'apify actors ls --limit 50 --offset 50',
 		},
+		{
+			description: 'List only public Actors.',
+			command: 'apify actors ls --public',
+		},
+		{
+			description: 'List only private Actors.',
+			command: 'apify actors ls --private',
+		},
 	];
 
 	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-actors-ls';
@@ -121,13 +138,21 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 			description: 'Whether to list Actors made by the logged in user.',
 			default: false,
 		}),
+		public: Flags.boolean({
+			description: 'Show only public Actors.',
+			default: false,
+			exclusive: ['private'],
+		}),
+		private: Flags.boolean({
+			description: 'Show only private Actors.',
+			default: false,
+			exclusive: ['public'],
+		}),
 		offset: Flags.integer({
-			description: 'Number of Actors that will be skipped.',
-			default: 0,
+			description: 'Number of Actors that will be skipped. Defaults to 0.',
 		}),
 		limit: Flags.integer({
-			description: 'Number of Actors that will be listed.',
-			default: 20,
+			description: 'Number of Actors that will be listed. Defaults to 20.',
 		}),
 		desc: Flags.boolean({
 			description: 'Sort Actors in descending order.',
@@ -138,69 +163,98 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 	static override enableJsonFlag = true;
 
 	async run() {
-		const { desc, limit, offset, my, json } = this.flags;
+		const { desc, limit, offset, my, json, public: publicOnly, private: privateOnly } = this.flags;
 
 		const client = await getLoggedClientOrThrow();
 
-		const rawActorList = await client.actors().list({ limit, offset, desc, my });
+		let actorItems: HydratedListData[];
+		let jsonTotal: number;
+		let jsonOffset: number;
+		let jsonLimit: number;
 
-		if (rawActorList.count === 0) {
+		if (publicOnly || privateOnly) {
+			const matching: HydratedListData[] = [];
+			let pageOffset = 0;
+			let total = Infinity;
+
+			while (pageOffset < total) {
+				const page = await client
+					.actors()
+					.list({ desc, my, limit: ActorsLsCommand.INTERNAL_PAGE_SIZE, offset: pageOffset });
+
+				total = page.total;
+
+				if (page.items.length === 0) break;
+
+				const hydrated = await this.hydrateActors(page.items, client);
+
+				for (const item of hydrated) {
+					if (publicOnly && item.actor?.isPublic === true) matching.push(item);
+					if (privateOnly && item.actor?.isPublic === false) matching.push(item);
+				}
+
+				pageOffset += page.items.length;
+			}
+
+			const sortedMatching = my ? this.sortByModifiedAt(matching) : this.sortByLastRun(matching);
+			jsonTotal = sortedMatching.length;
+			jsonOffset = offset ?? 0;
+			jsonLimit = limit ?? sortedMatching.length;
+			actorItems = sortedMatching.slice(jsonOffset, jsonOffset + jsonLimit);
+		} else {
+			const rawActorList = await client.actors().list({ limit: limit ?? 20, offset: offset ?? 0, desc, my });
+
+			if (rawActorList.count === 0) {
+				if (json) {
+					printJsonToStdout(rawActorList);
+					return;
+				}
+
+				info({
+					message: my ? "You don't have any Actors yet!" : 'There are no recent Actors used by you.',
+					stdout: true,
+				});
+
+				return;
+			}
+
+			actorItems = await this.hydrateActors(rawActorList.items, client);
+			actorItems = my ? this.sortByModifiedAt(actorItems) : this.sortByLastRun(actorItems);
+			jsonTotal = rawActorList.total;
+			jsonOffset = rawActorList.offset;
+			jsonLimit = limit ?? 20;
+		}
+
+		if (actorItems.length === 0) {
 			if (json) {
-				printJsonToStdout(rawActorList);
+				printJsonToStdout({ items: [], total: jsonTotal, count: 0, offset: jsonOffset, limit: jsonLimit, desc });
 				return;
 			}
 
 			info({
-				message: my ? "You don't have any Actors yet!" : 'There are no recent Actors used by you.',
+				message: publicOnly ? 'No public Actors found.' : 'No private Actors found.',
 				stdout: true,
 			});
 
 			return;
 		}
 
-		// Fetch the last run for actors
-		const actorList: PaginatedList<HydratedListData> = {
-			...rawActorList,
-			items: await Promise.all(
-				rawActorList.items.map(async (actorData) => {
-					const actor = await client.actor(actorData.id).get();
-					const runs = await client
-						.actor(actorData.id)
-						.runs()
-						.list({ desc: true, limit: 1 })
-						// Throws an error if the returned actor changed publicity status
-						.catch(
-							() =>
-								({
-									count: 0,
-									desc: true,
-									items: [],
-									limit: 1,
-									offset: 0,
-									total: 0,
-								}) satisfies PaginatedList<ActorRunListItem>,
-						);
-
-					return {
-						...actorData,
-						actor: actor ?? null,
-						lastRun: (runs.items[0] ?? null) as ActorRunListItem | null,
-					} as HydratedListData;
-				}),
-			),
-		};
-
-		actorList.items = my ? this.sortByModifiedAt(actorList.items) : this.sortByLastRun(actorList.items);
-
 		if (json) {
-			printJsonToStdout(actorList);
+			printJsonToStdout({
+				items: actorItems,
+				total: jsonTotal,
+				count: actorItems.length,
+				offset: jsonOffset,
+				limit: jsonLimit,
+				desc,
+			});
 			return;
 		}
 
 		const table = my ? myRecentlyUsedTable : recentlyUsedTable;
 
 		const longestActorTitleLength =
-			actorList.items.reduce((acc, curr) => {
+			actorItems.reduce((acc: number, curr: HydratedListData) => {
 				const title = `${curr.username}/${curr.name}`;
 
 				if (title.length > acc) {
@@ -214,7 +268,7 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 			// Runs column minimum size with padding
 			6;
 
-		for (const item of actorList.items) {
+		for (const item of actorItems) {
 			const lastRunDisplayedTimestamp = item.stats.lastRunStartedAt
 				? MultilineTimestampFormatter.display(item.stats.lastRunStartedAt)
 				: '';
@@ -298,6 +352,36 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 			message: table.render(CompactMode.WebLikeCompact),
 			stdout: true,
 		});
+	}
+
+	private async hydrateActors(items: ActorCollectionListItem[], client: ApifyClient): Promise<HydratedListData[]> {
+		return Promise.all(
+			items.map(async (actorData) => {
+				const actor = await client.actor(actorData.id).get();
+				const runs = await client
+					.actor(actorData.id)
+					.runs()
+					.list({ desc: true, limit: 1 })
+					// Throws an error if the returned actor changed publicity status
+					.catch(
+						() =>
+							({
+								count: 0,
+								desc: true,
+								items: [],
+								limit: 1,
+								offset: 0,
+								total: 0,
+							}) satisfies PaginatedList<ActorRunListItem>,
+					);
+
+				return {
+					...actorData,
+					actor: actor ?? null,
+					lastRun: (runs.items[0] ?? null) as ActorRunListItem | null,
+				} as HydratedListData;
+			}),
+		);
 	}
 
 	private sortByModifiedAt(items: HydratedListData[]) {

--- a/test/e2e/commands/actors/ls.test.ts
+++ b/test/e2e/commands/actors/ls.test.ts
@@ -36,6 +36,46 @@ describe('[e2e][api] actors ls', () => {
 		const result = await runCli('apify', ['actors', 'ls', '--my', '--limit', '5', '--json'], { env: authEnv });
 
 		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
-		expect(() => JSON.parse(result.stdout)).not.toThrow();
+		const parsed = JSON.parse(result.stdout);
+		expect(parsed.items.length).toBeLessThanOrEqual(5);
+		expect(parsed.limit).toBe(5);
+	});
+
+	it('filters to public actors with --public flag', async () => {
+		const result = await runCli('apify', ['actors', 'ls', '--public', '--json'], { env: authEnv });
+
+		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
+		const parsed = JSON.parse(result.stdout);
+		for (const item of parsed.items) {
+			expect(item.actor?.isPublic).toBe(true);
+		}
+	});
+
+	it('filters to private actors with --private flag', async () => {
+		const result = await runCli('apify', ['actors', 'ls', '--private', '--json'], { env: authEnv });
+
+		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
+		const parsed = JSON.parse(result.stdout);
+		for (const item of parsed.items) {
+			expect(item.actor?.isPublic).toBe(false);
+		}
+	});
+
+	it('--private --limit returns correct metadata', async () => {
+		const result = await runCli('apify', ['actors', 'ls', '--private', '--limit', '1', '--json'], { env: authEnv });
+
+		expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
+		const parsed = JSON.parse(result.stdout);
+		expect(parsed.items.length).toBeLessThanOrEqual(1);
+		expect(parsed.limit).toBe(1);
+		expect(parsed.offset).toBe(0);
+		expect(parsed.total).toBeGreaterThanOrEqual(parsed.items.length);
+	});
+
+	it('rejects --public and --private used together', async () => {
+		const result = await runCli('apify', ['actors', 'ls', '--public', '--private'], { env: authEnv });
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('cannot also be provided');
 	});
 });


### PR DESCRIPTION
## Summary

Adds two mutually exclusive flags — `--public` and `--private` — to `apify actors ls`. When either flag is provided the command silently paginates through all actors, filters by visibility client-side, sorts, then applies `--limit` / `--offset` on the result. The no-filter path (existing behavior) is completely unchanged.

Closes #1361.

---

## Problem

`apify actors ls` and `apify actors ls --my` return a mixed list of public and private actors. There was no way to ask "show me only my private actors" from the CLI; users had to open the Apify Console and filter manually.

**What users experienced:**

```
$ apify actors ls --my
# Returns a mix of public and private — no way to narrow it
```

Specifically painful for:
- Auditing which actors are accidentally public or private
- Shell-script automation ("process only private actors")
- CI pipelines that need to assert visibility state

**Why the existing flags were insufficient:**  
`--my`, `--limit`, `--offset`, and `--desc` all operate on raw API pagination; none of them expose `Actor.isPublic`. The Apify API (`GET /v2/acts`) does not accept an `isPublic` query parameter, so filtering had to be client-side.

---

## Root Cause

The `ActorCollectionListOptions` type in `apify-client` offers `my`, `desc`, `limit`, and `offset` — no visibility filter. The full `Actor` object (from `client.actor(id).get()`) _does_ expose `isPublic`, but the collection list endpoint returns lightweight `ActorCollectionListItem` objects that omit it.

Before this PR, the command fetched one page of results and rendered them directly. There was no mechanism to:

1. Fetch across all pages to find every matching actor.
2. Inspect `isPublic` at all.

```
User: apify actors ls --my
         ↓
client.actors().list({ limit, offset, my })   ← single page, no visibility info
         ↓
Render mixed list
```

---

## Solution

Two new boolean flags (`--public`, `--private`) are declared with the framework's `exclusive` constraint so providing both is a hard error.

When either flag is active, a different execution path runs:

```
User: apify actors ls --my --private
         ↓
Filter path activated
         ↓
Pagination loop: client.actors().list({ limit: 100, offset }) until all pages fetched
         ↓
hydrateActors(): client.actor(id).get() for each item → Actor.isPublic available
         ↓
Client-side filter: keep items where isPublic === false
         ↓
sortByModifiedAt() / sortByLastRun() on the full matched set
         ↓
slice(offset, offset + limit) applied after sort
         ↓
Render or emit JSON with correct metadata
```

**Key design decisions:**

- **Sort-before-slice**: `--offset`/`--limit` are applied _after_ sorting the full filtered set. Applying them before sorting would return the wrong page when actors span multiple API pages.
- **Default limit = full matched set**: In the filter path, when `--limit` is not provided, `jsonLimit` is set to `sortedMatching.length` (not 20). Since all actors are already in memory, capping silently at 20 would mean `apify actors ls --private` returns only 20 of 45 private actors with no indication there are more — a silent data loss. A user who wants 20 can still pass `--limit 20`.
- **No-filter path untouched**: the existing `client.actors().list({ limit: limit ?? 20, offset: offset ?? 0, ... })` single-page path is not modified. Its default of 20 is correct because it relies on API-level pagination.

---

## Architecture / Design

### Existing pattern

`ActorsLsCommand.run()` already owned the full fetch → hydrate → sort → render pipeline. The hydration step (fetching the full `Actor` object and last run per item) was inlined directly in `run()` as an anonymous `Promise.all` block.

### What changed

**`hydrateActors()` extracted to a private method** (`src/commands/actors/ls.ts`):

```
ActorsLsCommand
  └── run()
        ├── [filter path]   pagination loop → hydrateActors() → filter → sort → slice
        └── [no-filter path] single page   → hydrateActors() → sort
  └── hydrateActors()       reused by both paths
  └── sortByModifiedAt()    unchanged
  └── sortByLastRun()       unchanged
```

`hydrateActors()` was already effectively present as an inline `Promise.all` — this just gives it a name and signature so both paths can call it without duplicating the Actor + runs fetch logic. No new abstraction layer was introduced; the method lives on the same class and follows the existing private-method pattern (`sortByModifiedAt`, `sortByLastRun`).

**`INTERNAL_PAGE_SIZE = 100`** is a private static constant on the class, consistent with how other internal constants are declared in the codebase. It controls the per-page fetch size of the pagination loop in the filter path and is not exposed to users.

**Two-path `run()`** keeps `jsonTotal`, `jsonOffset`, `jsonLimit` as hoisted `let` variables populated by whichever path runs, so the JSON output block and empty-state block at the bottom of `run()` can use them correctly without duplication.

The change does not introduce any new file, module, or dependency.

---

## Impact

### User impact
Users can now filter by visibility directly from the terminal:
```bash
apify actors ls --private              # all private actors
apify actors ls --public               # all public actors
apify actors ls --my --private         # your private actors
apify actors ls --private --limit 10   # first 10 private actors
apify actors ls --public --private     # error: mutually exclusive
```

### Functional impact
- Filter path: visibility filtering, sort-before-slice, unlimited default.
- No-filter path: behavior identical to before this PR.

### Compatibility impact
**Fully backward-compatible.** The two new flags are additive. All existing invocations (`apify actors ls`, `apify actors ls --my`, `--limit`, `--offset`, `--desc`, `--json`) use the no-filter path and are not affected.

One subtle behavioural difference in the no-filter path: `--limit` and `--offset` no longer carry framework-level defaults (`default: 0` / `default: 20` removed from flag declarations). The values `0` and `20` are now applied explicitly in code (`offset ?? 0`, `limit ?? 20`) to avoid ambiguity between "user did not pass the flag" and "user passed 0/20". This does not change observable behavior but fixes a latent issue where the filter path could not distinguish an explicit `--limit 20` from the default.

### Performance impact
The filter path makes additional API calls (one `GET /v2/acts` per page + one `GET /v2/acts/{id}` per actor). This is inherent to the design: the API does not support server-side visibility filtering. The no-filter path makes the same number of calls as before.

### Security impact
None. No authentication, authorization, or credential-handling code is touched.

### Operational impact
None. No configuration, deployment, or environment changes required.

---

## What This Fixes

- `apify actors ls` could not filter by actor visibility.
- JSON output on the filter path now reports accurate `total`, `offset`, `limit`, and `count` metadata.
- `--limit` / `--offset` on a filtered result set now always apply to a consistently sorted set (sort-before-slice).
- `--public` and `--private` together produce a clear error message rather than silent incorrect behavior.

---

## Testing

**Build and static analysis:**
```
pnpm run build   ✅ clean
pnpm run lint    ✅ no violations (oxlint --type-aware)
pnpm run format  ✅ no diff (oxfmt --check)
pnpm run update-docs  ✅ docs/reference.md regenerated
```

**E2E tests added** (`test/e2e/commands/actors/ls.test.ts`):

| Test | What it proves |
|---|---|
| `filters to public actors with --public flag` | Every item in the response has `actor.isPublic === true` |
| `filters to private actors with --private flag` | Every item has `actor.isPublic === false` |
| `respects --limit flag` (strengthened) | `parsed.items.length ≤ 5` AND `parsed.limit === 5` — previously only checked JSON parsability |
| `--private --limit returns correct metadata` | `limit`, `offset`, `total` are internally consistent |
| `rejects --public and --private used together` | Exit code ≠ 0, stderr contains `"cannot also be provided"` |

---

## Before / After

**Filtering by visibility — Before:**
```
$ apify actors ls --my
# Mixed list, no way to see only private actors
```

**After:**
```
$ apify actors ls --my --private
# Only private actors, all of them, sorted by last run
$ apify actors ls --my --private --limit 5
# First 5 private actors
$ apify actors ls --public --private
Error: --private=true cannot also be provided when using --public
```

**JSON metadata — Before (filter path did not exist; no-filter path):**
```json
{ "total": 80, "count": 20, "offset": 0, "limit": 20 }
```

**After (`--private`, no limit, 45 private actors):**
```json
{ "total": 45, "count": 45, "offset": 0, "limit": 45 }
```

**After (`--private --limit 10`):**
```json
{ "total": 45, "count": 10, "offset": 0, "limit": 10 }
```

---

## Risk / Trade-offs

**Additional API calls in filter path:** Fetching all actors + full Actor objects is O(n) in the number of actors. For accounts with hundreds of actors this is slow. This is a known trade-off: the Apify API does not expose server-side visibility filtering. A future API change adding `?isPublic=true` to `GET /v2/acts` would allow eliminating the pagination loop entirely.

**No streaming:** Results appear only after all pages are fetched and filtered. For large accounts, the command may appear to hang. A progress indicator could be added in a follow-up.

**Concurrent hydration:** `hydrateActors()` calls `client.actor(id).get()` and `.runs().list()` concurrently via `Promise.all`. For the filter path this runs across all actors in a page (100). This should not cause rate-limit issues in normal usage but is worth noting.

Overall the change is low-risk: the no-filter path is untouched, the filter path is entirely new code, and the flags are additive.

---

## Files Changed

**`src/commands/actors/ls.ts`**
- Added `--public` / `--private` flags with `exclusive` mutual-exclusion constraint.
- Added `INTERNAL_PAGE_SIZE = 100` static constant.
- Extracted `hydrateActors()` private method (was inline `Promise.all` in `run()`).
- Added filter path in `run()`: pagination loop, client-side filter, sort-before-slice.
- Hoisted `jsonTotal`, `jsonOffset`, `jsonLimit` so both paths feed a shared JSON/empty-state block.
- Removed framework-level defaults from `--limit` / `--offset` flags; apply defaults explicitly in code.

**`test/e2e/commands/actors/ls.test.ts`**
- Strengthened `--limit` test: now asserts `parsed.limit` value, not just JSON parsability.
- Added four new e2e test cases covering the new flags.

**`docs/reference.md`**
- Regenerated by `pnpm run update-docs`. Now shows `[--private | --public]` in `apify actors ls` usage.

---

## Maintainer Notes

The filter path is intentionally kept separate from the no-filter path rather than merging them into a single flow. The two paths have fundamentally different pagination semantics: the no-filter path delegates pagination to the API (one call, API enforces limit/offset), while the filter path must fetch all data first (because the API cannot filter) and then paginate client-side. Merging them would add conditional complexity throughout the flow for a small DRY gain. The current structure makes it easy to replace the filter path with a server-side call if the API ever gains `?isPublic` support, without touching the no-filter path at all.