### PR TITLE
test: fix two local-only test failures caused by leftover state

### DIFF
--- a/test/lib/hooks/telemetry/detectEnvironment.test.ts
+++ b/test/lib/hooks/telemetry/detectEnvironment.test.ts
@@ -17,10 +17,15 @@ describe('detectAiAgent', () => {
 		'OPENCLAW_SHELL',
 	];
 
-	afterEach(() => {
+	beforeEach(() => {
+		// The suite itself may run inside one of these agents, so clear the vars before each test
 		for (const key of agentEnvVars) {
-			delete process.env[key];
+			vi.stubEnv(key, undefined);
 		}
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	test('returns undefined when no agent env vars are set', () => {

--- a/test/local/__fixtures__/python_support.test.ts
+++ b/test/local/__fixtures__/python_support.test.ts
@@ -12,7 +12,7 @@ const actorName = 'my-python-actor';
 const PYTHON_START_TEMPLATE_ID = 'python-start';
 const { beforeAllCalls, afterAllCalls, joinPath, tmpPath, toggleCwdBetweenFullAndParentPath } = useTempPath(actorName, {
 	create: true,
-	remove: false,
+	remove: true,
 	cwd: true,
 	cwdParent: true,
 });
@@ -34,6 +34,11 @@ describe('[python] Python support', () => {
 	});
 
 	it('should work', { timeout: TEST_TIMEOUT }, async () => {
+		if (existsSync(tmpPath)) {
+			// Remove the tmp path before detecting the runtime, so a leftover .venv is not picked up
+			await rm(tmpPath, { recursive: true, force: true });
+		}
+
 		const runtime = await usePythonRuntime({ cwd: tmpPath, force: true });
 
 		const pythonVersion = runtime.map((r) => r.version).unwrapOr(undefined);
@@ -42,11 +47,6 @@ describe('[python] Python support', () => {
 		if (!pythonVersion && !process.env.CI) {
 			console.log('Skipping Python template test since Python is not installed');
 			return;
-		}
-
-		if (existsSync(tmpPath)) {
-			// Remove the tmp path if it exists
-			await rm(tmpPath, { recursive: true, force: true });
 		}
 
 		await testRunCommand(CreateCommand, {


### PR DESCRIPTION
> [!NOTE]
> Two test-only fixes for failures that never show up in CI but break `pnpm run test:local`. One made the Python test alternate pass/fail on every other run; the other fails for anyone running the suite from inside an AI agent CLI.

---

## `python_support` alternated pass/fail

Measured 5/10 with `--retry=0`, deterministic alternation, pre-existing on `master`.

1. `useTempPath(..., { remove: false })` left `test/tmp/my-python-actor` behind — the only test in the repo using `remove: false`. It was flipped from `true` in #774 with no stated reason.
2. On the next run `usePythonRuntime({ cwd: tmpPath, force: true })` found the leftover `.venv` and cached `<tmpPath>/.venv/bin/python3` as the interpreter.
3. The test then deleted `tmpPath`, and so that interpreter.
4. The template setup invoked the cached path → exit 127, no `.venv` created, assertion failed.

CI never hit it: fresh checkout every job, plus `retry: 3` in `vitest.config.ts`.

Fix: `remove: true`, and delete `tmpPath` **before** runtime detection so an interrupted run can't leave a venv that gets picked up.

## `detectAiAgent` fails inside any agent CLI

The nine agent env vars were cleared in `afterEach` only, so the first test ran against whatever the shell exported. Inside Claude Code (`CLAUDECODE=1`) it returned `claude_code` instead of `undefined`. Same for Cursor, Codex, Gemini CLI.

Fix: clear them in `beforeEach` via `vi.stubEnv`, restore with `vi.unstubAllEnvs()`. The old `delete` also leaked — it removed `CLAUDECODE` from `process.env` for every later test in the worker.

## Verification

- `python_support`: 4/4 consecutive runs with `--retry=0` without clearing `test/tmp`; also passes with a real `.venv` planted at `test/tmp/my-python-actor/.venv` (the exact state that used to fail).
- `detectEnvironment`: 7/7 with `CLAUDECODE=1` set and 7/7 with it unset.
- Full local suite: 60 files / 557 tests, 0 failures, `--retry=0`.
- Lint, format, build clean. No install-size impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)