### PR TITLE
feat: require Node.js 22 or newer

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -76,7 +76,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-2025]
-                node-version: [20, 22, 24]
+                node-version: [22, 24]
 
         runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	},
 	"homepage": "https://github.com/apify/apify-cli#readme",
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"dependencies": {
 		"@apify/actor-memory-expression": "^0.2.0",
@@ -151,7 +151,7 @@
 		"runtime": [
 			{
 				"name": "node",
-				"version": "^20.19.0 || >=22.12.0",
+				"version": ">=22.12.0",
 				"onFail": "error"
 			},
 			{


### PR DESCRIPTION
> [!Note]
> **TL;DR** Drop node 20 as we discussed.

## Changes

- `engines.node`: `>=20` → `>=22`
- `devEngines.runtime.node`: drop the `^20.19.0` arm, leaving `>=22.12.0`
- `Local Tests` matrix: `[20, 22, 24]` → `[22, 24]`

No source or docs changes needed. `SUPPORTED_NODEJS_VERSION` reads `pkg.engines.node` (`src/lib/consts.ts:69`), so the runtime guard and all user-facing messages follow automatically. README and the installation docs already said 22+.

## Why `>=22` and not a patch-level floor

The strictest transitive runtime constraints are `which@7` (`^22.22.2 || ...`) and `@inquirer/core` (`^22.13.0`), so no single patch version is "the" true floor for long — it moves with every dependency bump.

`engines.node` is also enforced by a hard exit here (`processVersionCheck`, `src/entrypoints/_shared.ts:58`), not just an npm warning, so an over-strict floor blocks users who would otherwise be fine. A transitive engine mismatch is only a warning.

`devEngines` keeps the stricter `>=22.12.0` that the build tooling needs. That is the contributor requirement; `engines.node` is the support claim made to users, and it tracks the Node major line — the same one the CI matrix and base images track.

## Checked

- Branch protection requires only `Local Tests (…, 22)` contexts — no `…, 20)` context is left permanently pending
- Standalone bundle users are unaffected: `processVersionCheck` early-returns for `installMethod === 'bundle'`
- `pnpm run lint && format && build` pass. `test:local` has 8 pre-existing failures in `run.test.ts` ("input tests") that reproduce identically on unmodified `master` — unrelated to this change

## Follow-ups

- `src/commands/run.ts:193,204` and `src/entrypoints/_shared.ts:60` interpolate the raw semver range into prose ("install Node.js >=22 (or higher)"). Sibling call sites already use `minVersion(...)`. Pre-existing; not touched here
- Companion PR: apify/actor-templates#925

🤖 Generated with [Claude Code](https://claude.com/claude-code)