### PR TITLE
fix: isolate detectAiAgent test from ambient environment

### DIFF
--- a/test/lib/hooks/telemetry/detectEnvironment.test.ts
+++ b/test/lib/hooks/telemetry/detectEnvironment.test.ts
@@ -17,10 +17,16 @@ describe('detectAiAgent', () => {
 		'OPENCLAW_SHELL',
 	];
 
-	afterEach(() => {
+	// The suite may run inside an AI coding tool, which sets some of these,
+	// so clear them all instead of relying on the ambient environment.
+	beforeEach(() => {
 		for (const key of agentEnvVars) {
-			delete process.env[key];
+			vi.stubEnv(key, '');
 		}
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	test('returns undefined when no agent env vars are set', () => {
@@ -28,13 +34,13 @@ describe('detectAiAgent', () => {
 	});
 
 	test('returns correct agent for a known env var', () => {
-		process.env.GEMINI_CLI = '1';
+		vi.stubEnv('GEMINI_CLI', '1');
 		expect(detectAiAgent()).toBe('gemini_cli');
 	});
 
 	test('returns first match when multiple agent env vars are set', () => {
-		process.env.CURSOR_AGENT = '1';
-		process.env.GEMINI_CLI = '1';
+		vi.stubEnv('CURSOR_AGENT', '1');
+		vi.stubEnv('GEMINI_CLI', '1');
 
 		// CURSOR_AGENT appears before GEMINI_CLI in the lookup table
 		expect(detectAiAgent()).toBe('cursor');


### PR DESCRIPTION
> [!NOTE]
> fix flaky local test

## Problem

The test asserted no agent is detected, but relied on the ambient environment being clean. Inside Claude Code, Cursor, and similar tools, `CLAUDECODE` (or a sibling var) is set, so the test failed with `AssertionError: expected 'claude_code' to be undefined`.

Deterministic, not a flake — 6/6 failures on both master and feature branches. CI sets none of these variables, so it stayed green there.

## Change

- `beforeEach` stubs all nine vars from `AI_AGENT_ENV_VARS` to `''` with `vi.stubEnv`. Empty string is falsy, so the detector sees none set.
- `afterEach` calls `vi.unstubAllEnvs()`, which restores the real ambient values, replacing the manual delete loop.
- The two positive cases use `vi.stubEnv` too, so their values are restored as well.

The assertion is unchanged.

## Verification

Node 22.23.2, run from inside Claude Code:

- `CLAUDECODE=1` set: 7/7 pass
- `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` unset: 7/7 pass
- `CURSOR_AGENT=1 CODEX_SANDBOX=1 OPENCODE=1`: 7/7 pass
- `pnpm run lint`, `pnpm run format`, `pnpm run test:local`: clean, 557 passed / 4 skipped

## Follow-up

The var list in the test duplicates `AI_AGENT_ENV_VARS` in `src/lib/hooks/telemetry/detectEnvironment.ts`. A new agent var added to the source but not the test brings the leak back. Exporting the table and importing it in the test would close that gap — left out to keep this diff small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)