### PR TITLE
feat: ask before `apify push` drops a Git source

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -800,7 +800,8 @@ FLAGS
                                  Actor is located.
   -f, --force                    Push an Actor even
                                  when the local files are older than the Actor on
-                                 the platform.
+                                 the platform, or when the Actor builds from a Git
+                                 repository.
       --json                     Format the command
                                  output as JSON.
       --open                     Whether to open the

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -22,6 +22,7 @@ import { CommandExitCodes, DEPRECATED_LOCAL_CONFIG_NAME, LOCAL_CONFIG_PATH } fro
 import { sumFilesSizeInBytes } from '../../lib/files.js';
 import { useAbortJobOnSignal } from '../../lib/hooks/useAbortJobOnSignal.js';
 import { useActorConfig } from '../../lib/hooks/useActorConfig.js';
+import { useYesNoConfirm } from '../../lib/hooks/user-confirmations/useYesNoConfirm.js';
 import { error, info, run, simpleLog, warning } from '../../lib/outputs.js';
 import { transformEnvToEnvVars } from '../../lib/secrets.js';
 import {
@@ -122,6 +123,36 @@ export function resolvePushOutcome(buildStatus: string): PushOutcome {
 	}
 }
 
+/**
+ * Asks before `apify push` turns a Git-sourced version into source files, which drops the Git connection.
+ * `--force` skips the question but keeps the warning. Without a terminal and without it, the run stops here.
+ */
+const confirmGitSourceSwitch = async ({
+	actorName,
+	gitRepoUrl,
+	force,
+}: {
+	actorName: string;
+	gitRepoUrl: string;
+	force: boolean;
+}) => {
+	warning({
+		message: [
+			`Actor ${actorName} builds from a Git repository: ${gitRepoUrl}`,
+			'A push replaces that source with the local files and drops the Git connection.',
+			'To build from the repository, run git push instead. The platform builds on push when Automatic builds are on.',
+		].join('\n'),
+	});
+
+	if (force) return true;
+
+	return useYesNoConfirm({
+		message: 'Switch the source to the local files?',
+		default: false,
+		errorMessageForStdin: `Actor ${actorName} builds from a Git repository. Use --force to switch its source to the local files.`,
+	});
+};
+
 export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 	static override name = 'push' as const;
 
@@ -178,7 +209,8 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 		}),
 		force: Flags.boolean({
 			char: 'f',
-			description: 'Push an Actor even when the local files are older than the Actor on the platform.',
+			description:
+				'Push an Actor even when the local files are older than the Actor on the platform, or when the Actor builds from a Git repository.',
 			default: false,
 			required: false,
 		}),
@@ -329,37 +361,54 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 
 		const filesSize = await sumFilesSizeInBytes(filePathsToPush, cwd);
 
