### PR TITLE
feat: add 'apify runtime status', 'connect' and 'disconnect'

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -475,35 +475,50 @@ DESCRIPTION
   APIFY_CONTAINER_ENGINE=docker or =podman to choose.
 
   'apify runtime install' checks that the engine is available and pulls the 
-  runtime image.
+  runtime image, 'apify runtime start' runs it, and 'apify runtime status' says 
+  whether it is up.
 
   The runtime publishes two ports on localhost:
 
     3333   API      http://localhost:3333  (Apify API compatible endpoint)
     3000   Console  http://localhost:3000  (web UI)
 
-  Point the Apify CLI (and Apify SDKs and API clients that honour these 
-  variables) at the runtime instead of the Apify cloud by setting:
+  Run 'apify runtime connect' to send every Apify CLI command to the runtime 
+  instead of the Apify cloud, and 'apify runtime disconnect' to go back. The 
+  connection is remembered across terminals and does not touch your login.
+
+  These environment variables point the CLI (and the Apify SDKs and API clients 
+  that honour them) at the runtime for one shell only, and take precedence over 
+  the connection wherever they are set:
 
     export APIFY_CLIENT_BASE_URL=http://localhost:3333
     export APIFY_CONSOLE_URL=http://localhost:3000
 
-  Unset them to talk to the Apify cloud again. 'apify runtime start' prints the 
-  same values when the runtime boots.
+  Unset them to let 'apify runtime connect' decide where commands go.
 
   Pointed at the runtime, 'apify push' also registers the pushed directory as 
   the Actor's live dev folder, so runs pick up local edits without another push;
    'apify call --no-dev-folder' runs from the built image alone.
 
 SUBCOMMANDS
-  runtime install  Installs the Actor runtime: verifies this
-                   machine has a working container engine (Docker or Podman) and
-                   downloads the Actor runtime image ('apify/actor-runtime:latest'
-                   unless another one is given).
-  runtime start    Starts the Actor runtime, a local Apify
-                   platform running as a container on Docker or Podman.
-  runtime stop     Stops the Actor runtime container started with
-                   'apify runtime start --detach'.
+  runtime install     Installs the Actor runtime: verifies
+                      this machine has a working container engine (Docker or
+                      Podman) and downloads the Actor runtime image
+                      ('apify/actor-runtime:latest' unless another one is given).
+  runtime start       Starts the Actor runtime, a local Apify
+                      platform running as a container on Docker or Podman.
+  runtime stop        Stops the Actor runtime container
+                      started with 'apify runtime start --detach'.
+  runtime status      Prints whether the Actor runtime is
+                      running, the ports it publishes, the host directory it keeps
+                      its data in, and which API the Apify CLI currently talks to.
+  runtime connect     Points the Apify CLI at the local Actor
+                      runtime instead of the Apify platform, for every command
+                      from now on and in every terminal.
+  runtime disconnect  Reverts 'apify runtime connect': the
+                      Apify CLI targets the Apify platform again, unless the API
+                      and console URL environment variables point it somewhere
+                      else.
 ```
 
 ##### `apify runtime install`
@@ -560,6 +575,49 @@ DESCRIPTION
 
 USAGE
   $ apify runtime stop
+```
+
+##### `apify runtime status`
+
+```sh
+DESCRIPTION
+  Prints whether the Actor runtime is running, the ports it publishes, the host 
+  directory it keeps its data in, and which API the Apify CLI currently talks 
+  to.
+  Exits with code 1 when the runtime is not running, so scripts can test for it.
+
+USAGE
+  $ apify runtime status [--json]
+
+FLAGS
+      --json  Format the command output as JSON.
+```
+
+##### `apify runtime connect`
+
+```sh
+DESCRIPTION
+  Points the Apify CLI at the local Actor runtime instead of the Apify platform,
+   for every command from now on and in every terminal.
+  The API and console URL environment variables keep taking precedence where 
+  they are set, so a shell that exports them is unaffected. Your login is 
+  untouched - run 'apify runtime disconnect' to target the Apify platform again.
+
+USAGE
+  $ apify runtime connect
+```
+
+##### `apify runtime disconnect`
+
+```sh
+DESCRIPTION
+  Reverts 'apify runtime connect': the Apify CLI targets the Apify platform 
+  again, unless the API and console URL environment variables point it somewhere
+   else.
+  The runtime itself keeps running - stop it with 'apify runtime stop'.
+
+USAGE
+  $ apify runtime disconnect
 ```
 
 ##### `apify actor`

