### PR TITLE
fix: recover no-* boolean aliases swallowed by parseArgs allowNegative (#1349)

### DIFF
--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -523,6 +523,19 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 
 			let rawFlag = rawFlags[matchingFlags[0]];
 
+			// parseArgs with allowNegative:true intercepts '--no-X' before the options table,
+			// storing rawFlags['X'] = false instead of rawFlags['no-X'] = true. Recover aliases
+			// of the form 'no-X' by checking whether the stripped positive name was set to false.
+			if (rawFlag === undefined && builderData.flagTag === 'boolean') {
+				for (const alias of builderData.aliases ?? []) {
+					const kebabAlias = kebabCaseString(camelCaseToKebabCase(alias)).toLowerCase();
+					if (kebabAlias.startsWith('no-') && rawFlags[kebabAlias.slice(3)] === false) {
+						rawFlag = true;
+						break;
+					}
+				}
+			}
+
 			if (!rawFlag && builderData.required) {
 				throw new CommandError({
 					code: CommandErrorCode.APIFY_MISSING_FLAG,


### PR DESCRIPTION
## Problem

`apify create --no-optional` was silently ignored — optional deps always installed regardless of the flag.

**Root cause:** Node.js `parseArgs` with `allowNegative: true` intercepts any `--no-X` token before consulting the options table. For `--no-optional`, it strips the prefix and stores `rawFlags['optional'] = false` (even though `optional` is not a registered option). The registration of `no-optional` as a direct boolean option passes the `strict: true` validity check, but the value never lands under that key. `_parseFlags` then checks `allMatchers = ['omit-optional-deps', 'no-optional']` against `rawFlags`, finds neither key, and leaves `omitOptionalDeps` undefined.

Empirically confirmed with Node.js 24.19.0:
```
parseArgs({ allowNegative: true, strict: true,
  options: { 'omit-optional-deps': { type: 'boolean', multiple: true },
             'no-optional':         { type: 'boolean', multiple: true } },
  args: ['--no-optional'] })
// rawFlags: { "optional": false }  <-- wrong key; 'no-optional' never set
```

## Fix

Single insertion in `_parseFlags` (src/lib/command-framework/apify-command.ts): after the `allMatchers` lookup finds nothing, scan each `no-*` alias and check whether its stripped positive name is present in `rawFlags` with value `false`. If so, set `rawFlag = true` so the rest of the boolean-parsing path proceeds normally.

- `flags.ts` is unchanged -- the `no-optional` registration must stay so `strict: true` does not throw when `--no-optional` is passed.
- `create.ts` is unchanged -- `aliases: ['no-optional']` is now correctly recovered.
- The fix is general: any boolean flag that declares a `no-*` alias gets the same treatment automatically.

## Testing

- All 20 create-command tests pass (`pnpm exec vitest run test/local/commands/create.test.ts`).
- Full local suite passes except 2 pre-existing Python path failures unrelated to this change.
- Build clean (`pnpm run build`), lint+format pass (enforced by pre-commit hook).

Fixes #1349