+		if (filesSize < MAX_MULTIFILE_BYTES && !isActorCreatedNow) {
+			const client = await actorClient.get();
+
+			// Check when was files modified last
+			const mostRecentModifiedFileMs = filePathsToPush.reduce((modifiedMs, filePath) => {
+				const { mtimeMs, ctimeMs } = statSync(join(cwd, filePath));
+
+				// Sometimes it's possible mtimeMs is some messed up value (like 2000/01/01 midnight), then we want to check created if it's newer
+				const fileModifiedMs = mtimeMs > ctimeMs ? mtimeMs : ctimeMs;
+
+				return modifiedMs > fileModifiedMs ? modifiedMs : fileModifiedMs;
+			}, 0);
+			const actorModifiedMs = client?.modifiedAt.valueOf();
+
+			if (
+				!this.flags.force &&
+				actorModifiedMs &&
+				mostRecentModifiedFileMs < actorModifiedMs &&
+				(actorConfig?.name || forceActorId)
+			) {
+				throw new Error(
+					`Actor with identifier "${actorConfig?.name || forceActorId}" is already on the platform and was modified there since modified locally.
+Skipping push. Use --force to override.`,
+				);
+			}
+		}
+
+		const actorCurrentVersion = await actorClient.version(version).get();
+
+		// A push replaces the version's source with the local files. For a Git-sourced version that also
+		// drops the Git connection, so it needs an explicit go-ahead.
+		if (actorCurrentVersion?.sourceType === ACTOR_SOURCE_TYPES.GIT_REPO) {
+			const confirmed = await confirmGitSourceSwitch({
+				actorName: actor.name,
+				gitRepoUrl: actorCurrentVersion.gitRepoUrl,
+				force: this.flags.force,
+			});
+
+			if (!confirmed) {
+				info({ message: `Push aborted. Actor ${actor.name} still builds from its Git repository.` });
+				return;
+			}
+		}
+
 		let sourceType;
 		let sourceFiles;
 		let tarballUrl;
 		if (filesSize < MAX_MULTIFILE_BYTES) {
-			const client = await actorClient.get();
-
-			if (!isActorCreatedNow) {
-				// Check when was files modified last
-				const mostRecentModifiedFileMs = filePathsToPush.reduce((modifiedMs, filePath) => {
-					const { mtimeMs, ctimeMs } = statSync(join(cwd, filePath));
-
-					// Sometimes it's possible mtimeMs is some messed up value (like 2000/01/01 midnight), then we want to check created if it's newer
-					const fileModifiedMs = mtimeMs > ctimeMs ? mtimeMs : ctimeMs;
-
-					return modifiedMs > fileModifiedMs ? modifiedMs : fileModifiedMs;
-				}, 0);
-				const actorModifiedMs = client?.modifiedAt.valueOf();
-
-				if (
-					!this.flags.force &&
-					actorModifiedMs &&
-					mostRecentModifiedFileMs < actorModifiedMs &&
-					(actorConfig?.name || forceActorId)
-				) {
-					throw new Error(
-						`Actor with identifier "${actorConfig?.name || forceActorId}" is already on the platform and was modified there since modified locally.
-Skipping push. Use --force to override.`,
-					);
-				}
-			}
-
 			sourceFiles = await createSourceFiles(filePathsToPush, cwd);
 			sourceType = ACTOR_SOURCE_TYPES.SOURCE_FILES;
 		} else {
@@ -400,7 +449,6 @@ Skipping push. Use --force to override.`,
 		}
 
 		// Update Actor version
-		const actorCurrentVersion = await actorClient.version(version).get();
 		const envVars = actorConfig!.environmentVariables
 			? transformEnvToEnvVars(actorConfig!.environmentVariables as Record<string, string>, undefined, {
 					allowMissing: this.flags.allowMissingSecrets,

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -382,7 +382,7 @@ export class ActorsPushCommand extends ApifyCommand<typeof ActorsPushCommand> {
 				(actorConfig?.name || forceActorId)
 			) {
 				throw new Error(
-					`Actor with identifier "${actorConfig?.name || forceActorId}" is already on the platform and was modified there since modified locally.
+					`Actor with identifier "${actorConfig?.name || forceActorId}" already exists on the platform and has newer changes than your local copy.
 Skipping push. Use --force to override.`,
 				);
 			}

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -149,7 +149,7 @@ const confirmGitSourceSwitch = async ({
 	return useYesNoConfirm({
 		message: 'Switch the source to the local files?',
 		default: false,
-		errorMessageForStdin: `Actor ${actorName} builds from a Git repository. Use --force to switch its source to the local files.`,
+		errorMessageForStdin: `Actor ${actorName} builds from a Git repository. To switch the source to the local files, use --force.`,
 	});
 };
 

--- a/src/commands/actors/push.ts
+++ b/src/commands/actors/push.ts
@@ -140,7 +140,7 @@ const confirmGitSourceSwitch = async ({
 		message: [
 			`Actor ${actorName} builds from a Git repository: ${gitRepoUrl}`,
 			'A push replaces that source with the local files and drops the Git connection.',
-			'To build from the repository, run git push instead. The platform builds on push when Automatic builds are on.',
+			'To build from the repository, run git push instead. The platform builds on push when automated builds are on.',
 		].join('\n'),
 	});
 

--- a/test/api/commands/push.test.ts
+++ b/test/api/commands/push.test.ts
@@ -324,7 +324,7 @@ describe('[api] apify push', () => {
 			await testRunCommand(ActorsPushCommand, { args_actorId: testActor.id, flags_noPrompt: true });
 			if (testActor) await testActorClient.delete();
 
-			expect(lastErrorMessage()).to.includes('is already on the platform');
+			expect(lastErrorMessage()).to.includes('already exists on the platform');
 		},
 		TEST_TIMEOUT,
 	);

--- a/test/local/commands/push-git-source.test.ts
+++ b/test/local/commands/push-git-source.test.ts
@@ -111,7 +111,7 @@ describe('apify push on a Git-sourced Actor', () => {
 		const stderr = logMessages.error.join('\n');
 		expect(stderr).toContain(GIT_REPO_URL);
 		expect(stderr).toContain('run git push instead');
-		expect(stderr).toContain('Use --force to switch its source to the local files');
+		expect(stderr).toContain('To switch the source to the local files, use --force.');
 	});
 
 	it('leaves the Actor alone when the user says no', async () => {

--- a/test/local/commands/push-git-source.test.ts
+++ b/test/local/commands/push-git-source.test.ts
@@ -1,0 +1,165 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { ACTOR_SOURCE_TYPES } from '@apify/consts';
+
+import { testRunCommand } from '../../../src/lib/command-framework/apify-command.js';
+import { LOCAL_CONFIG_PATH } from '../../../src/lib/consts.js';
+import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
+import { useTempPath } from '../../__setup__/hooks/useTempPath.js';
+
+// Force `useYesNoConfirm` down its non-interactive path, so the prompt errors out instead of blocking on
+// stdin. See src/lib/hooks/user-confirmations/_stdinCheckWrapper.ts.
+vitest.mock('ci-info', async (importOriginal) => {
+	const original = await importOriginal<typeof import('ci-info')>();
+	return { ...original, isCI: true };
+});
+
+const actName = 'push-git-source-actor';
+const ACTOR_ID = 'aBcD1234efGh';
+const GIT_REPO_URL = 'git@github.com:apify/my-scraper.git';
+
+const actor = {
+	id: ACTOR_ID,
+	name: actName,
+	// Older than any local file, so the "modified on the platform" check never trips.
+	modifiedAt: new Date(0),
+	taggedBuilds: { latest: { buildId: 'build1' } },
+};
+const build = { id: 'build1', actId: ACTOR_ID, buildNumber: '0.0.1', status: 'SUCCEEDED' };
+
+let currentVersion: Record<string, unknown>;
+const versionUpdate = vitest.fn(async () => ({}));
+
+// Stands in for the platform: the Actor exists, and the version's source type is what is under test.
+vitest.mock('../../../src/lib/utils.js', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../../src/lib/utils.js')>()),
+	getLocalUserInfo: vitest.fn(async () => ({ id: 'userId', username: 'user' })),
+	outputJobLog: vitest.fn(async () => {}),
+	getLoggedClientOrThrow: vitest.fn(async () => ({
+		baseUrl: 'https://api.apify.com/v2',
+		actor: () => ({
+			get: async () => actor,
+			version: () => ({ get: async () => currentVersion, update: versionUpdate }),
+			build: async () => build,
+		}),
+		build: () => ({ get: async () => build }),
+	})),
+}));
+
+// Passes through to the real prompt, which errors out under the `ci-info` mock above. A test that wants
+// an interactive answer sets one with `mockResolvedValueOnce`.
+const yesNoConfirm = vitest.hoisted(() => vitest.fn());
+vitest.mock('../../../src/lib/hooks/user-confirmations/useYesNoConfirm.js', async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import('../../../src/lib/hooks/user-confirmations/useYesNoConfirm.js')>();
+	yesNoConfirm.mockImplementation(original.useYesNoConfirm);
+	return { useYesNoConfirm: yesNoConfirm };
+});
+
+// The mocked `node:process` copy has no signal handlers; nothing here needs them.
+vitest.mock('../../../src/lib/hooks/useAbortJobOnSignal.js', () => ({
+	useAbortJobOnSignal: () => ({ [Symbol.dispose]() {} }),
+}));
+
+const { beforeAllCalls, afterAllCalls, joinPath } = useTempPath(actName, {
+	create: true,
+	remove: true,
+	cwd: true,
+	cwdParent: false,
+});
+
+const { logMessages } = useConsoleSpy();
+
+const { ActorsPushCommand } = await import('../../../src/commands/actors/push.js');
+
+const run = (force = false) => testRunCommand(ActorsPushCommand, { flags_force: force });
+
+// The command framework records a thrown error on the real `process`, not on the `node:process` copy
+// `useTempPath({ cwd: true })` mocks. Put it back so a failing run cannot leak into the tests that follow.
+let originalExitCode: typeof process.exitCode;
+
+beforeEach(async () => {
+	originalExitCode = process.exitCode;
+	versionUpdate.mockClear();
+	yesNoConfirm.mockClear();
+	await beforeAllCalls();
+	await mkdir(joinPath('.actor'), { recursive: true });
+	await writeFile(
+		joinPath(LOCAL_CONFIG_PATH),
+		JSON.stringify({ actorSpecification: 1, name: actName, version: '0.0', buildTag: 'latest' }),
+	);
+	await writeFile(join(joinPath('.actor'), 'main.js'), 'console.log("hi")');
+});
+
+afterEach(async () => {
+	process.exitCode = originalExitCode;
+	await afterAllCalls();
+});
+
+describe('apify push on a Git-sourced Actor', () => {
+	beforeEach(() => {
+		currentVersion = { versionNumber: '0.0', sourceType: ACTOR_SOURCE_TYPES.GIT_REPO, gitRepoUrl: GIT_REPO_URL };
+	});
+
+	it('stops before the upload when it cannot ask and --force is not set', async () => {
+		await run();
+
+		expect(process.exitCode).toBe(1);
+		expect(versionUpdate).not.toHaveBeenCalled();
+
+		const stderr = logMessages.error.join('\n');
+		expect(stderr).toContain(GIT_REPO_URL);
+		expect(stderr).toContain('run git push instead');
+		expect(stderr).toContain('Use --force to switch its source to the local files');
+	});
+
+	it('leaves the Actor alone when the user says no', async () => {
+		yesNoConfirm.mockResolvedValueOnce(false);
+
+		await run();
+
+		expect(process.exitCode).toBeFalsy();
+		expect(versionUpdate).not.toHaveBeenCalled();
+		expect(logMessages.error.join('\n')).toContain('Push aborted');
+	});
+
+	it('switches the source to the local files when the user says yes', async () => {
+		yesNoConfirm.mockResolvedValueOnce(true);
+
+		await run();
+
+		expect(process.exitCode).toBeFalsy();
+		expect(versionUpdate).toHaveBeenCalledTimes(1);
+		expect(versionUpdate.mock.calls[0][0 as never]).toMatchObject({ sourceType: ACTOR_SOURCE_TYPES.SOURCE_FILES });
+		expect(logMessages.log.join('\n')).toContain('Apify push result: SUCCEEDED');
+	});
+
+	it('does not ask with --force, but still says what it drops', async () => {
+		await run(true);
+
+		expect(process.exitCode).toBeFalsy();
+		expect(yesNoConfirm).not.toHaveBeenCalled();
+		expect(versionUpdate).toHaveBeenCalledTimes(1);
+		expect(versionUpdate.mock.calls[0][0 as never]).toMatchObject({ sourceType: ACTOR_SOURCE_TYPES.SOURCE_FILES });
+		expect(logMessages.error.join('\n')).toContain(GIT_REPO_URL);
+		expect(logMessages.log.join('\n')).toContain('Apify push result: SUCCEEDED');
+	});
+});
+
+describe('apify push on an Actor that does not build from Git', () => {
+	it.each([
+		[ACTOR_SOURCE_TYPES.SOURCE_FILES, false],
+		[ACTOR_SOURCE_TYPES.SOURCE_FILES, true],
+		[ACTOR_SOURCE_TYPES.TARBALL, false],
+	])('neither asks nor warns for %s with force=%s', async (sourceType, force) => {
+		currentVersion = { versionNumber: '0.0', sourceType };
+
+		await run(force);
+
+		expect(process.exitCode).toBeFalsy();
+		expect(yesNoConfirm).not.toHaveBeenCalled();
+		expect(versionUpdate).toHaveBeenCalledTimes(1);
+		expect(logMessages.error.join('\n')).not.toContain('Git repository');
+	});
+});


