### PR TITLE
fix(run): purge local stores from the correct directory

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,6 @@
 import { existsSync, renameSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { join, resolve } from 'node:path';
 import process from 'node:process';
 
 import type { ExecaError } from 'execa';
@@ -244,8 +244,11 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 			return;
 		}
 
-		if (existsSync(LEGACY_LOCAL_STORAGE_DIR) && !existsSync(actualStoragePath)) {
-			renameSync(LEGACY_LOCAL_STORAGE_DIR, actualStoragePath);
+		const legacyStoragePath = resolve(cwd, LEGACY_LOCAL_STORAGE_DIR);
+		const resolvedStoragePath = resolve(cwd, actualStoragePath);
+
+		if (existsSync(legacyStoragePath) && !existsSync(resolvedStoragePath)) {
+			renameSync(legacyStoragePath, resolvedStoragePath);
 			warning({
 				message:
 					`The legacy 'apify_storage' directory was renamed to '${actualStoragePath}' to align it with Apify SDK v3.` +
@@ -494,6 +497,7 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 		resolvedInputKey = 'INPUT',
 	): Promise<ValidateAndStoreInputResult | null> {
 		const { inputSchema } = await readInputSchema({ cwd: process.cwd() });
+		const localStorePath = resolve(process.cwd(), getLocalKeyValueStorePath());
 
 		if (!inputSchema) {
 			if (!inputOverride) {
@@ -502,11 +506,10 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 
 			// We cannot validate input schema if it is not found -> default to no validation and overriding if flags are given
 			// Write the override to a temp file so the user's input file is never touched.
-			const defaultStorePath = join(process.cwd(), getLocalKeyValueStorePath());
-			await mkdir(defaultStorePath, { recursive: true });
+			await mkdir(localStorePath, { recursive: true });
 
 			const tempInputKey = `${TEMP_INPUT_KEY_PREFIX}${resolvedInputKey}`;
-			const tempInputFilePath = join(defaultStorePath, `${tempInputKey}.json`);
+			const tempInputFilePath = join(localStorePath, `${tempInputKey}.json`);
 
 			await writeFile(tempInputFilePath, JSON.stringify(inputOverride.input, null, 2));
 
@@ -527,11 +530,7 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 		const existingInput = getLocalInput(process.cwd(), resolvedInputKey);
 
 		// Prepare the file path for where we'll temporarily store the validated input
-		const inputFilePath = join(
-			process.cwd(),
-			getLocalKeyValueStorePath(),
-			existingInput?.fileName ?? `${resolvedInputKey}.json`,
-		);
+		const inputFilePath = join(localStorePath, existingInput?.fileName ?? `${resolvedInputKey}.json`);
 
 		let errorHeader: string;
 
@@ -568,9 +567,9 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 
 			// Write to a temp file so the user's input file is never touched.
 			const tempInputKey = `${TEMP_INPUT_KEY_PREFIX}${resolvedInputKey}`;
-			const tempInputFilePath = join(dirname(inputFilePath), `${tempInputKey}.json`);
+			const tempInputFilePath = join(localStorePath, `${tempInputKey}.json`);
 
-			await mkdir(dirname(inputFilePath), { recursive: true });
+			await mkdir(localStorePath, { recursive: true });
 			await writeFile(tempInputFilePath, JSON.stringify(fullInputOverride, null, 2));
 
 			return {
@@ -580,7 +579,7 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 		}
 
 		if (!existingInput) {
-			await mkdir(dirname(inputFilePath), { recursive: true });
+			await mkdir(localStorePath, { recursive: true });
 			// No input -> use defaults for this run
 			await writeFile(inputFilePath, JSON.stringify(defaults, null, 2));
 
@@ -615,7 +614,7 @@ export class RunCommand extends ApifyCommand<typeof RunCommand> {
 			// Write merged input to a temp file so the user's INPUT.json is never touched.
 			// The SDK is redirected to this file via the ACTOR_INPUT_KEY env var.
 			const tempInputKey = `${TEMP_INPUT_KEY_PREFIX}${resolvedInputKey}`;
-			const tempInputFilePath = join(dirname(inputFilePath), `${tempInputKey}.json`);
+			const tempInputFilePath = join(localStorePath, `${tempInputKey}.json`);
 
 			await writeFile(tempInputFilePath, JSON.stringify(fullInput, null, 2));
 

--- a/src/lib/hooks/useModuleVersion.ts
+++ b/src/lib/hooks/useModuleVersion.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 import { none, type Option, some } from '@sapphire/result';
 import { execa } from 'execa';
 
@@ -102,6 +104,7 @@ export async function useModuleVersion({ moduleName, project }: UseModuleVersion
 
 	try {
 		const result = await execa(project.runtime.executablePath, args, {
+			cwd: process.cwd(),
 			shell: true,
 			windowsHide: true,
 			verbose: process.env.APIFY_CLI_DEBUG ? 'full' : undefined,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 import { createWriteStream, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join, relative } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import process from 'node:process';
 
 import { DurationFormatter as SapphireDurationFormatter, TimeTypes } from '@sapphire/duration';
@@ -545,22 +545,22 @@ export const getLocalInput = (cwd: string, inputKey?: string) => {
 };
 
 export const purgeDefaultQueue = async () => {
-	const defaultQueuesPath = getLocalRequestQueuePath();
-	if (existsSync(getLocalStorageDir()) && existsSync(defaultQueuesPath)) {
+	const defaultQueuesPath = resolve(process.cwd(), getLocalRequestQueuePath());
+	if (existsSync(resolve(process.cwd(), getLocalStorageDir())) && existsSync(defaultQueuesPath)) {
 		await rimrafPromised(defaultQueuesPath);
 	}
 };
 
 export const purgeDefaultDataset = async () => {
-	const defaultDatasetPath = getLocalDatasetPath();
-	if (existsSync(getLocalStorageDir()) && existsSync(defaultDatasetPath)) {
+	const defaultDatasetPath = resolve(process.cwd(), getLocalDatasetPath());
+	if (existsSync(resolve(process.cwd(), getLocalStorageDir())) && existsSync(defaultDatasetPath)) {
 		await rimrafPromised(defaultDatasetPath);
 	}
 };
 
 export const purgeDefaultKeyValueStore = async (...inputKeys: string[]) => {
-	const defaultKeyValueStorePath = getLocalKeyValueStorePath();
-	if (!existsSync(getLocalStorageDir()) || !existsSync(defaultKeyValueStorePath)) {
+	const defaultKeyValueStorePath = resolve(process.cwd(), getLocalKeyValueStorePath());
+	if (!existsSync(resolve(process.cwd(), getLocalStorageDir())) || !existsSync(defaultKeyValueStorePath)) {
 		return;
 	}
 	const filesToDelete = readdirSync(defaultKeyValueStorePath);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -529,38 +529,36 @@ export const createActZip = async (zipName: string, pathsToZip: string[], cwd: s
 export const getLocalInput = (cwd: string, inputKey?: string) => {
 	const defaultLocalStorePath = getLocalKeyValueStorePath();
 
-	const folderExists = existsSync(join(cwd, defaultLocalStorePath));
+	const storePath = resolve(cwd, defaultLocalStorePath);
 
-	if (!folderExists) return;
+	if (!existsSync(storePath)) return;
 
-	const files = readdirSync(join(cwd, defaultLocalStorePath));
+	const files = readdirSync(storePath);
 	const inputName = files.find((file) => !!file.match(inputFileRegExp(inputKey ?? 'INPUT')));
 
 	// No input file
 	if (!inputName) return;
 
-	const input = readFileSync(join(cwd, defaultLocalStorePath, inputName));
+	const input = readFileSync(join(storePath, inputName));
 	const contentType = mime.getType(inputName);
 	return { body: input, contentType, fileName: inputName };
 };
 
 export const purgeDefaultQueue = async () => {
-	const defaultQueuesPath = resolve(process.cwd(), getLocalRequestQueuePath());
-	if (existsSync(resolve(process.cwd(), getLocalStorageDir())) && existsSync(defaultQueuesPath)) {
-		await rimrafPromised(defaultQueuesPath);
-	}
+	await rimrafPromised(resolve(process.cwd(), getLocalRequestQueuePath()));
 };
 
 export const purgeDefaultDataset = async () => {
-	const defaultDatasetPath = resolve(process.cwd(), getLocalDatasetPath());
-	if (existsSync(resolve(process.cwd(), getLocalStorageDir())) && existsSync(defaultDatasetPath)) {
-		await rimrafPromised(defaultDatasetPath);
-	}
+	await rimrafPromised(resolve(process.cwd(), getLocalDatasetPath()));
 };
 
+/**
+ * Deletes every record from the default key-value store, except the files
+ * matching the given input keys. Defaults to preserving `INPUT.*`.
+ */
 export const purgeDefaultKeyValueStore = async (...inputKeys: string[]) => {
 	const defaultKeyValueStorePath = resolve(process.cwd(), getLocalKeyValueStorePath());
-	if (!existsSync(resolve(process.cwd(), getLocalStorageDir())) || !existsSync(defaultKeyValueStorePath)) {
+	if (!existsSync(defaultKeyValueStorePath)) {
 		return;
 	}
 	const filesToDelete = readdirSync(defaultKeyValueStorePath);
@@ -647,15 +645,19 @@ export const getNpmCmd = (): string => {
 };
 
 /**
- * Returns true if apify storage is empty (expect INPUT.*)
+ * Returns true if the local storage holds nothing but the input file, either
+ * the user's own `<inputKey>.*` or the temporary copy the CLI writes next to it.
  */
 export const checkIfStorageIsEmpty = async (inputKey?: string) => {
 	const key = inputKey || KEY_VALUE_STORE_KEYS.INPUT;
-	const filesWithoutInput = await glob([
-		`${getLocalStorageDir()}/**`,
-		`!${getLocalKeyValueStorePath()}/${key}.*`,
-		`!${getLocalKeyValueStorePath()}/${TEMP_INPUT_KEY_PREFIX}${key}.*`,
-	]);
+	// Storage paths use backslashes on Windows, which glob reads as escape characters.
+	const storageDir = getLocalStorageDir().replaceAll('\\', '/');
+	const keyValueStoreDir = getLocalKeyValueStorePath().replaceAll('\\', '/');
+
+	const filesWithoutInput = await glob(
+		[`${storageDir}/**`, `!${keyValueStoreDir}/${key}.*`, `!${keyValueStoreDir}/${TEMP_INPUT_KEY_PREFIX}${key}.*`],
+		{ cwd: process.cwd() },
+	);
 
 	return filesWithoutInput.length === 0;
 };

--- a/test/local/commands/run-without-crawlee.test.ts
+++ b/test/local/commands/run-without-crawlee.test.ts
@@ -1,0 +1,81 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+
+import { testRunCommand } from '../../../src/lib/command-framework/apify-command.js';
+import { getLocalDatasetPath, getLocalKeyValueStorePath, getLocalRequestQueuePath } from '../../../src/lib/utils.js';
+import { TEST_TIMEOUT } from '../../__setup__/consts.js';
+import { useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
+import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
+import { useTempPath } from '../../__setup__/hooks/useTempPath.js';
+import { resetCwdCaches } from '../../__setup__/reset-cwd-caches.js';
+
+const actName = 'run-without-crawlee';
+
+useAuthSetup({ perTest: true });
+
+const { beforeAllCalls, afterAllCalls, joinPath, toggleCwdBetweenFullAndParentPath } = useTempPath(actName, {
+	create: true,
+	remove: true,
+	cwd: true,
+	cwdParent: true,
+});
+
+useConsoleSpy();
+
+const { CreateCommand } = await import('../../../src/commands/create.js');
+const { RunCommand } = await import('../../../src/commands/run.js');
+
+// Without dependencies there is no crawlee to purge the storage on start, so the
+// CLI has to do it. That is a different code path than the one crawlee projects take.
+describe('apify run without crawlee', () => {
+	beforeAll(async () => {
+		await beforeAllCalls();
+
+		await testRunCommand(CreateCommand, {
+			args_actorName: actName,
+			flags_template: 'project_empty',
+			flags_skipDependencyInstall: true,
+		});
+
+		toggleCwdBetweenFullAndParentPath();
+	}, TEST_TIMEOUT);
+
+	afterAll(async () => {
+		await afterAllCalls();
+	});
+
+	beforeEach(() => {
+		resetCwdCaches();
+	});
+
+	it('purges the default stores itself', async () => {
+		const markerPath = joinPath('result.txt');
+		const inputPath = joinPath(getLocalKeyValueStorePath(), 'INPUT.json');
+		const testJsonPath = joinPath(getLocalKeyValueStorePath(), 'TEST.json');
+
+		writeFileSync(
+			joinPath('src/main.js'),
+			`
+import { writeFileSync } from 'node:fs';
+writeFileSync(String.raw\`${markerPath}\`, 'hello world');
+`,
+			{ flag: 'w' },
+		);
+
+		mkdirSync(joinPath(getLocalKeyValueStorePath()), { recursive: true });
+		mkdirSync(joinPath(getLocalDatasetPath()), { recursive: true });
+		mkdirSync(joinPath(getLocalRequestQueuePath()), { recursive: true });
+		writeFileSync(inputPath, '{}', { flag: 'w' });
+		writeFileSync(testJsonPath, '{}', { flag: 'w' });
+		writeFileSync(joinPath(getLocalDatasetPath(), '000000001.json'), '{}', { flag: 'w' });
+		writeFileSync(joinPath(getLocalRequestQueuePath(), 'request.json'), '{}', { flag: 'w' });
+
+		await testRunCommand(RunCommand, { flags_purge: true });
+
+		// The marker proves the Actor ran, so an empty storage cannot come from an early exit.
+		expect(existsSync(markerPath)).toStrictEqual(true);
+		expect(existsSync(inputPath)).toStrictEqual(true);
+		expect(existsSync(testJsonPath)).toStrictEqual(false);
+		expect(existsSync(joinPath(getLocalDatasetPath()))).toStrictEqual(false);
+		expect(existsSync(joinPath(getLocalRequestQueuePath()))).toStrictEqual(false);
+	});
+});

--- a/test/local/commands/run-without-crawlee.test.ts
+++ b/test/local/commands/run-without-crawlee.test.ts
@@ -24,8 +24,7 @@ useConsoleSpy();
 const { CreateCommand } = await import('../../../src/commands/create.js');
 const { RunCommand } = await import('../../../src/commands/run.js');
 
-// Without dependencies there is no crawlee to purge the storage on start, so the
-// CLI has to do it. That is a different code path than the one crawlee projects take.
+// Without dependencies there is no crawlee to purge the storage on start, so the CLI has to do it.
 describe('apify run without crawlee', () => {
 	beforeAll(async () => {
 		await beforeAllCalls();

--- a/test/local/commands/run.test.ts
+++ b/test/local/commands/run.test.ts
@@ -1,5 +1,5 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path/win32';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 import { ACTOR_ENV_VARS, APIFY_ENV_VARS } from '@apify/consts';
 
@@ -278,8 +278,6 @@ writeFileSync(String.raw\`${joinPath('result.txt')}\`, 'hello world');
 
 	describe('input tests', () => {
 		const actPath = joinPath('src/main.js');
-		// Templates ship `.actor/input_schema.json`, which shadows a root-level
-		// `INPUT_SCHEMA.json` on case-insensitive file systems, so write there.
 		const inputSchemaPath = joinPath('.actor', 'INPUT_SCHEMA.json');
 		const inputPath = joinPath(getLocalKeyValueStorePath(), 'INPUT.json');
 		const outputPath = joinPath(getLocalKeyValueStorePath(), 'OUTPUT.json');
@@ -288,6 +286,9 @@ writeFileSync(String.raw\`${joinPath('result.txt')}\`, 'hello world');
 		beforeAll(() => {
 			writeFileSync(actPath, INPUT_SCHEMA_ACTOR_SRC, { flag: 'w' });
 			mkdirSync(dirname(inputPath), { recursive: true });
+			mkdirSync(dirname(inputSchemaPath), { recursive: true });
+			// Drop the template's own schema, so the test does not depend on how the file system treats case.
+			rmSync(joinPath('.actor', 'input_schema.json'), { force: true });
 		});
 
 		it('throws when required field is not provided', async () => {

--- a/test/local/commands/run.test.ts
+++ b/test/local/commands/run.test.ts
@@ -278,7 +278,9 @@ writeFileSync(String.raw\`${joinPath('result.txt')}\`, 'hello world');
 
 	describe('input tests', () => {
 		const actPath = joinPath('src/main.js');
-		const inputSchemaPath = joinPath('INPUT_SCHEMA.json');
+		// Templates ship `.actor/input_schema.json`, which shadows a root-level
+		// `INPUT_SCHEMA.json` on case-insensitive file systems, so write there.
+		const inputSchemaPath = joinPath('.actor', 'INPUT_SCHEMA.json');
 		const inputPath = joinPath(getLocalKeyValueStorePath(), 'INPUT.json');
 		const outputPath = joinPath(getLocalKeyValueStorePath(), 'OUTPUT.json');
 		const handPassedInput = JSON.stringify({ awesome: null });

--- a/test/local/lib/purge-storages.test.ts
+++ b/test/local/lib/purge-storages.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { useTempPath } from '../../__setup__/hooks/useTempPath.js';
+
+const { beforeAllCalls, afterAllCalls, joinPath } = useTempPath('purge-storages', {
+	create: true,
+	remove: true,
+	cwd: true,
+	cwdParent: false,
+});
+
+const {
+	getLocalDatasetPath,
+	getLocalKeyValueStorePath,
+	getLocalRequestQueuePath,
+	getLocalStorageDir,
+	purgeDefaultDataset,
+	purgeDefaultKeyValueStore,
+	purgeDefaultQueue,
+} = await import('../../../src/lib/utils.js');
+
+const seedStorage = () => {
+	const keyValueStorePath = joinPath(getLocalKeyValueStorePath());
+	const datasetPath = joinPath(getLocalDatasetPath());
+	const requestQueuePath = joinPath(getLocalRequestQueuePath());
+
+	mkdirSync(keyValueStorePath, { recursive: true });
+	mkdirSync(datasetPath, { recursive: true });
+	mkdirSync(requestQueuePath, { recursive: true });
+
+	writeFileSync(join(keyValueStorePath, 'INPUT.json'), '{}');
+	writeFileSync(join(keyValueStorePath, 'TEST.json'), '{}');
+	writeFileSync(join(datasetPath, '000000001.json'), '{}');
+	writeFileSync(join(requestQueuePath, 'request.json'), '{}');
+};
+
+describe('purge helpers', () => {
+	beforeAll(async () => {
+		await beforeAllCalls();
+	});
+
+	afterAll(async () => {
+		await afterAllCalls();
+	});
+
+	beforeEach(() => {
+		rmSync(joinPath(getLocalStorageDir()), { recursive: true, force: true });
+		seedStorage();
+	});
+
+	it('deletes stored records and keeps the input file', async () => {
+		await purgeDefaultKeyValueStore('INPUT');
+
+		expect(readdirSync(joinPath(getLocalKeyValueStorePath()))).toStrictEqual(['INPUT.json']);
+	});
+
+	it('keeps every input key it is given', async () => {
+		writeFileSync(joinPath(getLocalKeyValueStorePath(), 'TEMP_INPUT.json'), '{}');
+
+		await purgeDefaultKeyValueStore('INPUT', 'TEMP_INPUT');
+
+		expect(readdirSync(joinPath(getLocalKeyValueStorePath())).sort()).toStrictEqual(['INPUT.json', 'TEMP_INPUT.json']);
+	});
+
+	it('deletes the default dataset', async () => {
+		await purgeDefaultDataset();
+
+		expect(existsSync(joinPath(getLocalDatasetPath()))).toBe(false);
+	});
+
+	it('deletes the default request queue', async () => {
+		await purgeDefaultQueue();
+
+		expect(existsSync(joinPath(getLocalRequestQueuePath()))).toBe(false);
+	});
+
+	it('does nothing when the storage folder is missing', async () => {
+		rmSync(joinPath(getLocalStorageDir()), { recursive: true, force: true });
+
+		await expect(
+			Promise.all([purgeDefaultKeyValueStore('INPUT'), purgeDefaultDataset(), purgeDefaultQueue()]),
+		).resolves.toBeDefined();
+	});
+});

--- a/test/local/lib/useModuleVersion.test.ts
+++ b/test/local/lib/useModuleVersion.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { useTempPath } from '../../__setup__/hooks/useTempPath.js';
+
+const moduleName = 'apify-cli-probe-module';
+
+const { beforeAllCalls, afterAllCalls, joinPath, tmpPath } = useTempPath('use-module-version', {
+	create: true,
+	remove: true,
+	cwd: true,
+	cwdParent: false,
+});
+
+const { useCwdProject } = await import('../../../src/lib/hooks/useCwdProject.js');
+const { useModuleVersion } = await import('../../../src/lib/hooks/useModuleVersion.js');
+
+describe('useModuleVersion', () => {
+	beforeAll(async () => {
+		await beforeAllCalls();
+
+		writeFileSync(joinPath('package.json'), JSON.stringify({ name: 'probe-project', version: '0.0.1' }));
+
+		const modulePath = joinPath('node_modules', moduleName);
+		mkdirSync(modulePath, { recursive: true });
+		writeFileSync(join(modulePath, 'package.json'), JSON.stringify({ name: moduleName, version: '1.2.3' }));
+		writeFileSync(join(modulePath, 'index.js'), 'module.exports = {};');
+	});
+
+	afterAll(async () => {
+		await afterAllCalls();
+	});
+
+	// The probe runs in a child process, which only looks in the project when it is given the cwd explicitly.
+	it('reads the version from the project the CLI runs in', async () => {
+		const project = (await useCwdProject({ cwd: tmpPath })).unwrap();
+
+		const version = await useModuleVersion({ moduleName, project });
+
+		expect(version.unwrapOr(null)).toStrictEqual('1.2.3');
+	});
+
+	it('returns none for a module the project does not have', async () => {
+		const project = (await useCwdProject({ cwd: tmpPath })).unwrap();
+
+		const version = await useModuleVersion({ moduleName: `${moduleName}-missing`, project });
+
+		expect(version.isNone()).toStrictEqual(true);
+	});
+});

--- a/test/local/lib/utils-purge-storages.test.ts
+++ b/test/local/lib/utils-purge-storages.test.ts
@@ -11,6 +11,7 @@ const { beforeAllCalls, afterAllCalls, joinPath } = useTempPath('purge-storages'
 });
 
 const {
+	checkIfStorageIsEmpty,
 	getLocalDatasetPath,
 	getLocalKeyValueStorePath,
 	getLocalRequestQueuePath,
@@ -35,7 +36,7 @@ const seedStorage = () => {
 	writeFileSync(join(requestQueuePath, 'request.json'), '{}');
 };
 
-describe('purge helpers', () => {
+describe('local storage helpers', () => {
 	beforeAll(async () => {
 		await beforeAllCalls();
 	});
@@ -75,11 +76,22 @@ describe('purge helpers', () => {
 		expect(existsSync(joinPath(getLocalRequestQueuePath()))).toBe(false);
 	});
 
+	it('reports the storage as non-empty while records remain', async () => {
+		await expect(checkIfStorageIsEmpty('INPUT')).resolves.toBe(false);
+	});
+
+	it('reports the storage as empty once only the input file is left', async () => {
+		await Promise.all([purgeDefaultKeyValueStore('INPUT'), purgeDefaultDataset(), purgeDefaultQueue()]);
+
+		await expect(checkIfStorageIsEmpty('INPUT')).resolves.toBe(true);
+	});
+
 	it('does nothing when the storage folder is missing', async () => {
 		rmSync(joinPath(getLocalStorageDir()), { recursive: true, force: true });
 
-		await expect(
-			Promise.all([purgeDefaultKeyValueStore('INPUT'), purgeDefaultDataset(), purgeDefaultQueue()]),
-		).resolves.toBeDefined();
+		await Promise.all([purgeDefaultKeyValueStore('INPUT'), purgeDefaultDataset(), purgeDefaultQueue()]);
+
+		expect(existsSync(joinPath(getLocalStorageDir()))).toBe(false);
+		await expect(checkIfStorageIsEmpty('INPUT')).resolves.toBe(true);
 	});
 });


### PR DESCRIPTION
> [!NOTE]
> After we merged https://github.com/apify/actor-templates/pull/866 this popped up. Actually it is missing scenario in `run --purge` not covered by tests and also a bug. + one windows bug found in review.


## Why master is red

apify/actor-templates [#866](https://github.com/apify/actor-templates/pull/866) added `.actor/input_schema.json` to every template on 2026-09-08 15:15 UTC. The tests download the live template, so the change hit CI with no commit here — the run before it was green.

With a schema present, `apify run --purge` writes a merged temp input file, so it turns crawlee's purge-on-start off (that purge only preserves `INPUT*` and would delete the temp file) and purges by itself instead. That path was broken:

- `useModuleVersion` ran the crawlee version probe without `cwd`, so under the test cwd mock it looked in the repo root instead of the project. Production is unaffected — execa defaults to `process.cwd()` — but nothing could exercise the branch.
- `purgeDefault*` resolved storage paths against the OS working directory, so under the same mock they returned early and deleted nothing — a silent no-op that reads exactly like a pass.

## Two user-facing fixes

Found while reviewing the code around the above, both pre-existing:

- **Windows:** `checkIfStorageIsEmpty` interpolated `storage\key_value_stores\default` into glob patterns, which reads backslashes as escapes. The `!…/INPUT.*` negations never matched, so `apify run` without `--purge` always warned "the storage directory contains a previous state" — even with nothing but the input file. Confirmed empirically against the pinned tinyglobby.
- **Absolute `APIFY_LOCAL_STORAGE_DIR`:** `getLocalInput` and the input paths in `validateAndStoreInput` used `join(cwd, …)`, producing `<cwd>/<abs>`. Now `resolve`, matching the purge helpers.

## Changes

| File | Change |
|---|---|
| `src/lib/utils.ts` | Windows glob fix; purge helpers and `getLocalInput` resolve against the command's directory; redundant `existsSync` guards dropped |
| `src/commands/run.ts` | Legacy-storage rename and input/temp-input paths resolve against the command's directory |
| `src/lib/hooks/useModuleVersion.ts` | Pass `cwd` to the version probe |
| `test/local/lib/utils-purge-storages.test.ts` | New — the purge helpers and `checkIfStorageIsEmpty`, directly |
| `test/local/lib/useModuleVersion.test.ts` | New — the version probe resolves modules from the project |
| `test/local/commands/run-without-crawlee.test.ts` | New — the purge branch taken when crawlee is absent |
| `test/local/commands/run.test.ts` | Input tests own the schema instead of racing the template's |

The last one fixes the Windows/macOS half of the failure. `.actor/INPUT_SCHEMA.json` is first in `DEFAULT_INPUT_SCHEMA_PATHS`, and on case-insensitive file systems it matched the template's `.actor/input_schema.json`, so an empty schema won over the test's own. The tests now delete the template's file, so exactly one schema exists on every platform.

## Coverage

Every change here has a test that fails without it. `checkIfStorageIsEmpty` had no coverage at all before. The no-crawlee test asserts a marker file the Actor writes — without it, "the Actor never ran" and "the purge worked" both leave an empty storage folder, which is how the original bug stayed hidden.

`pnpm run test:local`: 550 passed, 4 skipped, 0 failed. Lint, format, `tsc --noEmit`, build clean. No dependency changes, so no install-size impact.

## Merge order

Node 20 legs fail here on `create.test.ts > should skip installing optional dependencies` — red on master since 2026-09-04, four days before the templates change, and unrelated to this PR. [#1403](https://github.com/apify/apify-cli/pull/1403) drops those legs; its own legs fail on the bug this PR fixes. Merging #1403 first lets this one get a fully green run before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
