### PR TITLE
feat: allow installing a specific Actor runtime image

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -498,8 +498,8 @@ DESCRIPTION
 SUBCOMMANDS
   runtime install  Installs the Actor runtime: verifies this
                    machine has a working container engine (Docker or Podman) and
-                   downloads the Actor runtime image
-                   ('apify/actor-runtime:latest').
+                   downloads the Actor runtime image ('apify/actor-runtime:latest'
+                   unless another one is given).
   runtime start    Starts the Actor runtime, a local Apify
                    platform running as a container on Docker or Podman.
   runtime stop     Stops the Actor runtime container started with
@@ -512,13 +512,18 @@ SUBCOMMANDS
 DESCRIPTION
   Installs the Actor runtime: verifies this machine has a working container 
   engine (Docker or Podman) and downloads the Actor runtime image 
-  ('apify/actor-runtime:latest').
+  ('apify/actor-runtime:latest' unless another one is given).
+  'apify runtime start' then runs the image installed last.
   The engine itself is a prerequisite and is not installed by this command - see
    https://docs.docker.com/get-started/get-docker/ or 
   https://podman.io/docs/installation.
 
 USAGE
-  $ apify runtime install [-f]
+  $ apify runtime install [image] [-f]
+
+ARGUMENTS
+  image  Container image to install as the Actor runtime. Defaults to
+         'apify/actor-runtime:latest'.
 
 FLAGS
   -f, --force  Download the Actor runtime image even when it is already

--- a/skills/apify/SKILL.md
+++ b/skills/apify/SKILL.md
@@ -115,7 +115,7 @@ With Docker, check with `docker info` and act on what it tells you:
   - Docker Desktop (macOS, Windows, Linux desktop): https://docs.docker.com/get-started/get-docker/
   - Docker Engine (Linux servers, headless): https://docs.docker.com/engine/install/
 
-`apify runtime install` runs the same engine checks and prints a platform-specific hint when something is missing.
+`apify runtime install` runs the same engine checks and prints a platform-specific hint when something is missing. It installs `apify/actor-runtime:latest` unless another image is given (for example `apify runtime install apify/actor-runtime:master-5462005` for a pinned build); `apify runtime start` runs whichever image was installed last. Only name an image when the user asks for a specific one.
 
 **Working directory.** Install the preview CLI locally in one dedicated directory rather than globally, so it cannot replace the user's stable `apify` install. Keep the runtime data and the Actor projects you create in the same directory - everything the session produced is then in one place and easy to clean up:
 

--- a/src/commands/runtime/install.ts
+++ b/src/commands/runtime/install.ts
@@ -1,14 +1,16 @@
 import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
+import { Args } from '../../lib/command-framework/args.js';
 import { Flags } from '../../lib/command-framework/flags.js';
 import { simpleLog, success } from '../../lib/outputs.js';
-import { ACTOR_RUNTIME_IMAGE, DOCKER_GET_DOCKER_URL, PODMAN_INSTALL_URL } from '../../lib/runtime/docker.js';
+import { DEFAULT_ACTOR_RUNTIME_IMAGE, DOCKER_GET_DOCKER_URL, PODMAN_INSTALL_URL } from '../../lib/runtime/docker.js';
 import { ensureActorRuntimeImage } from '../../lib/runtime/ensure.js';
 
 export class RuntimeInstallCommand extends ApifyCommand<typeof RuntimeInstallCommand> {
 	static override name = 'install' as const;
 
 	static override description =
-		`Installs the Actor runtime: verifies this machine has a working container engine (Docker or Podman) and downloads the Actor runtime image ('${ACTOR_RUNTIME_IMAGE}').\n` +
+		`Installs the Actor runtime: verifies this machine has a working container engine (Docker or Podman) and downloads the Actor runtime image ('${DEFAULT_ACTOR_RUNTIME_IMAGE}' unless another one is given).\n` +
+		`'apify runtime start' then runs the image installed last.\n` +
 		`The engine itself is a prerequisite and is not installed by this command - see ${DOCKER_GET_DOCKER_URL} or ${PODMAN_INSTALL_URL}.`;
 
 	static override group = 'Local Actor Development';
@@ -22,9 +24,19 @@ export class RuntimeInstallCommand extends ApifyCommand<typeof RuntimeInstallCom
 			description: 'Re-download the Actor runtime image even if it is already present.',
 			command: 'apify runtime install --force',
 		},
