### PR TITLE
feat: turn on automatic builds for a Git-sourced Actor

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -290,10 +290,10 @@ ARGUMENTS
 
 FLAGS
       --auto-build=<option>      Whether a push to the
-                                 repository rebuilds the Actor. Turning it on
-                                 registers a push webhook on the new repository,
-                                 which needs admin rights on it. Only used when
-                                 --source is a Git provider.
+                                 repository rebuilds the Actor. On by default.
+                                 Turning it on registers a push webhook on the new
+                                 repository, which needs admin rights on it. Only
+                                 used when --source is a Git provider.
                                  <options: on|off>
       --git-repo=<value>         Repository to create, as
                                  "workspace/name" — a workspace being an account or

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -277,7 +277,8 @@ DESCRIPTION
   directory.
 
 USAGE
-  $ apify create [actorName] [--git-repo <value>] [--json]
+  $ apify create [actorName] [--auto-build on|off]
+                 [--git-repo <value>] [--json]
                  [-l javascript|js|typescript|ts|python|py]
                  [--omit-optional-deps] [--skip-dependency-install]
                  [--skip-git-init] [--source apify|github|gitlab|bitbucket]
@@ -288,6 +289,12 @@ ARGUMENTS
   actorName  Name of the Actor and its directory.
 
 FLAGS
+      --auto-build=<option>      Whether a push to the
+                                 repository rebuilds the Actor. Turning it on
+                                 registers a push webhook on the new repository,
+                                 which needs admin rights on it. Only used when
+                                 --source is a Git provider.
+                                 <options: on|off>
       --git-repo=<value>         Repository to create, as
                                  "workspace/name" — a workspace being an account or
                                  organization you have given Apify access to. A bare

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -152,7 +152,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 		}),
 		'auto-build': Flags.string({
 			description:
-				'Whether a push to the repository rebuilds the Actor. Turning it on registers a push webhook on the new repository, which needs admin rights on it. Only used when --source is a Git provider.',
+				'Whether a push to the repository rebuilds the Actor. On by default. Turning it on registers a push webhook on the new repository, which needs admin rights on it. Only used when --source is a Git provider.',
 			choices: ['on', 'off'],
 			default: 'on',
 			required: false,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -150,6 +150,13 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 				'Repository to create, as "workspace/name" — a workspace being an account or organization you have given Apify access to. A bare value is read as the name, not the workspace. The name defaults to the Actor name, and the workspace is asked for when you have more than one. List yours with "apify api integrations/git". Only used when --source is a Git provider.',
 			required: false,
 		}),
+		'auto-build': Flags.string({
+			description:
+				'Whether a push to the repository rebuilds the Actor. Turning it on registers a push webhook on the new repository, which needs admin rights on it. Only used when --source is a Git provider.',
+			choices: ['on', 'off'],
+			default: 'on',
+			required: false,
+		}),
 		origin: Flags.string({
 			description: 'Where the command was invoked from. Used for funnel telemetry.',
 			choices: ['console', 'cli'],
@@ -306,6 +313,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 					client: await getLoggedClientOrThrow(),
 					// Read after the client, which refreshes auth.json from the token the run resolved.
 					account: toGitAccount(await getLocalUserInfo()),
+					autoBuild: this.flags.autoBuild !== 'off',
 					...parseGitRepoFlag(gitRepo, actorName),
 				}
 			: null;
@@ -348,6 +356,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 				client: gitSetup.client,
 				isInteractive,
 				account: gitSetup.account,
+				autoBuild: gitSetup.autoBuild,
 				customize: applyLocalConfig,
 			});
 		}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -154,7 +154,8 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 			description:
 				'Whether a push to the repository rebuilds the Actor. On by default. Turning it on registers a push webhook on the new repository, which needs admin rights on it. Only used when --source is a Git provider.',
 			choices: ['on', 'off'],