### PR DESCRIPTION
> [!NOTE]
> **TL;DR** — `apify push` on a Git-sourced Actor version now says what it is about to drop and asks before it switches the source to the local files. `--force` answers yes. Without a terminal and without `--force`, the push stops.

Closes #1142.

## What happened before

`apify push` set the version's `sourceType` to `SOURCE_FILES` without a word. The Git connection and its build setup were gone before anyone noticed, and the platform kept building from the uploaded files. See the [issue comments](https://github.com/apify/apify-cli/issues/1142#issuecomment-5506164415) for the agreed shape of the prompt.

## What changed

- The version is fetched before the upload, not after. When its source type is `GIT_REPO`, the command prints a warning with the repository URL, points at `git push` as the way to build from the repository, and asks:

  ```
  Warning: Actor my-scraper builds from a Git repository: git@github.com:apify/my-scraper.git
  A push replaces that source with the local files and drops the Git connection.
  To build from the repository, run git push instead. The platform builds on push when Automatic builds are on.
  ? Switch the source to the local files? (y/N)
  ```

  The question comes after the "modified on the platform" check, so nobody confirms a push that is about to be refused anyway.

- **No** stops the push before anything is uploaded. The Actor is untouched.
- **`--force`** skips the question but keeps the warning. Its description now covers both cases it overrides: a newer remote version, and a Git source.
- **Non-interactive** runs without `--force` stop with an error that names the flag. This is a behavior change for CI pipelines that push to a Git-sourced Actor. Such a pipeline is replacing the repository source on every run, so it should say so explicitly.
- Source-files and tarball versions are not affected. No prompt, no new output.

## The second half of the issue

"After switching back to Git, Automatic builds could not be enabled." The API only `$set`s the keys it receives, so `apify push` leaves `gitRepoUrl` and `githubWebhookId` on the version and flips `sourceType` only. Whether Console then re-creates the version fields on switch-back is a platform question. Not touched here, and the prompt above removes the usual way into it.

## Relation to #1377

#1377 turns Automatic builds on for Actors that `apify create --source <provider>` makes. This PR is independent of it and applies on `master`. The warning text says "when Automatic builds are on" rather than promising a build, since a Console-created Actor may have them off.

## Verification

`lint`, `format`, `build`, `test:local` clean. `docs/reference.md` regenerated for the `--force` description.

7 new tests in `test/local/commands/push-git-source.test.ts`, with the platform client mocked: the non-interactive stop leaves the version untouched and names `--force`; no leaves it untouched; yes and `--force` switch the source to `SOURCE_FILES`, and `--force` never reaches the prompt; source-files and tarball versions neither ask nor warn.

**Not run live** against a real Git-sourced Actor yet. Draft until that is done.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