+		{
+			description: 'Install a specific runtime image, e.g. a pinned build or another implementation.',
+			command: 'apify runtime install apify/actor-runtime:master-5462005',
+		},
 	];
 
 	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-runtime-install';
+
+	static override args = {
+		image: Args.string({
+			description: `Container image to install as the Actor runtime. Defaults to '${DEFAULT_ACTOR_RUNTIME_IMAGE}'.`,
+		}),
+	};
 
 	static override flags = {
 		force: Flags.boolean({
@@ -35,7 +47,10 @@ export class RuntimeInstallCommand extends ApifyCommand<typeof RuntimeInstallCom
 	};
 
 	async run() {
-		const installed = await ensureActorRuntimeImage({ forcePull: this.flags.force });
+		const installed = await ensureActorRuntimeImage({
+			image: this.args.image ?? DEFAULT_ACTOR_RUNTIME_IMAGE,
+			forcePull: this.flags.force,
+		});
 		if (!installed) return;
 
 		success({ message: 'Actor runtime is installed.' });

--- a/src/commands/runtime/start.ts
+++ b/src/commands/runtime/start.ts
@@ -18,7 +18,7 @@ import {
 	resolveEngineSocketPath,
 	runtimeEnvExportLines,
 } from '../../lib/runtime/docker.js';
-import { ensureActorRuntimeImage } from '../../lib/runtime/ensure.js';
+import { ensureActorRuntimeImage, installedActorRuntimeImage } from '../../lib/runtime/ensure.js';
 
 const defaultDataDir = () => join(GLOBAL_CONFIGS_FOLDER(), 'actor-runtime', 'data');
 
@@ -71,7 +71,8 @@ export class RuntimeStartCommand extends ApifyCommand<typeof RuntimeStartCommand
 			return;
 		}
 
-		const engine = await ensureActorRuntimeImage();
+		const image = installedActorRuntimeImage();
+		const engine = await ensureActorRuntimeImage({ image });
 		if (!engine) return;
 
 		const hostSocketPath = await resolveEngineSocketPath(engine);
@@ -91,7 +92,7 @@ export class RuntimeStartCommand extends ApifyCommand<typeof RuntimeStartCommand
 		});
 
 		// Spawned without a shell so interrupt signals reach the engine's 'run' directly instead of dying in 'sh -c'.
-		const args = buildRuntimeRunArgs({ dataDir, detach: this.flags.detach, hostSocketPath });
+		const args = buildRuntimeRunArgs({ image, dataDir, detach: this.flags.detach, hostSocketPath });
 		run({ message: `${engine} ${args.join(' ')}` });
 
 		const child = execa(engine, args, { stdio: 'inherit' });

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -58,6 +58,8 @@ export const STATE_FILE_PATH = () => join(GLOBAL_CONFIGS_FOLDER(), 'state.json')
 
 export const TELEMETRY_FILE_PATH = () => join(GLOBAL_CONFIGS_FOLDER(), 'telemetry.json');
 
+export const ACTOR_RUNTIME_CONFIG_FILE_PATH = () => join(GLOBAL_CONFIGS_FOLDER(), 'actor-runtime', 'config.json');
+
 export const DEPRECATED_LOCAL_CONFIG_NAME = 'apify.json';
 
 export const ACTOR_SPECIFICATION_FOLDER = '.actor';

--- a/src/lib/runtime/docker.ts
+++ b/src/lib/runtime/docker.ts
@@ -3,7 +3,7 @@ import process from 'node:process';
 import { execa } from 'execa';
 import which from 'which';
 
-export const ACTOR_RUNTIME_IMAGE = 'apify/actor-runtime:latest';
+export const DEFAULT_ACTOR_RUNTIME_IMAGE = 'apify/actor-runtime:latest';
 
 export const ACTOR_RUNTIME_CONTAINER_NAME = 'apify-actor-runtime';
 
