### PR TITLE
feat: re-prompt for a repository name when the provider rejects it

### DIFF
--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -9,6 +9,7 @@ import { ACTOR_SOURCE_TYPES } from '@apify/consts';
 
 import { getConsoleUrl } from '../console-url.js';
 import { useSelectFromList } from '../hooks/user-confirmations/useSelectFromList.js';
+import { useUserInput } from '../hooks/user-confirmations/useUserInput.js';
 import { info, warning } from '../outputs.js';
 import { cliDebugPrint } from '../utils/cliDebugPrint.js';
 
@@ -493,21 +494,36 @@ export const runGitSourceFlow = async ({
 	const { workspace } = chosen;
 
 	let repo: CreatedRemoteRepo;
-	try {
-		info({
-			message: `Creating ${isPrivate ? 'private' : 'public'} repository ${workspace}/${repoName} from the template...`,
-		});
-		repo = await createRemoteRepo({
-			client,
-			provider,
-			workspace,
-			repoName,
-			isPrivate,
-			templateArchiveUrl,
-		});
-	} catch (err) {
-		const stopReason = err instanceof CreateRemoteRepoError ? err.stopReason : 'repoCreateFailed';
-		return stopped(stopReason, err, { workspaces });
+	while (true) {
+		try {
+			info({
+				message: `Creating ${isPrivate ? 'private' : 'public'} repository ${workspace}/${repoName} from the template...`,
+			});
+			repo = await createRemoteRepo({
+				client,
+				provider,
+				workspace,
+				repoName,
+				isPrivate,
+				templateArchiveUrl,
+			});
+			break;
+		} catch (err) {
+			// A taken or malformed name is the one failure the user can fix without re-running, and
+			// nothing has been created yet — so ask for another name instead of stopping.
+			if (err instanceof CreateRemoteRepoError && err.stopReason === 'repoNameRejected' && isInteractive) {
+				warning({ message: err.message });
+				repoName = await useUserInput({
+					message: 'Choose a different repository name:',
+					validate: (value) => value.trim().length > 0 || 'Enter a repository name.',
+				});
+				continue;
+			}
+
+			return stopped(err instanceof CreateRemoteRepoError ? err.stopReason : 'repoCreateFailed', err, {
+				workspaces,
+			});
+		}
 	}
 
 	try {

--- a/test/local/lib/gitSource.test.ts
+++ b/test/local/lib/gitSource.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	buildGitSourceNextSteps,
@@ -9,8 +9,20 @@ import {
 	isGitProvider,
 	logGitSourceOutcome,
 	parseGitRepoFlag,
+	runGitSourceFlow,
 	chooseWorkspace,
 } from '../../../src/lib/git-source/gitSource.js';
+import { useUserInput } from '../../../src/lib/hooks/user-confirmations/useUserInput.js';
+
+vi.mock('../../../src/lib/hooks/user-confirmations/useUserInput.js', () => ({
+	useUserInput: vi.fn(),
+}));
+
+const useUserInputMock = vi.mocked(useUserInput);
+
+beforeEach(() => {
+	useUserInputMock.mockReset();
+});
 
 describe('parseGitRepoFlag', () => {
 	it('falls back to the Actor name and an unset workspace when the flag is omitted', () => {
@@ -207,5 +219,75 @@ describe('logGitSourceOutcome', () => {
 		}
 
 		expect(lines[0]).toContain('Actor scaffolded');
+	});
+});
+
+describe('runGitSourceFlow', () => {
+	const client = { baseUrl: 'https://api.example.com/v2', token: 'token' } as never;
+
+	const options = {
+		client,
+		provider: 'github' as const,
+		actorDir: '/tmp/apify-create-git-source',
+		actorName: 'my-scraper',
+		repoName: 'my-scraper',
+		isPrivate: true,
+		templateArchiveUrl: 'https://example.com/template.zip',
+		isInteractive: true,
+		customize: async () => {},
+	};
+
+	const jsonResponse = (status: number, body: unknown) =>
+		new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+	// A taken name is fixable on the spot, so the run has to ask for another one rather than making the
+	// user start over — the second attempt must reach the API with the name the user typed.
+	it('asks for another repository name when the provider rejects the first one', async () => {
+		useUserInputMock.mockResolvedValueOnce('my-scraper-2');
+
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValueOnce(
+				jsonResponse(200, {
+					data: [{ id: 'github-app', provider: 'github', workspaces: [{ id: 'apify', label: 'apify' }] }],
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse(400, { error: { type: 'invalid-parameter', message: 'Name already exists' } }),
+			)
+			.mockResolvedValueOnce(jsonResponse(500, { error: { type: 'internal-server-error', message: 'Boom' } }));
+
+		try {
+			const result = await runGitSourceFlow(options);
+
+			expect(useUserInputMock).toHaveBeenCalledTimes(1);
+			expect(JSON.parse(String(fetchMock.mock.calls[2][1]!.body))).toMatchObject({ repoName: 'my-scraper-2' });
+			expect(result.stopReason).toBe('repoCreateFailed');
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	// Nobody is there to answer the prompt, so a rejected name has to stop with actionable steps instead.
+	it('stops on a rejected name when it cannot ask', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValueOnce(
+				jsonResponse(200, {
+					data: [{ id: 'github-app', provider: 'github', workspaces: [{ id: 'apify', label: 'apify' }] }],
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse(400, { error: { type: 'invalid-parameter', message: 'Name already exists' } }),
+			);
+
+		try {
+			const result = await runGitSourceFlow({ ...options, isInteractive: false });
+
+			expect(useUserInputMock).not.toHaveBeenCalled();
+			expect(result.stopReason).toBe('repoNameRejected');
+		} finally {
+			fetchMock.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
> [!NOTE]
> **TL;DR** — `apify create --source github` no longer throws away the whole run when GitHub rejects the repository name. In a TTY it asks for another name and retries; without one it stops as before.

Closes #1372

`apify create --source github` stopped the whole run when the Git provider rejected the repository name — taken, or malformed. The name is fixable on the spot and nothing has been created at that point, so an interactive run now prints the provider's message and asks for another name, then retries.

- Interactive only. Without a TTY (`--json`, CI, piped stdin) the run keeps the previous `repoNameRejected` stop and its next steps.
- No prefilled value in the prompt: defaulting to the rejected name would make Enter repeat the same failure.
- Tests cover both branches of `runGitSourceFlow` — the retry sends the new name, the non-interactive path still stops.

Verified by hand against GitHub: taken name in a TTY re-prompts and the run completes; the same command with stdin from `/dev/null` stops with the error.

No new dependencies, so no install-size change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)