### PR TITLE
fix: connect the right Apify account in `apify create --source github`

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -38,6 +38,7 @@ import {
 	promptGitSource,
 	logGitSourceOutcome,
 	runGitSourceFlow,
+	toGitAccount,
 } from '../lib/git-source/gitSource.js';
 import { usePythonRuntime } from '../lib/hooks/runtimes/python.js';
 import { getInstallCommandSuggestion } from '../lib/hooks/runtimes/utils.js';
@@ -49,6 +50,7 @@ import { LANGUAGE_FLAG_CHOICES, USE_CASE_FLAG_CHOICES } from '../lib/templates/c
 import {
 	downloadAndUnzip,
 	getJsonFileContent,
+	getLocalUserInfo,
 	getLoggedClientOrThrow,
 	isNodeVersionSupported,
 	isPythonVersionSupported,
@@ -302,6 +304,8 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 			? {
 					provider: gitProvider,
 					client: await getLoggedClientOrThrow(),
+					// Read after the client, which refreshes auth.json from the token the run resolved.
+					account: toGitAccount(await getLocalUserInfo()),
 					...parseGitRepoFlag(gitRepo, actorName),
 				}
 			: null;
@@ -343,6 +347,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 				templateArchiveUrl,
 				client: gitSetup.client,
 				isInteractive,
+				account: gitSetup.account,
 				customize: applyLocalConfig,
 			});
 		}
@@ -567,6 +572,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 						repoName: gitSetup.repoName,
 						scaffolded: gitResult.scaffolded,
 						actorId: gitResult.actorId,
+						account: gitSetup.account,
 					})
 				: buildNextSteps({ actorName, dependenciesInstalled, installCommandSuggestion });
 
@@ -586,7 +592,9 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 				actorId: gitResult?.actorId ?? null,
 				stopReason: gitResult?.stopReason ?? null,
 				error: gitResult?.error ?? null,
-				gitConnectUrl: gitProvider ? getGitStopUrl(gitProvider, gitResult?.stopReason ?? null) : null,
+				gitConnectUrl: gitProvider
+					? getGitStopUrl(gitProvider, gitResult?.stopReason ?? null, gitSetup?.account)
+					: null,
 				workspaces: gitResult?.workspaces ?? null,
 			});
 		} else if (reportSuccess) {

--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -10,6 +10,7 @@ import { ACTOR_SOURCE_TYPES } from '@apify/consts';
 import { getConsoleUrl } from '../console-url.js';
 import { useSelectFromList } from '../hooks/user-confirmations/useSelectFromList.js';
 import { info, warning } from '../outputs.js';
+import type { AuthJSON } from '../types.js';
 import { cliDebugPrint } from '../utils/cliDebugPrint.js';
 
 /** Where a new Actor's source code lives. `apify` is the existing, Git-less path. */
@@ -83,11 +84,37 @@ const GIT_PROVIDERS = {
 	},
 } satisfies Record<GitProvider, GitProviderConfig>;
 
+/**
+ * The Apify account the CLI token belongs to, as `auth.json` records it. An organization login is the case
+ * that matters: Console completes the exchange as whichever account its own route prefix selects, so
+ * without that prefix the grant lands on the personal account behind the organization instead.
+ */
+export interface GitAccount {
+	id?: string;
+	username?: string;
+	organizationOwnerUserId?: string;
+}
+
+/** Narrows the stored login to what the handoff needs, so the token is not carried around with it. */
+export const toGitAccount = ({ id, username, organizationOwnerUserId }: AuthJSON): GitAccount => ({
+	id,
+	username,
+	organizationOwnerUserId,
+});
+
+/** The Console route the callback page has to run under to complete the exchange as this account. */
+const getConsoleRoutePrefix = (account?: GitAccount) =>
+	account?.organizationOwnerUserId && account.id ? `/organization/${account.id}` : null;
+
 /** Where to send a user who has not connected this provider to Apify yet. */