-			default: 'on',
+			// No default: the framework would fill it in, leaving no way to tell an omitted flag from a
+			// typed one — and a flag typed against the wrong source has to be caught, not ignored.
 			required: false,
 		}),
 		origin: Flags.string({
@@ -302,6 +303,11 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 			throw new Error('--git-repo only applies to a Git source, so add --source github|gitlab|bitbucket or drop it.');
 		}
 
+		// Only a Git source has a repository to rebuild from, so an Apify-sourced run would ignore this.
+		if (!gitProvider && this.flags.autoBuild) {
+			throw new Error('--auto-build only applies to a Git source, so add --source github|gitlab|bitbucket or drop it.');
+		}
+
 		// The platform only accepts archive URLs listed in the official manifest.
 		if (gitProvider && this.flags.templateArchiveUrl) {
 			throw new Error(`--template-archive-url is not supported with --source ${source}.`);
@@ -313,6 +319,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 					client: await getLoggedClientOrThrow(),
 					// Read after the client, which refreshes auth.json from the token the run resolved.
 					account: toGitAccount(await getLocalUserInfo()),
+					// Omitted means on: the webhook is what makes a Git-sourced Actor rebuild on a push.
 					autoBuild: this.flags.autoBuild !== 'off',
 					...parseGitRepoFlag(gitRepo, actorName),
 				}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -589,6 +589,7 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 				postCreate: messages?.postCreate ?? null,
 				gitRepositoryInitialized,
 				remote: gitResult?.remoteUrl ?? null,
+				automaticBuilds: gitResult?.automaticBuilds ?? null,
 				actorId: gitResult?.actorId ?? null,
 				stopReason: gitResult?.stopReason ?? null,
 				error: gitResult?.error ?? null,
@@ -608,7 +609,11 @@ export class CreateCommand extends ApifyCommand<typeof CreateCommand> {
 					installCommandSuggestion,
 					gitRemote:
 						gitResult?.remoteUrl && gitResult.actorId
-							? { remoteUrl: gitResult.remoteUrl, actorId: gitResult.actorId }
+							? {
+									remoteUrl: gitResult.remoteUrl,
+									actorId: gitResult.actorId,
+									automaticBuilds: gitResult.automaticBuilds,
+								}
 							: null,
 				}),
 			});