--- a/scripts/generate-cli-docs.ts
+++ b/scripts/generate-cli-docs.ts
@@ -31,6 +31,9 @@ const categories: Record<string, CommandsInCategory[]> = {
 		{ command: Commands.runtimeInstall },
 		{ command: Commands.runtimeStart },
 		{ command: Commands.runtimeStop },
+		{ command: Commands.runtimeStatus },
+		{ command: Commands.runtimeConnect },
+		{ command: Commands.runtimeDisconnect },
 
 		{ command: Commands.actor },
 		{ command: Commands.actorCalculateMemory },

--- a/src/commands/runtime/_index.ts
+++ b/src/commands/runtime/_index.ts
@@ -10,8 +10,11 @@ import {
 	PODMAN_INSTALL_URL,
 	runtimeEnvExportLines,
 } from '../../lib/runtime/docker.js';
+import { RuntimeConnectCommand } from './connect.js';
+import { RuntimeDisconnectCommand } from './disconnect.js';
 import { RuntimeInstallCommand } from './install.js';
 import { RuntimeStartCommand } from './start.js';
+import { RuntimeStatusCommand } from './status.js';
 import { RuntimeStopCommand } from './stop.js';
 
 export class RuntimeIndexCommand extends ApifyCommand<typeof RuntimeIndexCommand> {
@@ -31,18 +34,20 @@ export class RuntimeIndexCommand extends ApifyCommand<typeof RuntimeIndexCommand
 		'',
 		`The first engine found on PATH is used, Docker before Podman. Set ${CONTAINER_ENGINE_ENV_VAR}=docker or =podman to choose.`,
 		'',
-		`'apify runtime install' checks that the engine is available and pulls the runtime image.`,
+		`'apify runtime install' checks that the engine is available and pulls the runtime image, 'apify runtime start' runs it, and 'apify runtime status' says whether it is up.`,
 		'',
 		'The runtime publishes two ports on localhost:',
 		'',
 		`  ${String(ACTOR_RUNTIME_API_PORT).padEnd(5)}  API      ${ACTOR_RUNTIME_API_URL}  (Apify API compatible endpoint)`,
 		`  ${String(ACTOR_RUNTIME_CONSOLE_PORT).padEnd(5)}  Console  ${ACTOR_RUNTIME_CONSOLE_URL}  (web UI)`,
 		'',
-		'Point the Apify CLI (and Apify SDKs and API clients that honour these variables) at the runtime instead of the Apify cloud by setting:',
+		`Run 'apify runtime connect' to send every Apify CLI command to the runtime instead of the Apify cloud, and 'apify runtime disconnect' to go back. The connection is remembered across terminals and does not touch your login.`,
+		'',
+		'These environment variables point the CLI (and the Apify SDKs and API clients that honour them) at the runtime for one shell only, and take precedence over the connection wherever they are set:',
 		'',
 		...runtimeEnvExportLines().map((line) => `  ${line}`),
 		'',
-		`Unset them to talk to the Apify cloud again. 'apify runtime start' prints the same values when the runtime boots.`,
+		`Unset them to let 'apify runtime connect' decide where commands go.`,
 		'',
 		`Pointed at the runtime, 'apify push' also registers the pushed directory as the Actor's live dev folder, so runs pick up local edits without another push; 'apify call --no-dev-folder' runs from the built image alone.`,
 	].join('\n');
@@ -55,14 +60,25 @@ export class RuntimeIndexCommand extends ApifyCommand<typeof RuntimeIndexCommand
 			command: 'apify runtime start --detach',
 		},
 		{
-			description: 'Point the CLI at the runtime and list Actors it knows about.',
+			description: 'Point the CLI at the runtime and list the Actors it knows about.',
+			command: 'apify runtime connect && apify actors ls',
+		},
+		{
+			description: 'Point the CLI at the runtime for a single command instead.',
 			command: `APIFY_CLIENT_BASE_URL=${ACTOR_RUNTIME_API_URL} apify actors ls`,
 		},
 	];
 
 	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-runtime';
 
