### PR TITLE
fix: do not add .venv to gitignore

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -234,7 +234,7 @@ export const setLocalConfig = async (localConfig: Record<string, unknown>, actDi
 	writeFileSync(fullPath, JSON.stringify(localConfig, null, '\t'));
 };
 
-const GITIGNORE_REQUIRED_CONTENTS = [getLocalStorageDir(), 'node_modules', '.venv'];
+const GITIGNORE_REQUIRED_CONTENTS = [getLocalStorageDir(), 'node_modules'];
 
 export const setLocalEnv = async (actDir: string) => {
 	// Create folders for emulation Apify stores


### PR DESCRIPTION
This PR closes #1353.
**Summary**
Removes `.venv` from the generic `.gitignore` entries added by `setLocalEnv`.

That list is applied to every Actor project during setup, so JavaScript and TypeScript templates were also getting a Python-specific virtualenv entry.

 **Testing**
- `pnpm test:local`
- `pnpm run lint`
- `pnpm run format`
- `pnpm run build`