### PR TITLE
fix: name both Git grants when the platform cannot tell them apart

### DIFF
--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -219,6 +219,76 @@ const fetchGitIntegrations = async (options: ApiCallOptions): Promise<GitProvide
 const findIntegration = (integrations: GitProviderIntegration[], provider: GitProvider) =>
 	integrations.find((integration) => integration.id === GIT_PROVIDERS[provider].providerId);
 
+/** One of the two grants the platform needs, and how to ask the user for it. */
+export interface PendingGrant {
+	kind: 'connect' | 'install';
+	url: string;
+	what: string;
+	waiting: string;
+}
+
+/**
+ * The grants that may still be missing, the likeliest first.
+ *
+ * The API cannot say which one it is. An authorized user who has installed the app nowhere and one whose
+ * token the provider has revoked are reported identically: the integration is present, `workspaces` is
+ * empty, and `addWorkspaceUrl` is absent, because it is derived from the first installation. Only one of
+ * those is fixed by installing the app, so both are named whenever the run cannot tell them apart.
+ *
+ * `authorizedHere` is what breaks the tie: a run that has already sent the user through authorization
+ * knows the integration it is now seeing is the result, which leaves the installation as the missing one.
+ */
+export const getPendingGrants = (
+	provider: GitProvider,
+	integration: GitProviderIntegration | undefined,
+	{ account, authorizedHere = false }: { account?: GitAccount; authorizedHere?: boolean } = {},
+): PendingGrant[] => {
+	const connect: PendingGrant = {
+		kind: 'connect',
+		url: getGitConnectUrl(provider, account),
+		what: `Connect your ${provider} account to Apify`,
+		waiting: 'Waiting for authorization to complete in your browser.',
+	};
+
+	const install: PendingGrant = {
+		kind: 'install',
+		url: integration?.addWorkspaceUrl || getAddWorkspaceUrl(provider),
+		what: `Give Apify access to a ${provider} account`,
+		waiting: 'Waiting for the app installation to complete in your browser.',
+	};
+
+	if (!integration) return [connect];
+
+	// Both mean the provider token works, so authorization is settled and only the installation is left:
+	// the run watched the authorization land, or the API derived `addWorkspaceUrl` from a live listing.
+	if (authorizedHere || integration.addWorkspaceUrl) return [install];
+
+	return [connect, install];
+};
+
+/**
+ * Remembers what has already been offered, so the same URL is never opened twice and the run keeps track
+ * of whether it watched the user authorize. Returns the grants to show now, or null when nothing changed.
+ *
+ * Only an authorization offered while no integration existed counts: offering one in the ambiguous state
+ * says nothing about whether the user completed it, and treating it as done would reorder the grants on
+ * the very next poll and pull the user off the page they were just sent to.
+ */
+export const createGrantTracker = (provider: GitProvider, account?: GitAccount) => {
+	let openedUrl: string | null = null;
+	let authorizedHere = false;
+
+	return (integration: GitProviderIntegration | undefined): PendingGrant[] | null => {
+		const grants = getPendingGrants(provider, integration, { account, authorizedHere });
+		const [next] = grants;
+		if (next.url === openedUrl) return null;
+
+		openedUrl = next.url;
+		authorizedHere ||= next.kind === 'connect' && !integration;
+		return grants;
+	};
+};
+
 // Backs off, so the early polls stay fast without costing a request every two seconds for three minutes.
 const POLL_INTERVAL_START_MS = 2_000;
 const POLL_INTERVAL_MAX_MS = 10_000;
@@ -230,8 +300,8 @@ const POLL_TIMEOUT_MS = 3 * 60_000;
  * the API is the only way to know it finished. Returns null when the user never did.
  *
  * Two separate grants are needed: OAuth authorization makes the integration appear at all, while
