### PR TITLE
fix(task): support raw task IDs in task run

### DIFF
--- a/src/commands/task/run.ts
+++ b/src/commands/task/run.ts
@@ -1,5 +1,7 @@
 import type { ActorRun, ApifyClient, TaskStartOptions } from 'apify-client';
 
+import { APIFY_ID_REGEX } from '@apify/consts';
+
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
 import { runActorOrTaskOnCloud, SharedRunOnCloudFlags } from '../../lib/commands/run-on-cloud.js';
@@ -100,12 +102,26 @@ export class TaskRunCommand extends ApifyCommand<typeof TaskRunCommand> {
 			};
 		}
 
-		// Try fetching task directly by name
+		// Try fetching task directly by name or ID
 		if (taskId) {
+			// If the input looks like a raw Apify resource ID, try it directly first
+			if (APIFY_ID_REGEX.test(taskId)) {
+				const taskById = await client.task(taskId).get();
+
+				if (taskById) {
+					return {
+						id: taskById.id,
+						userFriendlyId: `${usernameOrId}/${taskById.name}`,
+						title: taskById.title,
+						task: taskById,
+					};
+				}
+			}
+
 			const task = await client.task(`${usernameOrId}/${taskId.toLowerCase()}`).get();
 
 			if (!task) {
-				throw new Error(`Cannot find Task with name '${taskId}' in your account.`);
+				throw new Error(`Cannot find Task with name or ID '${taskId}' in your account.`);
 			}
 
 			return {

--- a/test/api/commands/task/run.test.ts
+++ b/test/api/commands/task/run.test.ts
@@ -31,6 +31,7 @@ const expectedOutput = {
 describe('[api] apify task run', () => {
 	let actorId: string;
 	let taskId: string;
+	let rawTaskId: string;
 
 	beforeAll(async () => {
 		await beforeAllCalls();
@@ -77,6 +78,7 @@ describe('[api] apify task run', () => {
 			input: expectedOutput,
 		});
 
+		rawTaskId = task.id;
 		taskId = `${username}/${task.name}`;
 	}, TEST_TIMEOUT);
 
@@ -104,6 +106,20 @@ describe('[api] apify task run', () => {
 	it('should work with the full name', async () => {
 		await testRunCommand(TaskRunCommand, {
 			args_taskId: taskId,
+		});
+
+		const taskClient = testUserClient.task(taskId);
+		const runs = await taskClient.runs().list();
+		const lastRun = runs.items.pop();
+		const lastRunDetail = await testUserClient.run(lastRun!.id).get();
+		const output = await testUserClient.keyValueStore(lastRunDetail!.defaultKeyValueStoreId).getRecord('OUTPUT');
+
+		expect(expectedOutput).toStrictEqual(output!.value);
+	});
+
+	it('should work with just the task ID', async () => {
+		await testRunCommand(TaskRunCommand, {
+			args_taskId: rawTaskId,
 		});
 
 		const taskClient = testUserClient.task(taskId);


### PR DESCRIPTION
Fixes #1360

## Problem

`apify task run <rawId>` fails with _"Cannot find Task with name …"_ for any raw Apify task ID. The `resolveTaskId` method has only two branches:

1. Input contains `/` → use as-is (`username/task-name`)
2. Input has no `/` → **always** prepend the authenticated username → `username/rawId` → 404

The argument description has always read `"Name or ID of the Task to run (e.g. 'my-task' or 'E2jjCZBezvAZnX8Rb')"`. The ID half has never worked.

The identical bug was fixed for `apify call` in `ffb0b7c3` (`fix(call): support calling with bare ids`) but was never applied to `task run`.

## Fix

Import `APIFY_ID_REGEX` from `@apify/consts` (already in the dependency tree) and use it as a gate before the name-based fallback:

```
bare argument
  │
  ├─ contains "/" ──────────────────────→ client.task(id).get()  [unchanged]
  │
  └─ matches APIFY_ID_REGEX ──────────→ client.task(rawId).get()  [new]
       │                                      │
       │ not found                            └─ found → return task
       └─────────────────────────────────────→ client.task("username/name").get()  [existing]
```

Normal task names containing hyphens (e.g. `my-task`) do not match `APIFY_ID_REGEX` and skip the new path entirely — **zero extra API calls** for existing usage.

## Changes

- **`src/commands/task/run.ts`** — add `APIFY_ID_REGEX` import and raw-ID lookup path in `resolveTaskId`; update error message to `"name or ID"` (consistent with `actors/call.ts:315`)
- **`test/api/commands/task/run.test.ts`** — capture `rawTaskId = task.id` in `beforeAll`; add `'should work with just the task ID'` test case

## Behaviour matrix

| Input | Before | After | API calls |
|---|---|---|---|
| `yRWwqZmoMTLdEoMOI` (raw ID) | ❌ 404 | ✅ resolves | 1 |
| `my-task` (bare name) | ✅ | ✅ | 1 — **unchanged** |
| `username/my-task` (qualified) | ✅ | ✅ | 1 — **unchanged** |

## Install size

No new package. `APIFY_ID_REGEX` is an additional named import from `@apify/consts`, which is already in the dependency tree.

## Out of scope

`task publish` and `task unpublish` carry the same pattern but their documented contract lists names only — tracked separately.