@@ -202,6 +202,7 @@ export function socketMountArg(hostSocketPath: string, platform: NodeJS.Platform
 }
 
 export interface RuntimeRunArgsOptions {
+	image: string;
 	dataDir: string;
 	detach: boolean;
 	hostSocketPath: string;
@@ -209,6 +210,7 @@ export interface RuntimeRunArgsOptions {
 }
 
 export function buildRuntimeRunArgs({
+	image,
 	dataDir,
 	detach,
 	hostSocketPath,
@@ -230,7 +232,7 @@ export function buildRuntimeRunArgs({
 		socketMountArg(hostSocketPath, platform),
 		'-v',
 		`${dataDir}:/data`,
-		ACTOR_RUNTIME_IMAGE,
+		image,
 	);
 
 	return args;

--- a/src/lib/runtime/ensure.ts
+++ b/src/lib/runtime/ensure.ts
@@ -1,12 +1,15 @@
+import { readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 
 import chalk from 'chalk';
 
+import { ACTOR_RUNTIME_CONFIG_FILE_PATH } from '../consts.js';
 import { execWithLog } from '../exec.js';
+import { ensureApifyDirectory } from '../files.js';
 import { error, info } from '../outputs.js';
 import {
-	ACTOR_RUNTIME_IMAGE,
 	CONTAINER_ENGINE_ENV_VAR,
+	DEFAULT_ACTOR_RUNTIME_IMAGE,
 	type ContainerEngine,
 	engineDaemonHint,
 	engineInstallHint,
@@ -16,7 +19,23 @@ import {
 } from './docker.js';
 
 export interface EnsureActorRuntimeImageOptions {
+	image: string;
 	forcePull?: boolean;
+}
+
+/** The image the last 'apify runtime install' fetched, or the default when nothing was installed yet. */
+export function installedActorRuntimeImage(): string {
+	try {
+		const { image } = JSON.parse(readFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), 'utf-8'));
+		return typeof image === 'string' && image ? image : DEFAULT_ACTOR_RUNTIME_IMAGE;
+	} catch {
+		return DEFAULT_ACTOR_RUNTIME_IMAGE;
+	}
+}
+
+export function rememberInstalledActorRuntimeImage(image: string) {
+	ensureApifyDirectory(ACTOR_RUNTIME_CONFIG_FILE_PATH());
+	writeFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), JSON.stringify({ image }, null, '\t'));
 }
 
 /**
@@ -24,8 +43,9 @@ export interface EnsureActorRuntimeImageOptions {
  * Resolves to the engine to drive, or null after printing a user-facing error and setting the exit code.
  */
 export async function ensureActorRuntimeImage({
+	image,
 	forcePull = false,
-}: EnsureActorRuntimeImageOptions = {}): Promise<ContainerEngine | null> {
+}: EnsureActorRuntimeImageOptions): Promise<ContainerEngine | null> {
 	const found = await findContainerEngine();
 	if (!found) {
 		const requested = requestedContainerEngine();
@@ -50,23 +70,25 @@ export async function ensureActorRuntimeImage({
 		return null;
 	}
 
-	if (!forcePull && (await imageExistsLocally(engine, ACTOR_RUNTIME_IMAGE))) {
-		info({ message: `Actor runtime image '${ACTOR_RUNTIME_IMAGE}' is already available locally.` });
+	if (!forcePull && (await imageExistsLocally(engine, image))) {
+		info({ message: `Actor runtime image '${image}' is already available locally.` });
+		rememberInstalledActorRuntimeImage(image);
 		return engine;
 	}
 
-	info({ message: `Downloading the Actor runtime image '${ACTOR_RUNTIME_IMAGE}'...` });
+	info({ message: `Downloading the Actor runtime image '${image}'...` });
 
 	try {
-		await execWithLog({ cmd: engine, args: ['pull', ACTOR_RUNTIME_IMAGE] });
+		await execWithLog({ cmd: engine, args: ['pull', image] });
+		rememberInstalledActorRuntimeImage(image);
 		return engine;
 	} catch {
 		error({
 			message: [
-				`Could not pull '${ACTOR_RUNTIME_IMAGE}'.`,
+				`Could not pull '${image}'.`,
 				`  Check that you are online and can access the image - a private repository needs ${chalk.white.bold(`${engine} login`)} first.`,
 				'  You can also build the image locally from an actor-runtime checkout instead:',
-				chalk.white.bold(`    ${engine} build -t ${ACTOR_RUNTIME_IMAGE} .`),
+				chalk.white.bold(`    ${engine} build -t ${image} .`),
 			].join('\n'),
 		});
 		process.exitCode = 1;

--- a/test/local/lib/runtime-docker.test.ts
+++ b/test/local/lib/runtime-docker.test.ts
@@ -1,7 +1,7 @@
 import {
 	ACTOR_RUNTIME_CONTAINER_NAME,
-	ACTOR_RUNTIME_IMAGE,
 	buildRuntimeRunArgs,
+	DEFAULT_ACTOR_RUNTIME_IMAGE,
 	engineDaemonHint,
 	engineInstallHint,
 	requestedContainerEngine,
@@ -73,6 +73,7 @@ describe('runtime/docker', () => {
 		it('builds the canonical run command around the resolved host socket', () => {
 			expect(
 				buildRuntimeRunArgs({
+					image: DEFAULT_ACTOR_RUNTIME_IMAGE,
 					dataDir: '/home/me/data',
 					detach: false,
 					hostSocketPath: '/var/run/docker.sock',
@@ -92,12 +93,13 @@ describe('runtime/docker', () => {
 				'/var/run/docker.sock:/var/run/docker.sock',
 				'-v',
 				'/home/me/data:/data',
-				ACTOR_RUNTIME_IMAGE,
+				DEFAULT_ACTOR_RUNTIME_IMAGE,
 			]);
 		});
 
 		it("mounts a rootless Podman socket at the runtime's expected path", () => {
 			const args = buildRuntimeRunArgs({
+				image: DEFAULT_ACTOR_RUNTIME_IMAGE,
 				dataDir: '/data',
 				detach: false,
 				hostSocketPath: '/run/user/1000/podman/podman.sock',
@@ -108,13 +110,14 @@ describe('runtime/docker', () => {
 
 		it('adds --detach before the image when requested', () => {
 			const args = buildRuntimeRunArgs({
+				image: DEFAULT_ACTOR_RUNTIME_IMAGE,
 				dataDir: '/data',
 				detach: true,
 				hostSocketPath: '/var/run/docker.sock',
 				platform: 'linux',
 			});
 			expect(args).toContain('--detach');
-			expect(args.indexOf('--detach')).toBeLessThan(args.indexOf(ACTOR_RUNTIME_IMAGE));
+			expect(args.indexOf('--detach')).toBeLessThan(args.indexOf(DEFAULT_ACTOR_RUNTIME_IMAGE));
 		});
 	});
 });

--- a/test/local/lib/runtime-ensure.test.ts
+++ b/test/local/lib/runtime-ensure.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+
+import { ACTOR_RUNTIME_CONFIG_FILE_PATH } from '../../../src/lib/consts.js';
+import { DEFAULT_ACTOR_RUNTIME_IMAGE } from '../../../src/lib/runtime/docker.js';
+import { installedActorRuntimeImage, rememberInstalledActorRuntimeImage } from '../../../src/lib/runtime/ensure.js';
+import { useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
+
+useAuthSetup();
+
+describe('runtime/ensure installed image', () => {
+	it('falls back to the default image when nothing was installed yet', () => {
+		expect(installedActorRuntimeImage()).toBe(DEFAULT_ACTOR_RUNTIME_IMAGE);
+	});
+
+	it('remembers the installed image for the next start', () => {
+		rememberInstalledActorRuntimeImage('apify/actor-runtime:master-5462005');
+
+		expect(installedActorRuntimeImage()).toBe('apify/actor-runtime:master-5462005');
+		expect(JSON.parse(readFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), 'utf-8'))).toEqual({
+			image: 'apify/actor-runtime:master-5462005',
+		});
+	});
+});


### PR DESCRIPTION
`apify runtime install [image]` pulls the given image instead of the default `apify/actor-runtime:latest`, so a pinned build or another runtime implementation can be used:

```sh
apify runtime install apify/actor-runtime:master-5462005
```

- The installed image is recorded in `~/.apify/actor-runtime/config.json`.
- `apify runtime start` runs whatever was installed last; no flags or checks there.
- Without an argument, `install` keeps using the default image.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7Bi6BtaXTmLFxAiV3gRZ3