- * installing the app populates `workspaces`. Authorizing again cannot fix a missing installation, so the
- * two cases open different URLs.
+ * installing the app populates `workspaces`. `createGrantTracker` decides what is still missing, and
+ * it is re-read every poll because completing one changes the answer.
  */
 const ensureUsableIntegration = async (
 	provider: GitProvider,
@@ -250,36 +320,42 @@ const ensureUsableIntegration = async (
 	// Agents and CI must never be parked on a browser; the caller emits the URL and stops instead.
 	if (!isInteractive) return integration ?? null;
 
-	// Which grant is missing decides the URL, and authorizing changes the answer: the integration then
-	// exists with no workspaces, and only installing the app fills them. So this is re-read every poll,
-	// and a URL that has already been opened is never opened twice.
-	let openedUrl: string | null = null;
+	// Which grant is pending changes as the user makes progress, so it is re-read every poll.
+	const trackGrants = createGrantTracker(provider, account);
 	const offer = async (current: GitProviderIntegration | undefined) => {
-		const url = current ? current.addWorkspaceUrl || getAddWorkspaceUrl(provider) : getGitConnectUrl(provider, account);
-		if (url === openedUrl) return;
-		openedUrl = url;
+		const grants = trackGrants(current);
+		if (!grants) return false;
 
-		const what = current ? `Give Apify access to a ${provider} account` : `Connect your ${provider} account to Apify`;
-		info({ message: `${what}: ${url}` });
+		const [next, ...also] = grants;
+		info({ message: `${next.what}: ${next.url}` });
+		// Only the first is opened. The rest are printed so an ambiguous state still leaves the user with
+		// the link the platform could not tell them they needed.
+		for (const other of also) info({ message: `Already done? ${other.what}: ${other.url}` });
 		// Printed above as well — a headless session, or a machine with no usable default browser, still needs it.
-		await open(url).catch(() => undefined);
+		await open(next.url).catch(() => undefined);
 		info({
 			message: account?.username
-				? `Waiting for authorization to complete in your browser. It connects ${provider} to the Apify account ${account.username}.`
-				: 'Waiting for authorization to complete in your browser...',
+				? `${next.waiting} Apify will connect ${provider} to the account ${account.username}.`
+				: next.waiting,
 		});
+		return true;
 	};
 
 	await offer(integration);
 
-	const deadline = Date.now() + POLL_TIMEOUT_MS;
+	// Each new URL is a step the user still has to do in the browser, so it gets the whole budget rather
+	// than what the step before it left over.
+	let deadline = Date.now() + POLL_TIMEOUT_MS;
 	let interval = POLL_INTERVAL_START_MS;
 	while (Date.now() < deadline) {
 		await sleep(interval);
 		interval = Math.min(Math.round(interval * 1.5), POLL_INTERVAL_MAX_MS);
 		integration = await load();
 		if (integration?.workspaces.length) return integration;
-		await offer(integration);
+		if (await offer(integration)) {
+			deadline = Date.now() + POLL_TIMEOUT_MS;
+			interval = POLL_INTERVAL_START_MS;
+		}
 	}
 
 	return integration ?? null;
@@ -669,8 +745,14 @@ export const buildGitSourceNextSteps = ({
 				`Connect your ${provider} account to Apify: ${getGitConnectUrl(provider, account)}`,
 				'then re-run apify create',
 			];
+		// Both grants are named: from here the CLI cannot tell a missing installation from a revoked token,
+		// and the second is only recovered by authorizing again.
 		case 'noWorkspace':
-			return [`Give Apify access to an account: ${getAddWorkspaceUrl(provider)}`, 'then re-run apify create'];
+			return [
+				`Give Apify access to an account: ${getAddWorkspaceUrl(provider)}`,
+				`Or reconnect ${provider} if access is already granted: ${getGitConnectUrl(provider, account)}`,
+				'then re-run apify create',
+			];
 		case 'unknownWorkspace':
 		case 'ambiguousWorkspace':
 			return [`Re-run naming the account: --git-repo <account>/${repoName}`];

--- a/test/local/lib/gitSource.test.ts
+++ b/test/local/lib/gitSource.test.ts
@@ -4,6 +4,8 @@ import {
 	buildGitSourceNextSteps,
 	getAddWorkspaceUrl,
 	getGitConnectUrl,
+	createGrantTracker,
+	getPendingGrants,
 	type GitProviderIntegration,
 	type GitSourceResult,
 	isGitProvider,
@@ -114,6 +116,117 @@ describe('getAddWorkspaceUrl', () => {
 	});
 });
 
+describe('getPendingGrants', () => {
+	const account = { id: 'orgId', username: 'my-org', organizationOwnerUserId: 'ownerId' };
+	const authorize = 'https://github.com/login/oauth/authorize';
+	const install = 'https://github.com/apps/apify/installations/new';
+	const empty: GitProviderIntegration = { id: 'github-app', provider: 'github', workspaces: [] };
+
+	// The API leaves the integration out entirely until the user has authorized, so this state is the
+	// only unambiguous one.
+	it('asks only for authorization when nothing is connected', () => {
+		const grants = getPendingGrants('github', undefined, { account });
+
+		expect(grants).toHaveLength(1);
+		expect(grants[0].kind).toBe('connect');
+		expect(grants[0].url).toContain(authorize);
+		expect(grants[0].url).toContain('routePrefix');
+	});
+
+	// An authorized user who has installed the app nowhere and one whose token the provider revoked are
+	// reported identically, and the fix for one does nothing for the other, so neither may be dropped.
+	it('names both grants when the integration has no workspaces', () => {
+		const grants = getPendingGrants('github', empty, { account });
+
+		expect(grants.map(({ kind }) => kind)).toEqual(['connect', 'install']);
+		expect(grants[0].url).toContain(authorize);
+		expect(grants[1].url).toBe(install);
+	});
+
+	// The run watched the user authorize, so the integration it is seeing now is that grant landing, which
+	// settles authorization and leaves only the installation.
+	it('asks only for the installation once this run has sent the user through authorization', () => {
+		const grants = getPendingGrants('github', empty, { account, authorizedHere: true });
+
+		expect(grants.map(({ kind }) => kind)).toEqual(['install']);
+		expect(grants[0].url).toBe(install);
+	});
+
+	// `addWorkspaceUrl` is derived from a live installation listing, so the token behind it works and the
+	// ambiguity does not apply.
+	it('asks only for the installation when the API reports a place to add one', () => {
+		const grants = getPendingGrants('github', { ...empty, addWorkspaceUrl: install }, { account });
+
+		expect(grants.map(({ kind }) => kind)).toEqual(['install']);
+	});
+
+	it('prefers the installation URL the API reports over the one it builds', () => {
+		const reported = 'https://github.com/apps/apify-staging/installations/new';
+		const grants = getPendingGrants('github', { ...empty, addWorkspaceUrl: reported }, { account });
+
+		expect(grants.find(({ kind }) => kind === 'install')?.url).toBe(reported);
+	});
+
+	// The wait line is the only thing on screen while the CLI polls, so it has to name the grant that is
+	// actually pending.
+	it('carries a wait line matching each grant', () => {
+		const [connect, installGrant] = getPendingGrants('github', empty, { account });
+
+		expect(connect.waiting).toContain('authorization');
+		expect(installGrant.waiting).toContain('installation');
+	});
+});
+
+describe('createGrantTracker', () => {
+	const account = { id: 'orgId', username: 'my-org', organizationOwnerUserId: 'ownerId' };
+	const empty: GitProviderIntegration = { id: 'github-app', provider: 'github', workspaces: [] };
+	const filled: GitProviderIntegration = {
+		id: 'github-app',
+		provider: 'github',
+		workspaces: [],
+		addWorkspaceUrl: 'https://github.com/apps/apify/installations/new',
+	};
+
+	it('offers both grants once when the state is ambiguous, then goes quiet', () => {
+		const track = createGrantTracker('github', account);
+
+		expect(track(empty)?.map(({ kind }) => kind)).toEqual(['connect', 'install']);
+		expect(track(empty)).toBeNull();
+		expect(track(empty)).toBeNull();
+	});
+
+	// Offering authorization in the ambiguous state says nothing about whether the user completed it.
+	// Counting it as done reordered the grants on the next poll and opened a second tab two seconds
+	// after sending the user to the first one.
+	it('does not treat an authorization offered in the ambiguous state as completed', () => {
+		const track = createGrantTracker('github', account);
+		const first = track(empty);
+
+		expect(first?.[0].kind).toBe('connect');
+		expect(track(empty)).toBeNull();
+	});
+
+	it('moves on to the installation once authorization it watched has landed', () => {
+		const track = createGrantTracker('github', account);
+
+		expect(track(undefined)?.map(({ kind }) => kind)).toEqual(['connect']);
+		expect(track(empty)?.map(({ kind }) => kind)).toEqual(['install']);
+		expect(track(empty)).toBeNull();
+	});
+
+	it('never offers the same URL twice in a row', () => {
+		const track = createGrantTracker('github', account);
+		const opened: string[] = [];
+
+		for (const state of [undefined, empty, empty, filled, filled]) {
+			const grants = track(state);
+			if (grants) opened.push(grants[0].url);
+		}
+
+		expect(new Set(opened).size).toBe(opened.length);
+	});
+});
+
 describe('chooseWorkspace', () => {
 	const two: GitProviderIntegration = {
 		id: 'github-app',
@@ -172,8 +285,8 @@ describe('buildGitSourceNextSteps', () => {
 		expect(steps.every((step) => step.trim().length > 0)).toBe(true);
 	});
 
-	// Authorizing again cannot fix a missing installation, so these two must not send the user to the
-	// same place.
+	// `noWorkspace` names both grants, because at that point the two are indistinguishable — but the
+	// installation is the one the `notAuthorized` steps never mention.
 	it('distinguishes "never connected" from "connected but no account"', () => {
 		const notAuthorized = buildGitSourceNextSteps({ ...base, stopReason: 'notAuthorized' });
 		const noWorkspace = buildGitSourceNextSteps({ ...base, stopReason: 'noWorkspace' });
@@ -220,7 +333,7 @@ describe('logGitSourceOutcome', () => {
 		actorId: null,
 		workspaces: null,
 		stopReason: 'notAuthorized',
-		error: 'Apify is not authorized to access your github account.',
+		error: 'Apify is not authorized to access github.',
 		scaffolded,
 	});
 


### PR DESCRIPTION
> [!IMPORTANT]
> **TL;DR** — `apify create --source github` in some scenarios I got stuck in auth flow, this needs further investigation

---

Stacked on #1371 — it depends on the `GitAccount` parameter that PR adds to `getGitConnectUrl`. Retarget to `master` once #1371 merges.

Not the redirect bug in #1371. This one hits personal accounts too.

### The state the CLI has to read

apify-core, `src/api/src/routes/integrations/git_providers.ts`, reports four situations in three shapes:

| situation | integration | `workspaces` | `addWorkspaceUrl` | grant needed |
|---|---|---|---|---|
| not authorized | absent | — | — | authorize |
| authorized, app installed | present | filled | present | none |
| authorized, app installed nowhere | present | `[]` | absent | **install** |
| provider token revoked | present | `[]` | absent | **authorize** |

`addWorkspaceUrl` comes from `data.installations[0]?.app_slug`, so it is absent when there are no installations — and absent again in the `catch` when the installation listing fails, which is what a revoked token produces. The last two rows are byte-identical on the wire. No heuristic separates them.

The old code always chose the installation link for both, so a revoked token was handed a link that changes nothing, and the poll loop waited out its full budget on a state that could never move.

### What changed

`src/lib/git-source/gitSource.ts`

- `getPendingGrants()` returns the grants that may still be missing, likeliest first. No integration means authorization, unambiguously. An integration carrying `addWorkspaceUrl` means the listing succeeded, so the token works and only the installation is left. Anything else is ambiguous and names both.
- `createGrantTracker()` holds the state that spans polls: the last URL opened, and whether this run watched an authorization land. A run that offered authorization while no integration existed knows the integration it then sees is that grant landing. Offering authorization in the ambiguous state proves nothing and does not count — treating it as proof reorders the grants on the very next poll and opens a second tab on top of a user still sitting on the consent page.
- The wait loop opens the first grant and prints the rest, so an ambiguous state always leaves the other link on screen. It never opens the same URL twice, and resets the deadline and backoff when a new URL is opened, so each browser step gets the whole budget rather than the previous step's leftovers.
- The wait line follows the grant, so it no longer says "Waiting for authorization" while the pending step is the installation.
- The `noWorkspace` recovery steps name both grants, for the same reason the wait loop does.

### Reviewer notes

- Splitting the decision out of the polling is what makes it testable. `createGrantTracker` is driven directly over a poll sequence, with no mocking of `open`, `fetch` or timers. Reverting the tie-break fails five of those tests.
- `--json` `gitConnectUrl` still carries a single URL for `noWorkspace`. The same payload includes `nextSteps`, which names both, and a single-URL field cannot represent an ambiguity the API itself cannot resolve.
- Worth fixing in apify-core, which would let this logic be deleted: the `catch` in `getGithubIntegration` turns a revoked token into a shape meaning "authorized, nothing installed". Returning `null` on a 401 collapses that into "not authorized". There is also no `github_app_authorization` webhook handler, so `isAuthorized` is never cleared when a user revokes on GitHub.

### Verification

Reproduced live by revoking the Apify authorization on GitHub, which leaves `GET /v2/integrations/git` reporting `workspaces: []` and no `addWorkspaceUrl` — the state that used to hang. The CLI now opens the authorization URL, the grant lands, and workspace selection proceeds.

### Checks

`lint`, `format`, `build`, `test:local` (503 passed, 4 skipped). No docs regen — no flag, arg or description changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