-export const getGitConnectUrl = (provider: GitProvider) => {
+export const getGitConnectUrl = (provider: GitProvider, account?: GitAccount) => {
 	const { authorizeEndpoint, defaultClientId, clientIdEnvVar, redirectPath } = GIT_PROVIDERS[provider];
 
 	const redirectUri = new URL(redirectPath, getConsoleUrl());
+	const routePrefix = getConsoleRoutePrefix(account);
+	// Encoded twice on purpose, matching Console: it encodes the prefix into the query it builds, and the
+	// callback page decodes it once of its own accord before navigating there.
+	if (routePrefix) redirectUri.searchParams.set('routePrefix', encodeURIComponent(routePrefix));
 
 	const url = new URL(authorizeEndpoint);
 	url.searchParams.set('client_id', process.env[clientIdEnvVar] || defaultClientId);
@@ -207,7 +234,7 @@ const POLL_TIMEOUT_MS = 3 * 60_000;
  */
 const ensureUsableIntegration = async (
 	provider: GitProvider,
-	{ client, isInteractive }: ApiCallOptions & { isInteractive: boolean },
+	{ client, isInteractive, account }: ApiCallOptions & { isInteractive: boolean; account?: GitAccount },
 ): Promise<GitProviderIntegration | null> => {
 	const load = async () => findIntegration(await fetchGitIntegrations({ client }), provider);
 
@@ -222,13 +249,27 @@ const ensureUsableIntegration = async (
 	// Agents and CI must never be parked on a browser; the caller emits the URL and stops instead.
 	if (!isInteractive) return integration ?? null;
 
-	const url = integration ? integration.addWorkspaceUrl || getAddWorkspaceUrl(provider) : getGitConnectUrl(provider);
-	const what = integration ? `Give Apify access to a ${provider} account` : `Connect your ${provider} account to Apify`;
+	// Which grant is missing decides the URL, and authorizing changes the answer: the integration then
+	// exists with no workspaces, and only installing the app fills them. So this is re-read every poll,
+	// and a URL that has already been opened is never opened twice.
+	let openedUrl: string | null = null;
+	const offer = async (current: GitProviderIntegration | undefined) => {
+		const url = current ? current.addWorkspaceUrl || getAddWorkspaceUrl(provider) : getGitConnectUrl(provider, account);
+		if (url === openedUrl) return;
+		openedUrl = url;
 
-	info({ message: `${what}: ${url}` });
-	// Printed above as well — a headless session, or a machine with no usable default browser, still needs it.
-	await open(url).catch(() => undefined);
-	info({ message: 'Waiting for authorization to complete in your browser...' });
+		const what = current ? `Give Apify access to a ${provider} account` : `Connect your ${provider} account to Apify`;
+		info({ message: `${what}: ${url}` });
+		// Printed above as well — a headless session, or a machine with no usable default browser, still needs it.
+		await open(url).catch(() => undefined);
+		info({
+			message: account?.username
+				? `Waiting for authorization to complete in your browser. It connects ${provider} to the Apify account ${account.username}.`
+				: 'Waiting for authorization to complete in your browser...',
+		});
+	};
+
+	await offer(integration);
 
 	const deadline = Date.now() + POLL_TIMEOUT_MS;
 	let interval = POLL_INTERVAL_START_MS;
@@ -237,6 +278,7 @@ const ensureUsableIntegration = async (
 		interval = Math.min(Math.round(interval * 1.5), POLL_INTERVAL_MAX_MS);
 		integration = await load();
 		if (integration?.workspaces.length) return integration;
+		await offer(integration);
 	}
 
 	return integration ?? null;
@@ -425,6 +467,8 @@ export interface RunGitSourceFlowOptions extends ApiCallOptions {
 	isPrivate: boolean;
 	templateArchiveUrl: string;
 	isInteractive: boolean;
+	/** The account the run authorizes as, so an organization login connects the organization. */
+	account?: GitAccount;
 	/** Local-only setup for the clone. Runs between the clone and the commit, so its changes land in git. */
 	customize: (dir: string) => Promise<void>;
 }
@@ -443,6 +487,7 @@ export const runGitSourceFlow = async ({
 	isPrivate,
 	templateArchiveUrl,
 	isInteractive,
+	account,
 	customize,
 }: RunGitSourceFlowOptions): Promise<GitSourceResult> => {
 	let scaffolded = false;
@@ -464,16 +509,17 @@ export const runGitSourceFlow = async ({
 
 	let integration: GitProviderIntegration | null;
 	try {
-		integration = await ensureUsableIntegration(provider, { client, isInteractive });
+		integration = await ensureUsableIntegration(provider, { client, isInteractive, account });
 	} catch (err) {
 		return stopped('lookupFailed', err);
 	}
 
+	const who = account?.username ? `The Apify account ${account.username}` : 'Apify';
 	if (!integration) {
-		return stopped('notAuthorized', new Error(`Apify is not authorized to access your ${provider} account.`));
+		return stopped('notAuthorized', new Error(`${who} is not authorized to access ${provider}.`));
 	}
 	if (!integration.workspaces.length) {
-		return stopped('noWorkspace', new Error(`Apify has no ${provider} account to create the repository in.`));
+		return stopped('noWorkspace', new Error(`${who} has no ${provider} account to create the repository in.`));
 	}
 
 	const workspaces = integration.workspaces.map(({ id }) => id);
@@ -557,8 +603,12 @@ export const runGitSourceFlow = async ({
  * The URL that unblocks a stop, when one exists — `gitConnectUrl` in the `--json` payload. Authorization
  * and installation are separate grants, so the two stops resolve to different places.
  */
-export const getGitStopUrl = (provider: GitProvider, stopReason: GitSourceStopReason | null): string | null => {
-	if (stopReason === 'notAuthorized') return getGitConnectUrl(provider);
+export const getGitStopUrl = (
+	provider: GitProvider,
+	stopReason: GitSourceStopReason | null,
+	account?: GitAccount,
+): string | null => {
+	if (stopReason === 'notAuthorized') return getGitConnectUrl(provider, account);
 	if (stopReason === 'noWorkspace') return getAddWorkspaceUrl(provider);
 	return null;
 };
@@ -576,6 +626,7 @@ export interface GitSourceNextStepsOptions {
 	scaffolded: boolean;
 	/** Set once the Actor exists, so a later stop can link to it. */
 	actorId?: string | null;
+	account?: GitAccount;
 }
 
 /** What to tell the user, or hand an agent in `--json`, once the Git wiring has stopped. */
@@ -588,6 +639,7 @@ export const buildGitSourceNextSteps = ({
 	repoName,
 	scaffolded,
 	actorId,
+	account,
 }: GitSourceNextStepsOptions): string[] => {
 	const enter = `cd "${actorName}"`;
 
@@ -597,7 +649,10 @@ export const buildGitSourceNextSteps = ({
 		case 'lookupFailed':
 			return ['Re-run with APIFY_CLI_DEBUG=1 to see the failing request'];
 		case 'notAuthorized':
-			return [`Connect your ${provider} account to Apify: ${getGitConnectUrl(provider)}`, 'then re-run apify create'];
+			return [
+				`Connect your ${provider} account to Apify: ${getGitConnectUrl(provider, account)}`,
+				'then re-run apify create',
+			];
 		case 'noWorkspace':
 			return [`Give Apify access to an account: ${getAddWorkspaceUrl(provider)}`, 'then re-run apify create'];
 		case 'unknownWorkspace':

--- a/test/local/lib/gitSource.test.ts
+++ b/test/local/lib/gitSource.test.ts
@@ -58,6 +58,31 @@ describe('getGitConnectUrl', () => {
 		);
 	});
 
+	// The callback page verifies the code as the account its route prefix selects, so an organization
+	// login without this connects the personal account behind it and the CLI waits for nothing.
+	it('sends an organization login to its own Console route', () => {
+		const url = new URL(
+			getGitConnectUrl('github', {
+				id: 'qTyaZThN7mnbef6iQ',
+				username: 'balrog',
+				organizationOwnerUserId: 'eCJxAGafqfxEVvmjx',
+			}),
+		);
+		const redirectUri = new URL(url.searchParams.get('redirect_uri')!);
+
+		// Double-encoded, as Console builds it: the page decodes the value once before navigating there.
+		expect(redirectUri.searchParams.get('routePrefix')).toBe('%2Forganization%2FqTyaZThN7mnbef6iQ');
+		expect(decodeURIComponent(redirectUri.searchParams.get('routePrefix')!)).toBe('/organization/qTyaZThN7mnbef6iQ');
+	});
+
+	it('leaves a personal login on the root Console route', () => {
+		const url = new URL(getGitConnectUrl('github', { id: 'eCJxAGafqfxEVvmjx', username: 'l2ysho' }));
+
+		expect(url.searchParams.get('redirect_uri')).toBe(
+			'https://console.apify.com/actors/new/git/connected?service=github',
+		);
+	});
+
 	it('honours the environment overrides', () => {
 		process.env.APIFY_GITHUB_APP_CLIENT_ID = 'Iv1.staging';
 		process.env.APIFY_CONSOLE_URL = 'https://console.staging.example.com';
@@ -143,6 +168,17 @@ describe('buildGitSourceNextSteps', () => {
 
 		expect(notAuthorized).toContainEqual(expect.stringContaining('login/oauth/authorize'));
 		expect(noWorkspace).toContainEqual(expect.stringContaining('installations/new'));
+	});
+
+	// The recovery URL has to carry the prefix too, or the re-run repeats the same dead end.
+	it('keeps an organization login on its own route in the recovery steps', () => {
+		const steps = buildGitSourceNextSteps({
+			...base,
+			stopReason: 'notAuthorized',
+			account: { id: 'qTyaZThN7mnbef6iQ', username: 'balrog', organizationOwnerUserId: 'eCJxAGafqfxEVvmjx' },
+		});
+
+		expect(steps.join('\n')).toContain('routePrefix');
 	});
 
 	// A clone that landed already has its remote, so re-adding one would exit with "remote origin


### PR DESCRIPTION
> [!NOTE]
> **TL;DR** — `apify create --source github` connected GitHub to the wrong Apify account for anyone logged in as an organization. The connect link omitted the `routePrefix` query parameter, so Console verified the OAuth code as the personal account behind the organization and the CLI waited for an integration that could never appear. Fixed by sending the prefix, and by naming the account the CLI is connecting so a grant that lands elsewhere is visible instead of silent.

Fixes #1370.

### What changed

`src/lib/git-source/gitSource.ts`

- `getGitConnectUrl` sends `routePrefix=/organization/<id>` for an organization login, encoded the way Console encodes it. The callback page decodes it and navigates to the organization route, so the code is verified as the organization.
- New `GitAccount` type and `toGitAccount()`, which keeps id, username and `organizationOwnerUserId` and leaves the token out of the flow options.
- The wait loop re-reads which grant is missing on every poll. Authorizing makes the integration appear with no workspaces, and only installing the app fills them, so the install URL is offered as soon as authorization lands instead of after the 3-minute timeout. A URL that has already been opened is never opened twice.
- The wait line and the `notAuthorized` / `noWorkspace` errors name the Apify account, so a grant that landed on another account is visible instead of silent.
- `getGitStopUrl` and `buildGitSourceNextSteps` take the account too, so the recovery URL is not the same dead end.

`src/commands/create.ts` reads the account after `getLoggedClientOrThrow()`, which refreshes `auth.json` from the token the run resolved, and threads it through the flow, the next steps and the `--json` `gitConnectUrl`.

### Reviewer notes

- The prefix is double-encoded on the wire. This matches Console's own implementation, which does `encodeURIComponent(prefix)` and then encodes again into the query it builds; the callback page decodes once by parsing the query and once more with `decodeURIComponent`. Verified against the deployed Console bundle, not inferred.
- `type: USER` routes each get a generated `/organization/:viewedUserId` twin, and `viewedUserId` from the pathname selects the token the callback verifies under. That is what binds the grant to the organization.
- Nothing else changes for a personal login. There is a test asserting the URL stays byte-identical to before.
- Console-side, not fixed here: the callback page calls `window.close()`, which browsers ignore for a tab the CLI opened with `open()`. Console's own flow uses a 900×700 popup, where close works. The CLI cannot get a popup, so the user is left on a page with a dead Close button.

### Verification

Verified live on an organization login, with Console's UI left on the personal account to prove the routing does not depend on it. `apify create --source github` sends the grant to the organization, and workspace selection proceeds.

### Follow-up

A second bug surfaced while testing this one: the CLI guesses which GitHub grant is missing from an API state where the two possibilities are indistinguishable, so it can offer a link that never resolves. That is unrelated to redirects and hits personal accounts too. It is fixed in a follow-up PR stacked on this branch.

### Checks

`lint`, `format`, `build`, `test:local` (493 passed, 4 skipped). No docs regen — no flag, arg or description changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