-	static override subcommands = [RuntimeInstallCommand, RuntimeStartCommand, RuntimeStopCommand];
+	static override subcommands = [
+		RuntimeInstallCommand,
+		RuntimeStartCommand,
+		RuntimeStopCommand,
+		RuntimeStatusCommand,
+		RuntimeConnectCommand,
+		RuntimeDisconnectCommand,
+	];
 
 	async run() {
 		this.printHelp();

--- a/src/commands/runtime/connect.ts
+++ b/src/commands/runtime/connect.ts
@@ -1,0 +1,63 @@
+import chalk from 'chalk';
+
+import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
+import { simpleLog, success, warning } from '../../lib/outputs.js';
+import {
+	ACTOR_RUNTIME_API_URL,
+	ACTOR_RUNTIME_CONSOLE_URL,
+	findRunningRuntimeEngine,
+} from '../../lib/runtime/docker.js';
+import { overridingRuntimeEnvVars, setConnectedToActorRuntime } from '../../lib/runtime/target.js';
+
+export class RuntimeConnectCommand extends ApifyCommand<typeof RuntimeConnectCommand> {
+	static override name = 'connect' as const;
+
+	static override description =
+		`Points the Apify CLI at the local Actor runtime instead of the Apify platform, for every command from now on ` +
+		`and in every terminal.\n` +
+		`The API and console URL environment variables keep taking precedence where they are set, so a shell that ` +
+		`exports them is unaffected. Your login is untouched - run 'apify runtime disconnect' to target the Apify ` +
+		`platform again.`;
+
+	static override group = 'Local Actor Development';
+
+	static override examples = [
+		{
+			description: 'Send every Apify CLI command to the local Actor runtime.',
+			command: 'apify runtime connect',
+		},
+	];
+
+	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-runtime-connect';
+
+	async run() {
+		setConnectedToActorRuntime(true);
+
+		success({ message: 'The Apify CLI now targets the local Actor runtime.' });
+		simpleLog({
+			message: [
+				`  API:     ${ACTOR_RUNTIME_API_URL}`,
+				`  Console: ${ACTOR_RUNTIME_CONSOLE_URL}`,
+				'',
+				`Run ${chalk.white.bold('apify runtime disconnect')} to target the Apify platform again.`,
+			].join('\n'),
+		});
+
+		const overrides = overridingRuntimeEnvVars();
+		if (overrides.length) {
+			warning({
+				message: [
+					'These environment variables are set in this shell and take precedence over the connection:',
+					...overrides.map(([name, value]) => `  ${name}=${value}`),
+					'Unset them to let the connection decide where commands go.',
+				].join('\n'),
+			});
+		}
+
+		if (!(await findRunningRuntimeEngine())) {
+			warning({
+				message: `The Actor runtime is not running - commands will fail until you start it with ${chalk.white.bold('apify runtime start --detach')}.`,
+			});
+		}
+	}
+}

--- a/src/commands/runtime/disconnect.ts
+++ b/src/commands/runtime/disconnect.ts
@@ -1,0 +1,49 @@
+import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
+import { info, success, warning } from '../../lib/outputs.js';
+import {
+	isConnectedToActorRuntime,
+	overridingRuntimeEnvVars,
+	setConnectedToActorRuntime,
+} from '../../lib/runtime/target.js';
+
+export class RuntimeDisconnectCommand extends ApifyCommand<typeof RuntimeDisconnectCommand> {
+	static override name = 'disconnect' as const;
+
+	static override description =
+		`Reverts 'apify runtime connect': the Apify CLI targets the Apify platform again, unless the API and console URL ` +
+		`environment variables point it somewhere else.\n` +
+		`The runtime itself keeps running - stop it with 'apify runtime stop'.`;
+
+	static override group = 'Local Actor Development';
+
+	static override examples = [
+		{
+			description: 'Send Apify CLI commands to the Apify platform again.',
+			command: 'apify runtime disconnect',
+		},
+	];
+
+	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-runtime-disconnect';
+
+	async run() {
+		const wasConnected = isConnectedToActorRuntime();
+		setConnectedToActorRuntime(false);
+
+		if (wasConnected) {
+			success({ message: 'The Apify CLI no longer targets the local Actor runtime.' });
+		} else {
+			info({ message: 'The Apify CLI was not connected to the local Actor runtime.' });
+		}
+
+		const overrides = overridingRuntimeEnvVars();
+		if (overrides.length) {
+			warning({
+				message: [
+					'These environment variables are still set in this shell and keep pointing the CLI away from the Apify platform:',
+					...overrides.map(([name, value]) => `  ${name}=${value}`),
+					'Unset them to talk to the Apify platform.',
+				].join('\n'),
+			});
+		}
+	}
+}

--- a/src/commands/runtime/status.ts
+++ b/src/commands/runtime/status.ts
@@ -1,0 +1,124 @@
+import process from 'node:process';
+
+import chalk from 'chalk';
+
+import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
+import { simpleLog } from '../../lib/outputs.js';
+import {
+	ACTOR_RUNTIME_API_PORT,
+	ACTOR_RUNTIME_CONSOLE_PORT,
+	ACTOR_RUNTIME_CONTAINER_NAME,
+	findRunningRuntimeEngine,
+	inspectRuntimeContainer,
+	type PublishedPort,
+} from '../../lib/runtime/docker.js';
+import { installedActorRuntimeImage } from '../../lib/runtime/ensure.js';
+import { isConnectedToActorRuntime, overridingRuntimeEnvVars, resolveApiBaseUrl } from '../../lib/runtime/target.js';
+import { printJsonToStdout } from '../../lib/utils.js';
+
+function portRole(containerPort: number): string {
+	if (containerPort === ACTOR_RUNTIME_API_PORT) return 'API';
+	if (containerPort === ACTOR_RUNTIME_CONSOLE_PORT) return 'Console';
+	return '';
+}
+
+function portLine({ containerPort, protocol, hostAddress }: PublishedPort): string {
+	const role = portRole(containerPort);
+	return `  ${`${containerPort}/${protocol}`.padEnd(10)} -> ${hostAddress}${role ? `  (${role})` : ''}`;
+}
+
+export class RuntimeStatusCommand extends ApifyCommand<typeof RuntimeStatusCommand> {
+	static override name = 'status' as const;
+
+	static override description =
+		`Prints whether the Actor runtime is running, the ports it publishes, the host directory it keeps its data in, ` +
+		`and which API the Apify CLI currently talks to.\n` +
+		`Exits with code 1 when the runtime is not running, so scripts can test for it.`;
+
+	static override group = 'Local Actor Development';
+
+	static override examples = [
+		{
+			description: 'Show what the Actor runtime is doing.',
+			command: 'apify runtime status',
+		},
+		{
+			description: 'Read the status as JSON.',
+			command: 'apify runtime status --json',
+		},
+	];
+
+	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-runtime-status';
+
+	static override enableJsonFlag = true;
+
+	async run() {
+		const engine = await findRunningRuntimeEngine();
+		const container = engine ? await inspectRuntimeContainer(engine) : null;
+		const connected = isConnectedToActorRuntime();
+		const overrides = overridingRuntimeEnvVars();
+
+		if (this.flags.json) {
+			if (!engine) process.exitCode = 1;
+
+			printJsonToStdout({
+				running: Boolean(engine),
+				engine,
+				container: engine ? ACTOR_RUNTIME_CONTAINER_NAME : undefined,
+				image: container?.image ?? (engine ? undefined : installedActorRuntimeImage()),
+				status: container?.status,
+				startedAt: container?.startedAt,
+				dataDir: container?.dataDir,
+				ports: container?.ports ?? [],
+				connected,
+				apiBaseUrl: resolveApiBaseUrl() ?? null,
+				envOverrides: Object.fromEntries(overrides),
+			});
+			return;
+		}
+
+		const lines: string[] = [];
+
+		if (!engine) {
+			lines.push(
+				`Actor runtime: ${chalk.yellow('not running')}`,
+				'',
+				`  Installed image:  ${installedActorRuntimeImage()}`,
+				'',
+				`Start it with ${chalk.white.bold('apify runtime start --detach')}.`,
+			);
+		} else {
+			lines.push(
+				`Actor runtime: ${chalk.green(container?.status ?? 'running')} on ${engine} (container '${ACTOR_RUNTIME_CONTAINER_NAME}')`,
+				'',
+				`  Image:            ${container?.image ?? installedActorRuntimeImage()}`,
+				`  Data directory:   ${container?.dataDir ?? 'unknown'}`,
+			);
+
+			if (container?.startedAt) {
+				lines.push(`  Started at:       ${container.startedAt}`);
+			}
+
+			lines.push('', container?.ports.length ? 'Published ports:' : 'Published ports: none');
+			lines.push(...(container?.ports ?? []).map(portLine));
+		}
+
+		lines.push('', 'Apify CLI target:');
+		lines.push(
+			`  ${connected ? `the Actor runtime (${chalk.white.bold('apify runtime connect')})` : `the Apify platform (connect with ${chalk.white.bold('apify runtime connect')})`}`,
+		);
+		lines.push(`  API base URL:     ${resolveApiBaseUrl() ?? 'https://api.apify.com (default)'}`);
+
+		if (overrides.length) {
+			lines.push(
+				'',
+				'Set in this shell, taking precedence over the connection above:',
+				...overrides.map(([name, value]) => `  ${name}=${value}`),
+			);
+		}
+
+		simpleLog({ message: lines.join('\n') });
+
+		if (!engine) process.exitCode = 1;
+	}
+}

--- a/src/lib/console-url.ts
+++ b/src/lib/console-url.ts
@@ -1,14 +1,15 @@
-import process from 'node:process';
+import { resolveConsoleUrl } from './runtime/target.js';
 
 const DEFAULT_CONSOLE_URL = 'https://console.apify.com';
 
 /**
  * Resolves the base URL of the Apify Console used whenever the CLI prints links. Set
- * `APIFY_CONSOLE_URL` to point at a non-production Console (staging, a local instance, ...);
- * otherwise the production Console is used.
+ * `APIFY_CONSOLE_URL` to point at a non-production Console (staging, a local instance, ...), or run
+ * `apify runtime connect` to point at the local Actor runtime's console; otherwise the production
+ * Console is used.
  */
 export function getConsoleUrl(): string {
-	const explicit = process.env.APIFY_CONSOLE_URL;
+	const explicit = resolveConsoleUrl();
 	if (explicit) {
 		const stripped = stripTrailingSlash(explicit);
 		if (!URL.canParse(stripped)) {

--- a/src/lib/hooks/useRentalSunsetNotice.ts
+++ b/src/lib/hooks/useRentalSunsetNotice.ts
@@ -13,6 +13,7 @@ import {
 	RENTAL_SUNSET_NOTICE_UNTIL,
 } from '../consts.js';
 import { simpleLog, warning } from '../outputs.js';
+import { resolveApiBaseUrl } from '../runtime/target.js';
 import type { AuthJSON } from '../types.js';
 import { cliDebugPrint } from '../utils/cliDebugPrint.js';
 import { useCLIMetadata } from './useCLIMetadata.js';
@@ -114,7 +115,7 @@ async function getLocalUsername() {
 async function fetchRentalActorCount(username: string) {
 	const metadata = useCLIMetadata();
 
-	const url = new URL('/v2/store', process.env.APIFY_CLIENT_BASE_URL || DEFAULT_API_BASE_URL);
+	const url = new URL('/v2/store', resolveApiBaseUrl() || DEFAULT_API_BASE_URL);
 
 	try {
 		// axios rather than `fetch`, so the lookup honors HTTP_PROXY/HTTPS_PROXY/NO_PROXY like every

--- a/src/lib/runtime/config.ts
+++ b/src/lib/runtime/config.ts
@@ -1,0 +1,30 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { ACTOR_RUNTIME_CONFIG_FILE_PATH } from '../consts.js';
+import { ensureApifyDirectory } from '../files.js';
+
+/** What the CLI remembers about the Actor runtime between commands, stored in `~/.apify/actor-runtime/config.json`. */
+export interface ActorRuntimeConfig {
+	/** The image the last `apify runtime install` fetched. */
+	image?: string;
+	/** Whether `apify runtime connect` pointed the CLI at the runtime. */
+	connected?: boolean;
+}
+
+export function readActorRuntimeConfig(): ActorRuntimeConfig {
+	try {
+		const parsed = JSON.parse(readFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), 'utf-8')) as unknown;
+		return parsed && typeof parsed === 'object' ? (parsed as ActorRuntimeConfig) : {};
+	} catch {
+		return {};
+	}
+}
+
+/** Merges `patch` into the stored config, so writing one field never drops the others. */
+export function updateActorRuntimeConfig(patch: ActorRuntimeConfig) {
+	ensureApifyDirectory(ACTOR_RUNTIME_CONFIG_FILE_PATH());
+	writeFileSync(
+		ACTOR_RUNTIME_CONFIG_FILE_PATH(),
+		JSON.stringify({ ...readActorRuntimeConfig(), ...patch }, null, '\t'),
+	);
+}

--- a/src/lib/runtime/docker.ts
+++ b/src/lib/runtime/docker.ts
@@ -44,6 +44,9 @@ export const CONTAINER_ENGINE_ENV_VAR = 'APIFY_CONTAINER_ENGINE';
 /** Where the runtime container expects the engine's API socket. */
 export const RUNTIME_SOCKET_PATH = '/var/run/docker.sock';
 
+/** Where the runtime container expects its data directory (storages, builds and run records). */
+export const RUNTIME_DATA_PATH = '/data';
+
 export function runtimeEnvExportLines(): string[] {
 	return Object.entries(ACTOR_RUNTIME_ENV_VARS).map(([name, value]) => `export ${name}=${value}`);
 }
@@ -167,6 +170,87 @@ export async function isRuntimeContainerRunning(engine: ContainerEngine): Promis
 	}
 }
 
+/** A port the runtime container publishes: `containerPort/protocol` reachable at `hostAddress`. */
+export interface PublishedPort {
+	containerPort: number;
+	protocol: string;
+	hostAddress: string;
+}
+
+export interface RuntimeContainerInfo {
+	engine: ContainerEngine;
+	image?: string;
+	status?: string;
+	startedAt?: string;
+	/** The host directory mounted as the runtime's `/data`, where storages, builds and run records live. */
+	dataDir?: string;
+	ports: PublishedPort[];
+}
+
+interface InspectedContainer {
+	Name?: string;
+	ImageName?: string;
+	Config?: { Image?: string };
+	State?: { Status?: string; StartedAt?: string };
+	Mounts?: { Destination?: string; Source?: string }[];
+	NetworkSettings?: { Ports?: Record<string, { HostIp?: string; HostPort?: string }[] | null> };
+	HostConfig?: { PortBindings?: Record<string, { HostIp?: string; HostPort?: string }[] | null> };
+}
+
+function parsePublishedPorts(container: InspectedContainer): PublishedPort[] {
+	const bindings = container.NetworkSettings?.Ports ?? container.HostConfig?.PortBindings ?? {};
+	const ports: PublishedPort[] = [];
+
+	for (const [portAndProtocol, hostBindings] of Object.entries(bindings)) {
+		const [port, protocol = 'tcp'] = portAndProtocol.split('/');
+		const containerPort = Number(port);
+		if (!Number.isInteger(containerPort)) continue;
+
+		for (const binding of hostBindings ?? []) {
+			if (!binding?.HostPort) continue;
+			// An empty HostIp means every interface, which both engines print as 0.0.0.0.
+			ports.push({ containerPort, protocol, hostAddress: `${binding.HostIp || '0.0.0.0'}:${binding.HostPort}` });
+		}
+	}
+
+	return ports.sort((a, b) => a.containerPort - b.containerPort);
+}
+
+/** Reads one `inspect --format '{{json .}}'` payload, in either engine's shape. Null when it is unusable. */
+export function parseRuntimeContainerInfo(engine: ContainerEngine, raw: string): RuntimeContainerInfo | null {
+	let container: InspectedContainer;
+	try {
+		container = JSON.parse(raw) as InspectedContainer;
+	} catch {
+		return null;
+	}
+
+	if (!container || typeof container !== 'object') return null;
+
+	return {
+		engine,
+		// Docker reports the image under Config, Podman at the top level.
+		image: container.Config?.Image ?? container.ImageName,
+		status: container.State?.Status,
+		startedAt: container.State?.StartedAt,
+		dataDir: container.Mounts?.find((mount) => mount.Destination === RUNTIME_DATA_PATH)?.Source,
+		ports: parsePublishedPorts(container),
+	};
+}
+
+/**
+ * What the engine knows about the runtime container - its image, published ports and data directory.
+ * Null when the container is gone or the engine cannot be asked about it.
+ */
+export async function inspectRuntimeContainer(engine: ContainerEngine): Promise<RuntimeContainerInfo | null> {
+	try {
+		const { stdout } = await execa(engine, ['inspect', ACTOR_RUNTIME_CONTAINER_NAME, '--format', '{{json .}}']);
+		return parseRuntimeContainerInfo(engine, stdout);
+	} catch {
+		return null;
+	}
+}
+
 function unixSocketPath(url: string | undefined): string | undefined {
 	return url?.startsWith('unix://') ? url.slice('unix://'.length) : undefined;
 }
@@ -231,7 +315,7 @@ export function buildRuntimeRunArgs({
 		'-v',
 		socketMountArg(hostSocketPath, platform),
 		'-v',
-		`${dataDir}:/data`,
+		`${dataDir}:${RUNTIME_DATA_PATH}`,
 		image,
 	);
 

--- a/src/lib/runtime/ensure.ts
+++ b/src/lib/runtime/ensure.ts
@@ -1,12 +1,10 @@
-import { readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 
 import chalk from 'chalk';
 
-import { ACTOR_RUNTIME_CONFIG_FILE_PATH } from '../consts.js';
 import { execWithLog } from '../exec.js';
-import { ensureApifyDirectory } from '../files.js';
 import { error, info } from '../outputs.js';
+import { readActorRuntimeConfig, updateActorRuntimeConfig } from './config.js';
 import {
 	CONTAINER_ENGINE_ENV_VAR,
 	DEFAULT_ACTOR_RUNTIME_IMAGE,
@@ -25,17 +23,12 @@ export interface EnsureActorRuntimeImageOptions {
 
 /** The image the last 'apify runtime install' fetched, or the default when nothing was installed yet. */
 export function installedActorRuntimeImage(): string {
-	try {
-		const { image } = JSON.parse(readFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), 'utf-8'));
-		return typeof image === 'string' && image ? image : DEFAULT_ACTOR_RUNTIME_IMAGE;
-	} catch {
-		return DEFAULT_ACTOR_RUNTIME_IMAGE;
-	}
+	const { image } = readActorRuntimeConfig();
+	return image || DEFAULT_ACTOR_RUNTIME_IMAGE;
 }
 
 export function rememberInstalledActorRuntimeImage(image: string) {
-	ensureApifyDirectory(ACTOR_RUNTIME_CONFIG_FILE_PATH());
-	writeFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), JSON.stringify({ image }, null, '\t'));
+	updateActorRuntimeConfig({ image });
 }
 
 /**

--- a/src/lib/runtime/target.ts
+++ b/src/lib/runtime/target.ts
@@ -1,0 +1,33 @@
+import process from 'node:process';
+
+import { readActorRuntimeConfig, updateActorRuntimeConfig } from './config.js';
+import { ACTOR_RUNTIME_API_URL, ACTOR_RUNTIME_CONSOLE_URL, ACTOR_RUNTIME_ENV_VARS } from './docker.js';
+
+/** Whether `apify runtime connect` pointed the CLI at the local Actor runtime. */
+export function isConnectedToActorRuntime(): boolean {
+	return readActorRuntimeConfig().connected === true;
+}
+
+export function setConnectedToActorRuntime(connected: boolean) {
+	updateActorRuntimeConfig({ connected });
+}
+
+/** The environment variables from {@link ACTOR_RUNTIME_ENV_VARS} the user set themselves, with their values. */
+export function overridingRuntimeEnvVars(env: NodeJS.ProcessEnv = process.env): [string, string][] {
+	return Object.keys(ACTOR_RUNTIME_ENV_VARS)
+		.filter((name) => env[name])
+		.map((name) => [name, env[name]!]);
+}
+
+/**
+ * The API the CLI talks to: `APIFY_CLIENT_BASE_URL` when set, else the local Actor runtime while
+ * `apify runtime connect` is in effect, else undefined for the Apify platform default.
+ */
+export function resolveApiBaseUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	return env.APIFY_CLIENT_BASE_URL || (isConnectedToActorRuntime() ? ACTOR_RUNTIME_API_URL : undefined);
+}
+
+/** The Console the CLI links to, resolved the same way as {@link resolveApiBaseUrl}. */
+export function resolveConsoleUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	return env.APIFY_CONSOLE_URL || (isConnectedToActorRuntime() ? ACTOR_RUNTIME_CONSOLE_URL : undefined);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -45,6 +45,7 @@ import { ensureMigrated, getBackend, getProxyPassword, getToken, setProxyPasswor
 import { deleteFile, ensureApifyDirectory, ensureFolderExistsSync, rimrafPromised } from './files.js';
 import { useCLIMetadata } from './hooks/useCLIMetadata.js';
 import { inputFileRegExp, TEMP_INPUT_KEY_PREFIX } from './input-key.js';
+import { resolveApiBaseUrl } from './runtime/target.js';
 import type { AuthJSON } from './types.js';
 import { cliDebugPrint } from './utils/cliDebugPrint.js';
 
@@ -145,7 +146,7 @@ export const getApifyClientOptions = async (token?: string, apiBaseUrl?: string)
 
 	return {
 		token: resolvedToken,
-		baseUrl: apiBaseUrl || process.env.APIFY_CLIENT_BASE_URL,
+		baseUrl: apiBaseUrl || resolveApiBaseUrl(),
 		requestInterceptors: [
 			(config) => {
 				config.headers ??= new AxiosHeaders() as CJSAxiosHeaders;
@@ -586,7 +587,7 @@ export const outputJobLog = async ({
 	apifyClient?: ApifyClient;
 }) => {
 	const { id: logId, status } = job;
-	const client = apifyClient || new ApifyClient({ baseUrl: process.env.APIFY_CLIENT_BASE_URL });
+	const client = apifyClient || new ApifyClient({ baseUrl: resolveApiBaseUrl() });
 
 	// In case job was already done just output log
 	if (ACTOR_JOB_TERMINAL_STATUSES.includes(status as never)) {

--- a/test/local/lib/runtime-docker.test.ts
+++ b/test/local/lib/runtime-docker.test.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_ACTOR_RUNTIME_IMAGE,
 	engineDaemonHint,
 	engineInstallHint,
+	parseRuntimeContainerInfo,
 	requestedContainerEngine,
 	resolveEngineSocketPath,
 	socketMountArg,
@@ -66,6 +67,59 @@ describe('runtime/docker', () => {
 			expect(engineDaemonHint('podman', 'linux')).toContain('podman system service');
 			expect(engineDaemonHint('podman', 'darwin')).toContain('podman machine start');
 			expect(engineDaemonHint('podman', 'win32')).toContain('podman machine start');
+		});
+	});
+
+	describe('parseRuntimeContainerInfo()', () => {
+		it("reads the image, data directory and published ports out of either engine's inspect payload", () => {
+			expect(
+				parseRuntimeContainerInfo(
+					'docker',
+					JSON.stringify({
+						Config: { Image: 'apify/actor-runtime:latest' },
+						State: { Status: 'running', StartedAt: '2026-09-11T08:00:00Z' },
+						Mounts: [
+							{ Destination: '/var/run/docker.sock', Source: '/var/run/docker.sock' },
+							{ Destination: '/data', Source: '/home/me/.apify/actor-runtime/data' },
+						],
+						NetworkSettings: {
+							Ports: {
+								'3000/tcp': [{ HostIp: '0.0.0.0', HostPort: '3000' }],
+								'3333/tcp': [{ HostIp: '127.0.0.1', HostPort: '3333' }],
+							},
+						},
+					}),
+				),
+			).toEqual({
+				engine: 'docker',
+				image: 'apify/actor-runtime:latest',
+				status: 'running',
+				startedAt: '2026-09-11T08:00:00Z',
+				dataDir: '/home/me/.apify/actor-runtime/data',
+				ports: [
+					{ containerPort: 3000, protocol: 'tcp', hostAddress: '0.0.0.0:3000' },
+					{ containerPort: 3333, protocol: 'tcp', hostAddress: '127.0.0.1:3333' },
+				],
+			});
+
+			// Podman names the image at the top level and can report the bindings under HostConfig.
+			expect(
+				parseRuntimeContainerInfo(
+					'podman',
+					JSON.stringify({
+						ImageName: 'docker.io/apify/actor-runtime:latest',
+						State: { Status: 'running' },
+						Mounts: [{ Destination: '/data', Source: '/home/me/data' }],
+						HostConfig: { PortBindings: { '3333/tcp': [{ HostIp: '', HostPort: '3333' }] } },
+					}),
+				),
+			).toMatchObject({
+				image: 'docker.io/apify/actor-runtime:latest',
+				dataDir: '/home/me/data',
+				ports: [{ containerPort: 3333, protocol: 'tcp', hostAddress: '0.0.0.0:3333' }],
+			});
+
+			expect(parseRuntimeContainerInfo('docker', 'not json')).toBeNull();
 		});
 	});
 

--- a/test/local/lib/runtime-target.test.ts
+++ b/test/local/lib/runtime-target.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+
+import { ACTOR_RUNTIME_CONFIG_FILE_PATH } from '../../../src/lib/consts.js';
+import { ACTOR_RUNTIME_API_URL, ACTOR_RUNTIME_CONSOLE_URL } from '../../../src/lib/runtime/docker.js';
+import { rememberInstalledActorRuntimeImage } from '../../../src/lib/runtime/ensure.js';
+import {
+	overridingRuntimeEnvVars,
+	resolveApiBaseUrl,
+	resolveConsoleUrl,
+	setConnectedToActorRuntime,
+} from '../../../src/lib/runtime/target.js';
+import { useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
+
+useAuthSetup();
+
+describe('runtime/target', () => {
+	it('targets the runtime while connected and the platform otherwise, keeping the installed image', () => {
+		rememberInstalledActorRuntimeImage('apify/actor-runtime:master-5462005');
+
+		expect(resolveApiBaseUrl({})).toBeUndefined();
+		expect(resolveConsoleUrl({})).toBeUndefined();
+
+		setConnectedToActorRuntime(true);
+
+		expect(resolveApiBaseUrl({})).toBe(ACTOR_RUNTIME_API_URL);
+		expect(resolveConsoleUrl({})).toBe(ACTOR_RUNTIME_CONSOLE_URL);
+		expect(JSON.parse(readFileSync(ACTOR_RUNTIME_CONFIG_FILE_PATH(), 'utf-8'))).toEqual({
+			image: 'apify/actor-runtime:master-5462005',
+			connected: true,
+		});
+
+		setConnectedToActorRuntime(false);
+
+		expect(resolveApiBaseUrl({})).toBeUndefined();
+		expect(resolveConsoleUrl({})).toBeUndefined();
+	});
+
+	it('lets the environment variables win over the connection', () => {
+		setConnectedToActorRuntime(true);
+
+		const env = { APIFY_CLIENT_BASE_URL: 'https://api.apify.com', APIFY_CONSOLE_URL: 'https://console.apify.com' };
+
+		expect(resolveApiBaseUrl(env)).toBe('https://api.apify.com');
+		expect(resolveConsoleUrl(env)).toBe('https://console.apify.com');
+		expect(overridingRuntimeEnvVars(env)).toEqual([
+			['APIFY_CLIENT_BASE_URL', 'https://api.apify.com'],
+			['APIFY_CONSOLE_URL', 'https://console.apify.com'],
+		]);
+		expect(overridingRuntimeEnvVars({})).toEqual([]);
+	});
+});


### PR DESCRIPTION
'apify runtime status' reports whether the runtime container is running, on which engine and image, the ports it publishes, the host directory mounted as its data directory, and which API the CLI currently targets. It exits 1 when the runtime is down, and takes --json.

'apify runtime connect' makes every CLI command target the local runtime, and 'apify runtime disconnect' reverts to the Apify platform. The connection is stored next to the installed image in ~/.apify/actor-runtime/config.json, so it holds across terminals and does not touch the login. APIFY_CLIENT_BASE_URL and APIFY_CONSOLE_URL keep taking precedence wherever they are set, so the current per-shell behavior is unchanged; both commands say so when they are set.


Claude-Session: https://claude.ai/code/session_01PaySaAvWxMBNuVMSXXLqno