--- a/src/lib/create-utils.ts
+++ b/src/lib/create-utils.ts
@@ -103,7 +103,7 @@ export function formatCreateSuccessMessage(params: {
 	gitRepositoryInitialized?: boolean;
 	installCommandSuggestion?: string | null;
 	/** Set once the Actor is wired to a Git remote, which changes how it gets deployed. */
-	gitRemote?: { remoteUrl: string; actorId: string } | null;
+	gitRemote?: { remoteUrl: string; actorId: string; automaticBuilds: boolean } | null;
 }) {
 	const {
 		actorName,
@@ -120,10 +120,12 @@ export function formatCreateSuccessMessage(params: {
 	message += `\n\nNext steps:\n\n${nextSteps.join('\n')}`;
 
 	if (gitRemote) {
-		// A Git-sourced Actor builds from the repository, so `apify push` is the wrong advice. Automatic
-		// builds are off by default, so do not promise that a plain `git push` rebuilds anything.
+		// A Git-sourced Actor builds from the repository, so `apify push` is the wrong advice. Only promise
+		// that a push rebuilds it when the webhook actually landed.
 		message += `\n\n🌱 Connected to ${gitRemote.remoteUrl} — Actor ${gitRemote.actorId} builds from this repository.`;
-		message += `\n💡 Tip: Turn on Automatic builds in the Actor's Source settings to rebuild on every push.`;
+		message += gitRemote.automaticBuilds
+			? `\n🔁 Every push to this repository rebuilds the Actor.`
+			: `\n💡 Tip: Turn on Automatic builds in the Actor's Source settings to rebuild on every push.`;
 	} else {
 		message += `\n\n💡 Tip: Use 'apify push' to deploy your Actor to the Apify platform`;
 

--- a/src/lib/create-utils.ts
+++ b/src/lib/create-utils.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 
 import type { Manifest, Template } from '@apify/actor-templates';
 
+import type { AutomaticBuilds } from './git-source/gitSource.js';
 import type { ChoicesType } from './hooks/user-confirmations/useSelectFromList.js';
 import { useSelectFromList } from './hooks/user-confirmations/useSelectFromList.js';
 import { useUserInput } from './hooks/user-confirmations/useUserInput.js';
@@ -103,7 +104,7 @@ export function formatCreateSuccessMessage(params: {
 	gitRepositoryInitialized?: boolean;
 	installCommandSuggestion?: string | null;
 	/** Set once the Actor is wired to a Git remote, which changes how it gets deployed. */
-	gitRemote?: { remoteUrl: string; actorId: string; automaticBuilds: boolean } | null;
+	gitRemote?: { remoteUrl: string; actorId: string; automaticBuilds: AutomaticBuilds } | null;
 }) {
 	const {
 		actorName,
@@ -123,9 +124,12 @@ export function formatCreateSuccessMessage(params: {
 		// A Git-sourced Actor builds from the repository, so `apify push` is the wrong advice. Only promise
 		// that a push rebuilds it when the webhook actually landed.
 		message += `\n\n🌱 Connected to ${gitRemote.remoteUrl} — Actor ${gitRemote.actorId} builds from this repository.`;
-		message += gitRemote.automaticBuilds
-			? `\n🔁 Every push to this repository rebuilds the Actor.`
-			: `\n💡 Tip: Turn on Automatic builds in the Actor's Source settings to rebuild on every push.`;
+		if (gitRemote.automaticBuilds === 'on') {
+			message += `\n🔁 Every push to this repository rebuilds the Actor.`;
+		} else if (gitRemote.automaticBuilds === 'failed') {
+			// Only worth a tip when it was asked for and refused; someone who passed --auto-build=off knows.
+			message += `\n💡 Tip: Turn on Automatic builds in the Actor's Source settings to rebuild on every push.`;
+		}
 	} else {
 		message += `\n\n💡 Tip: Use 'apify push' to deploy your Actor to the Apify platform`;
 

--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -539,9 +539,6 @@ const cloneRepo = async (dir: string, httpsUrl: string, isInteractive: boolean) 
 	await execa('git', ['clone', httpsUrl, dir], { env });
 };
 
-/** The single version `createGitActor` makes, and the one the build-on-push webhook is keyed to. */
-const GIT_ACTOR_VERSION = '0.0';
-
 const createGitActor = async ({
 	client,
 	actorName,
@@ -551,7 +548,7 @@ const createGitActor = async ({
 		name: actorName,
 		versions: [
 			{
-				versionNumber: GIT_ACTOR_VERSION,
+				versionNumber: '0.0',
 				// TODO: export enum from apify-client (same cast as actors/push.ts)
 				sourceType: ACTOR_SOURCE_TYPES.GIT_REPO as never,
 				gitRepoUrl,
@@ -604,15 +601,16 @@ const registerDeploymentKey = async ({
  * rebuilds the Actor. Console calls this "Automatic builds", and leaves it off.
  *
  * The API resolves the provider token from `providerId` itself, so nothing about the repository is passed.
- * Registering a webhook needs admin rights on it, which connecting the account does not, so this is the
- * one platform step a fully connected account can still be refused.
+ * The version is the only one `createGitActor` makes. Registering a webhook needs admin rights on the
+ * repository, which connecting the account does not, so this is the one platform step a fully connected
+ * account can still be refused.
  */
 export const enableAutomaticBuilds = async ({
 	client,
 	providerId,
 	actorId,
 }: ApiCallOptions & { providerId: string; actorId: string }) => {
-	const url = apiUrl({ client }, `actors/${actorId}/versions/${GIT_ACTOR_VERSION}/build-on-push`);
+	const url = apiUrl({ client }, `actors/${actorId}/versions/0.0/build-on-push`);
 	const body = JSON.stringify({ providerId, enabled: true });
 	cliDebugPrint('git-source', 'PUT', url, body);
 

--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -803,10 +803,13 @@ export const runGitSourceFlow = async ({
 		try {
 			await enableAutomaticBuilds({ client, providerId: workspace.providerId, actorId });
 			automaticBuilds = 'on';
+			info({ message: 'Turned on automatic builds.' });
 		} catch (err) {
 			automaticBuilds = 'failed';
 			warning({ message: `Automatic builds stay off: ${err instanceof Error ? err.message : String(err)}` });
 		}
+	} else {
+		info({ message: 'Automatic builds stay off, so a push does not rebuild the Actor.' });
 	}
 
 	if (cloneError) {

--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -49,6 +49,8 @@ export interface GitSourceResult {
 	error: string | null;
 	/** Whether the clone put the template on disk — false means the Actor directory is still empty. */
 	scaffolded: boolean;
+	/** Whether a push to the repository rebuilds the Actor. False also when we stopped before trying. */
+	automaticBuilds: boolean;
 }
 
 interface GitProviderConfig {
@@ -532,6 +534,9 @@ const cloneRepo = async (dir: string, httpsUrl: string, isInteractive: boolean) 
 	await execa('git', ['clone', httpsUrl, dir], { env });
 };
 
+/** The single version `createGitActor` makes, and the one the build-on-push webhook is keyed to. */
+const GIT_ACTOR_VERSION = '0.0';
+
 const createGitActor = async ({
 	client,
 	actorName,
@@ -541,7 +546,7 @@ const createGitActor = async ({
 		name: actorName,
 		versions: [
 			{
-				versionNumber: '0.0',
+				versionNumber: GIT_ACTOR_VERSION,
 				// TODO: export enum from apify-client (same cast as actors/push.ts)
 				sourceType: ACTOR_SOURCE_TYPES.GIT_REPO as never,
 				gitRepoUrl,
@@ -578,6 +583,45 @@ const registerDeploymentKey = async ({
 
 	// The API distinguishes a revoked token, a denied key, a missing repository and a duplicate key, but
 	// they all leave the user in one place: no key, so no build. Its own message says which.
+	const message = (() => {
+		try {
+			return (JSON.parse(raw) as { error?: { message?: string } }).error?.message;
+		} catch {
+			return null;
+		}
+	})();
+
+	throw new Error(message || `${response.status} ${response.statusText}`);
+};
+
+/**
+ * `PUT /v2/actors/:id/versions/:v/build-on-push` — registers a push webhook on the repository, so a push
+ * rebuilds the Actor. Console calls this "Automatic builds", and leaves it off.
+ *
+ * The API resolves the provider token from `providerId` itself, so nothing about the repository is passed.
+ * Registering a webhook needs admin rights on it, which connecting the account does not, so this is the
+ * one platform step a fully connected account can still be refused.
+ */
+export const enableAutomaticBuilds = async ({
+	client,
+	providerId,
+	actorId,
+}: ApiCallOptions & { providerId: string; actorId: string }) => {
+	const url = apiUrl({ client }, `actors/${actorId}/versions/${GIT_ACTOR_VERSION}/build-on-push`);
+	const body = JSON.stringify({ providerId, enabled: true });
+	cliDebugPrint('git-source', 'PUT', url, body);
+
+	const response = await fetch(url, {
+		method: 'PUT',
+		headers: { ...authHeader({ client }), 'Content-Type': 'application/json' },
+		body,
+	});
+
+	const raw = await response.text();
+	cliDebugPrint('git-source', 'PUT', url, '->', response.status, raw.slice(0, 400));
+
+	if (response.ok) return;
+
 	const message = (() => {
 		try {
 			return (JSON.parse(raw) as { error?: { message?: string } }).error?.message;
@@ -633,6 +677,7 @@ export const runGitSourceFlow = async ({
 		actorId: null,
 		workspaces: null,
 		scaffolded,
+		automaticBuilds: false,
 		...extra,
 		stopReason,
 		error: err instanceof Error ? err.message : String(err),
@@ -743,12 +788,23 @@ export const runGitSourceFlow = async ({
 		});
 	}
 
+	// A webhook is what makes a push rebuild; without it the Actor still builds on demand. So a refusal
+	// here costs a convenience, not the run, and the next steps say where to turn it on by hand.
+	let automaticBuilds = false;
+	try {
+		await enableAutomaticBuilds({ client, providerId: workspace.providerId, actorId });
+		automaticBuilds = true;
+	} catch (err) {
+		warning({ message: `Automatic builds stay off: ${err instanceof Error ? err.message : String(err)}` });
+	}
+
 	if (cloneError) {
 		return stopped('gitSetupFailed', cloneError, {
 			workspaces,
 			remoteUrl: repo.sshUrl,
 			httpsUrl: repo.httpsUrl,
 			actorId,
+			automaticBuilds,
 		});
 	}
 
@@ -760,6 +816,7 @@ export const runGitSourceFlow = async ({
 		stopReason: null,
 		error: null,
 		scaffolded: true,
+		automaticBuilds,
 	};
 };
 

--- a/src/lib/git-source/gitSource.ts
+++ b/src/lib/git-source/gitSource.ts
@@ -37,6 +37,8 @@ export type GitSourceStopReason =
 	| 'actorCreateFailed'
 	| 'deploymentKeyFailed';
 
+export type AutomaticBuilds = 'on' | 'off' | 'failed';
+
 export interface GitSourceResult {
 	remoteUrl: string | null;
 	/** The clone URL, kept apart from `remoteUrl`: local recovery has no SSH key, the platform does. */
@@ -49,8 +51,11 @@ export interface GitSourceResult {
 	error: string | null;
 	/** Whether the clone put the template on disk — false means the Actor directory is still empty. */
 	scaffolded: boolean;
-	/** Whether a push to the repository rebuilds the Actor. False also when we stopped before trying. */
-	automaticBuilds: boolean;
+	/**
+	 * Whether a push to the repository rebuilds the Actor: `off` when it was not asked for or we stopped
+	 * before trying, `failed` when the provider refused the webhook.
+	 */
+	automaticBuilds: AutomaticBuilds;
 }
 
 interface GitProviderConfig {
@@ -642,6 +647,8 @@ export interface RunGitSourceFlowOptions extends ApiCallOptions {
 	isPrivate: boolean;
 	templateArchiveUrl: string;
 	isInteractive: boolean;
+	/** Whether to register the push webhook, so a push rebuilds the Actor. */
+	autoBuild: boolean;
 	/** The account the run authorizes as, so an organization login connects the organization. */
 	account?: GitAccount;
 	/** Local-only setup for the clone. Runs between the clone and the commit, so its changes land in git. */
@@ -663,6 +670,7 @@ export const runGitSourceFlow = async ({
 	templateArchiveUrl,
 	isInteractive,
 	account,
+	autoBuild,
 	customize,
 }: RunGitSourceFlowOptions): Promise<GitSourceResult> => {
 	let scaffolded = false;
@@ -677,7 +685,7 @@ export const runGitSourceFlow = async ({
 		actorId: null,
 		workspaces: null,
 		scaffolded,
-		automaticBuilds: false,
+		automaticBuilds: 'off',
 		...extra,
 		stopReason,
 		error: err instanceof Error ? err.message : String(err),
@@ -789,13 +797,16 @@ export const runGitSourceFlow = async ({
 	}
 
 	// A webhook is what makes a push rebuild; without it the Actor still builds on demand. So a refusal
-	// here costs a convenience, not the run, and the next steps say where to turn it on by hand.
-	let automaticBuilds = false;
-	try {
-		await enableAutomaticBuilds({ client, providerId: workspace.providerId, actorId });
-		automaticBuilds = true;
-	} catch (err) {
-		warning({ message: `Automatic builds stay off: ${err instanceof Error ? err.message : String(err)}` });
+	// here costs a convenience, not the run, and the success message says where to turn it on by hand.
+	let automaticBuilds: AutomaticBuilds = 'off';
+	if (autoBuild) {
+		try {
+			await enableAutomaticBuilds({ client, providerId: workspace.providerId, actorId });
+			automaticBuilds = 'on';
+		} catch (err) {
+			automaticBuilds = 'failed';
+			warning({ message: `Automatic builds stay off: ${err instanceof Error ? err.message : String(err)}` });
+		}
 	}
 
 	if (cloneError) {

--- a/test/local/commands/create-git-source.test.ts
+++ b/test/local/commands/create-git-source.test.ts
@@ -17,6 +17,7 @@ const SUCCESS: GitSourceResult = {
 	stopReason: null,
 	error: null,
 	scaffolded: true,
+	automaticBuilds: 'on',
 };
 
 // Gave up before the clone, so nothing reached the disk.
@@ -28,6 +29,7 @@ const AMBIGUOUS_WORKSPACE_STOP: GitSourceResult = {
 	stopReason: 'ambiguousWorkspace',
 	error: 'Several accounts are connected (apify, l2ysho); pick one with --git-repo <account>/<name>.',
 	scaffolded: false,
+	automaticBuilds: 'off',
 };
 
 // The clone landed but the wiring after it did not, so the scaffold is on disk with no Actor.
@@ -39,6 +41,7 @@ const GIT_SETUP_FAILED_STOP: GitSourceResult = {
 	stopReason: 'gitSetupFailed',
 	error: 'Could not write the Actor configuration.',
 	scaffolded: true,
+	automaticBuilds: 'off',
 };
 
 let stop: GitSourceResult = AMBIGUOUS_WORKSPACE_STOP;
@@ -47,7 +50,14 @@ let stop: GitSourceResult = AMBIGUOUS_WORKSPACE_STOP;
 vitest.mock('../../../src/lib/git-source/gitSource.js', async (importOriginal) => ({
 	...(await importOriginal<typeof import('../../../src/lib/git-source/gitSource.js')>()),
 	runGitSourceFlow: vitest.fn(
-		async ({ actorDir, customize }: { actorDir: string; customize: (dir: string) => Promise<void> }) => {
+		async ({
+			actorDir,
+			customize,
+		}: {
+			actorDir: string;
+			autoBuild: boolean;
+			customize: (dir: string) => Promise<void>;
+		}) => {
 			// Stand in for the clone: a scaffolded stop leaves a repository behind.
 			if (stop.scaffolded) {
 				await mkdir(join(actorDir, '.git'), { recursive: true });
@@ -176,9 +186,31 @@ describe('apify create --source github, successful', () => {
 		expect(output).toContain('created successfully');
 		expect(output).toContain(SUCCESS.remoteUrl);
 		expect(output).toContain(SUCCESS.actorId);
-		expect(output).toContain('Automatic builds');
+		expect(output).toContain('Every push to this repository rebuilds the Actor');
 		// A Git-sourced Actor builds from the repository, so the push tip would be wrong.
 		expect(output).not.toContain('apify push');
+	});
+
+	// Automatic builds are on unless asked otherwise, and someone who turned them off does not need to be
+	// told how to turn them on.
+	it('honours --auto-build=off', async () => {
+		stop = { ...SUCCESS, automaticBuilds: 'off' };
+
+		await testRunCommand(CreateCommand, {
+			args_actorName: actName,
+			flags_template: 'project_empty',
+			flags_source: 'github',
+			flags_skipDependencyInstall: true,
+			flags_autoBuild: 'off',
+		});
+
+		const { runGitSourceFlow } = await import('../../../src/lib/git-source/gitSource.js');
+		expect(vitest.mocked(runGitSourceFlow).mock.lastCall![0]).toMatchObject({ autoBuild: false });
+
+		const output = logMessages.error.join('\n');
+		expect(output).toContain('created successfully');
+		expect(output).not.toContain('Automatic builds');
+		expect(output).not.toContain('Every push');
 	});
 
 	it('applies the local configuration to the clone', async () => {
@@ -203,6 +235,7 @@ describe('apify create --source github, successful', () => {
 		const output = JSON.parse(logMessages.log[0]);
 
 		expect(output.source).toBe('github');
+		expect(output.automaticBuilds).toBe('on');
 		expect(output.stopReason).toBeNull();
 		expect(output.error).toBeNull();
 		expect(output.remote).toBe(SUCCESS.remoteUrl);

--- a/test/local/commands/create-git-source.test.ts
+++ b/test/local/commands/create-git-source.test.ts
@@ -113,6 +113,22 @@ afterEach(async () => {
 	await afterAllCalls();
 });
 
+// A flag the run would ignore is worse than a stop, which is how `--git-repo` and `--skip-git-init`
+// already behave against the wrong source.
+describe('apify create --auto-build without a Git source', () => {
+	it('stops instead of ignoring the flag', async () => {
+		await testRunCommand(CreateCommand, {
+			args_actorName: actName,
+			flags_template: 'project_empty',
+			flags_source: 'apify',
+			flags_skipDependencyInstall: true,
+			flags_autoBuild: 'off',
+		});
+
+		expect(logMessages.error.join('\n')).toContain('--auto-build only applies to a Git source');
+	});
+});
+
 describe('apify create --source github, stopped before the clone', () => {
 	beforeEach(() => {
 		stop = AMBIGUOUS_WORKSPACE_STOP;

--- a/test/local/lib/create-utils.test.ts
+++ b/test/local/lib/create-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCreateSuccessMessage } from '../../../src/lib/create-utils.js';
+
+describe('formatCreateSuccessMessage', () => {
+	const base = { actorName: 'my-scraper', dependenciesInstalled: true };
+	const gitRemote = { remoteUrl: 'git@github.com:apify/my-scraper.git', actorId: 'abc123' };
+
+	// `apify push` replaces the source with the local files, which is the opposite of what a Git-sourced
+	// Actor wants, so the Git cases must never suggest it.
+	it('names the repository the Actor builds from', () => {
+		const message = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: false } });
+
+		expect(message).toContain('git@github.com:apify/my-scraper.git');
+		expect(message).toContain('Actor abc123 builds from this repository');
+		expect(message).not.toContain('apify push');
+	});
+
+	// Registering the webhook needs admin rights on the repository, which connecting the account does not,
+	// so the promise that a push rebuilds anything has to follow what actually landed.
+	it('promises a rebuild on push only once the webhook is registered', () => {
+		const on = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: true } });
+		const off = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: false } });
+
+		expect(on).toContain('Every push to this repository rebuilds the Actor');
+		expect(on).not.toContain('Turn on Automatic builds');
+
+		expect(off).toContain('Turn on Automatic builds');
+		expect(off).not.toContain('Every push to this repository rebuilds');
+	});
+
+	it('keeps pointing a template without a Git remote at apify push', () => {
+		const message = formatCreateSuccessMessage({ ...base, gitRepositoryInitialized: true });
+
+		expect(message).toContain("Use 'apify push'");
+		expect(message).not.toContain('builds from this repository');
+	});
+});

--- a/test/local/lib/create-utils.test.ts
+++ b/test/local/lib/create-utils.test.ts
@@ -9,7 +9,7 @@ describe('formatCreateSuccessMessage', () => {
 	// `apify push` replaces the source with the local files, which is the opposite of what a Git-sourced
 	// Actor wants, so the Git cases must never suggest it.
 	it('names the repository the Actor builds from', () => {
-		const message = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: false } });
+		const message = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: 'on' } });
 
 		expect(message).toContain('git@github.com:apify/my-scraper.git');
 		expect(message).toContain('Actor abc123 builds from this repository');
@@ -19,14 +19,23 @@ describe('formatCreateSuccessMessage', () => {
 	// Registering the webhook needs admin rights on the repository, which connecting the account does not,
 	// so the promise that a push rebuilds anything has to follow what actually landed.
 	it('promises a rebuild on push only once the webhook is registered', () => {
-		const on = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: true } });
-		const off = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: false } });
+		const on = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: 'on' } });
+		const failed = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: 'failed' } });
 
 		expect(on).toContain('Every push to this repository rebuilds the Actor');
 		expect(on).not.toContain('Turn on Automatic builds');
 
-		expect(off).toContain('Turn on Automatic builds');
-		expect(off).not.toContain('Every push to this repository rebuilds');
+		expect(failed).toContain('Turn on Automatic builds');
+		expect(failed).not.toContain('Every push to this repository rebuilds');
+	});
+
+	// Someone who passed --auto-build=off does not need to be told how to turn it on.
+	it('says nothing about automatic builds when they were not asked for', () => {
+		const message = formatCreateSuccessMessage({ ...base, gitRemote: { ...gitRemote, automaticBuilds: 'off' } });
+
+		expect(message).toContain('builds from this repository');
+		expect(message).not.toContain('Automatic builds');
+		expect(message).not.toContain('Every push');
 	});
 
 	it('keeps pointing a template without a Git remote at apify push', () => {

--- a/test/local/lib/gitSource.test.ts
+++ b/test/local/lib/gitSource.test.ts
@@ -16,6 +16,7 @@ import {
 	chooseWorkspace,
 	readProviderState,
 	ensureUsableIntegration,
+	enableAutomaticBuilds,
 } from '../../../src/lib/git-source/gitSource.js';
 import { useUserInput } from '../../../src/lib/hooks/user-confirmations/useUserInput.js';
 
@@ -509,6 +510,44 @@ describe('ensureUsableIntegration', () => {
 
 		expect(state).toEqual({ connected: false, workspaces: [], addWorkspaceUrl: undefined });
 		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('enableAutomaticBuilds', () => {
+	const client = { baseUrl: 'https://api.example.com/v2', token: 'token' } as never;
+
+	// The webhook is keyed to the single version `createGitActor` makes, so the path has to name it.
+	it('toggles the webhook on the version the Actor was created with', async () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }) as never);
+
+		try {
+			await enableAutomaticBuilds({ client, providerId: 'integration-1', actorId: 'abc123' });
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://api.example.com/v2/actors/abc123/versions/0.0/build-on-push');
+			expect(init.method).toBe('PUT');
+			expect(JSON.parse(String(init.body))).toEqual({ providerId: 'integration-1', enabled: true });
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	// Connecting an account does not grant admin rights on a repository, so this is the one platform step
+	// a fully connected account can still be refused — and the API's own message says which.
+	it('reports the API message when the provider refuses the webhook', async () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ error: { type: 'integration-auth', message: 'Repository admin required' } }), {
+				status: 403,
+			}) as never,
+		);
+
+		try {
+			await expect(enableAutomaticBuilds({ client, providerId: 'integration-1', actorId: 'abc123' })).rejects.toThrow(
+				'Repository admin required',
+			);
+		} finally {
+			fetchMock.mockRestore();
+		}
 	});
 });
 

--- a/test/local/lib/gitSource.test.ts
+++ b/test/local/lib/gitSource.test.ts
@@ -563,6 +563,7 @@ describe('runGitSourceFlow', () => {
 		isPrivate: true,
 		templateArchiveUrl: 'https://example.com/template.zip',
 		isInteractive: true,
+		autoBuild: true,
 		customize: async () => {},
 	};
 


### PR DESCRIPTION
> [!NOTE]
> **TL;DR** — `apify create --source github|gitlab|bitbucket` now registers the push webhook, so a push rebuilds the Actor. It used to tell the user to go and switch it on in Console. `--auto-build=off` opts out.

Closes #1355.

## What was missing

The flow wired the repository, the Actor and the deploy key, and then stopped. Nothing registered the push webhook — **not for any provider, GitHub included.** `create-utils.ts` even said so:

```
// Automatic builds are off by default, so do not promise that a plain `git push` rebuilds anything.
```

So every Git-sourced Actor the CLI made needed a manual visit to Console → Source → Build settings.

## Nothing was needed on the platform side

Parity already exists for all three providers:

| Layer | Route | Providers |
|---|---|---|
| Public API | `PUT /v2/actors/:id/versions/:v/build-on-push` | `setGithub…`, `setGitlab…`, `setBitbucket…BuildOnPushWebhook` |
| Console backend | `POST /<provider>/setup-webhook/:actorId` | `github_app`, `gitlab`, `bitbucket` |

Body is `{ providerId, enabled }`. The API resolves the provider token from `providerId`, so the CLI passes nothing about the repository. Neither `create-repo` nor Console's own new-Actor-from-git wizard registers it, which is why it was off everywhere.

## What changed

- One `PUT` after `registerDeploymentKey` succeeds, with the `providerId` the flow already used for `create-repo` and the version `createGitActor` makes. That version number is now a shared const instead of two literals.
- **A refusal does not fail the run.** Registering a webhook needs admin rights on the repository; connecting an account does not grant them. So this is the one platform step a fully connected account can still be refused — it warns and continues, the same way a failed clone keeps the Actor.
- The success message promises a rebuild on push only when the webhook landed. Otherwise it keeps the old tip.
- **`--auto-build on|off`, default `on`.** `off` skips the registration entirely.
- `automaticBuilds` added to the flow result and to `create --json`. It is `on`, `off` or `failed` rather than a boolean — `off` covers both "not asked for" and "stopped before trying", and only `failed` earns the tip about turning it on by hand.

## Worth knowing about the default

On by default diverges from Console, whose git wizard makes the user opt in. Two consequences:

1. Enabling mints an `INTEGRATION_API_TOKEN` per webhook, embedded in the delivery URL. So a plain `apify create` now creates a token in the user's account without asking.
2. A Bitbucket token without `repository:admin` connects cleanly — `shouldValidateScopes: false` on the core side — and is refused only here. Those users get a warning they did not get before.

Neither breaks the run, and `--auto-build=off` is the escape hatch.

## Not fixed here: #1142

That issue is two other things, and this change touches neither:

1. `apify push` on a Git-sourced Actor switches the source type to the local files.
2. After switching back to Git, Automatic builds could not be enabled.

Worth noting for whoever picks it up: the API throws `The Actor version is not linked to a git repository` when the version has no `gitRepoUrl`. If (1) leaves the version without one, that is exactly the symptom in (2) — so (2) may be a consequence of (1) rather than its own bug.

## Verification

`lint`, `format`, `build` clean. `test:local`: 532 passed, 4 skipped. `docs/reference.md` regenerated for the new flag.

8 new tests: the request shape (URL, method, body), the API-message path on a 403, the success message in all three states, and `--auto-build=off` reaching the flow and staying quiet.

**Not yet run live.** The endpoint and its parameters were read from `apify-core`, not exercised. Draft until a real `apify create --source gitlab` and `--source bitbucket` confirm a push triggers a build.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
