### PR TITLE
fix: commands now exit with code 1 on failure

### DIFF
--- a/src/commands/cli-management/upgrade.ts
+++ b/src/commands/cli-management/upgrade.ts
@@ -284,7 +284,7 @@ export class UpgradeCommand extends ApifyCommand<typeof UpgradeCommand> {
 				].join('\n'),
 			});
 
-			process.exit(1);
+			return;
 		}
 
 		const buffer = await res.arrayBuffer();

--- a/src/commands/edit-input-schema.ts
+++ b/src/commands/edit-input-schema.ts
@@ -12,7 +12,7 @@ import { Args } from '../lib/command-framework/args.js';
 import { LOCAL_CONFIG_PATH } from '../lib/consts.js';
 import { readInputSchema } from '../lib/input_schema.js';
 import { createLocalApiServer } from '../lib/local-api-server.js';
-import { error, info, success, warning } from '../lib/outputs.js';
+import { info, logError, success, warning } from '../lib/outputs.js';
 
 const INPUT_SCHEMA_EDITOR_BASE_URL = 'https://apify.github.io/input-schema-editor-react/';
 const INPUT_SCHEMA_EDITOR_ORIGIN = new URL(INPUT_SCHEMA_EDITOR_BASE_URL).origin;
@@ -105,7 +105,7 @@ export class EditInputSchemaCommand extends ApifyCommand<typeof EditInputSchemaC
 						}
 					} catch (err) {
 						const errorMessage = `Reading input schema from disk failed with: ${(err as Error).message}`;
-						error({ message: errorMessage });
+						logError({ message: errorMessage });
 						res.status(500);
 						res.send(errorMessage);
 						return;
@@ -116,7 +116,7 @@ export class EditInputSchemaCommand extends ApifyCommand<typeof EditInputSchemaC
 						inputSchemaObj = JSON.parse(inputSchemaStr || '{}');
 					} catch (err) {
 						const errorMessage = `Parsing input schema failed with error: ${(err as Error).message}`;
-						error({ message: errorMessage });
+						logError({ message: errorMessage });
 						res.status(500);
 						res.send(errorMessage);
 						return;
@@ -141,7 +141,7 @@ export class EditInputSchemaCommand extends ApifyCommand<typeof EditInputSchemaC
 						info({ message: 'Input schema saved to disk.' });
 					} catch (err) {
 						const errorMessage = `Saving input schema failed with error: ${(err as Error).message}`;
-						error({ message: errorMessage });
+						logError({ message: errorMessage });
 						res.status(500);
 						res.send(errorMessage);
 					}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -71,7 +71,7 @@ export class InitCommand extends ApifyCommand<typeof InitCommand> {
 		// TODO: use direct .unwrap() once we migrate to yargs
 		if (projectResult.isErr()) {
 			error({ message: projectResult.unwrapErr().message });
-			process.exit(1);
+			return;
 		}
 
 		const project = projectResult.unwrap();

--- a/src/entrypoints/_shared.ts
+++ b/src/entrypoints/_shared.ts
@@ -60,7 +60,7 @@ export function processVersionCheck(cliName: string) {
 			message: `${cliName} CLI requires Node.js version ${SUPPORTED_NODEJS_VERSION}. Your current version is ${process.version}.`,
 		});
 
-		process.exit(1);
+		return;
 	}
 }
 
@@ -97,7 +97,7 @@ type TopLevelValues = ReturnType<
 	}>
 >;
 
-function handleCommandNotFound(commandName: string): never {
+function handleCommandNotFound(commandName: string): void {
 	const closestMatches = useCommandSuggestions(String(commandName));
 
 	let message = chalk.gray(`Command ${chalk.whiteBright(commandName)} not found`);
@@ -108,8 +108,6 @@ function handleCommandNotFound(commandName: string): never {
 	}
 
 	error({ message });
-
-	process.exit(1);
 }
 
 async function runVersionCheck(entrypoint: string, maybeCommandName?: string) {
@@ -282,7 +280,5 @@ export async function runCLI(entrypoint: string) {
 		const commandError = CommandError.into(err, FinalCommand);
 
 		error({ message: commandError.getPrettyMessage() });
-
-		process.exit(1);
 	}
 }

--- a/src/lib/command-framework/apify-command.ts
+++ b/src/lib/command-framework/apify-command.ts
@@ -383,15 +383,15 @@ export abstract class ApifyCommand<T extends typeof BuiltApifyCommand = typeof B
 			}
 		}
 
-		if (missingRequiredArgs.size) {
-			process.exitCode = 1;
-			this._printMissingRequiredArgs(missingRequiredArgs);
-			return;
-		}
-
 		this._parseFlags(rawFlags, rawTokens);
 
 		try {
+			if (missingRequiredArgs.size) {
+				process.exitCode = 1;
+				this._printMissingRequiredArgs(missingRequiredArgs);
+				return;
+			}
+
 			await this.run();
 		} catch (err: any) {
 			error({ message: err.message });

--- a/src/lib/hooks/useAbortJobOnSignal.ts
+++ b/src/lib/hooks/useAbortJobOnSignal.ts
@@ -2,7 +2,7 @@ import type { ApifyClient } from 'apify-client';
 import chalk from 'chalk';
 
 import { INTERRUPT_SIGNALS } from '../consts.js';
-import { error, info } from '../outputs.js';
+import { info, logError } from '../outputs.js';
 import { useSignalHandler } from './useSignalHandler.js';
 
 export type UseAbortJobOnSignalInput = {
@@ -84,7 +84,7 @@ export function useAbortJobOnSignal(input: UseAbortJobOnSignalInput): Disposable
 				try {
 					await apifyClient.build(input.jobId).abort();
 				} catch (abortErr) {
-					error({
+					logError({
 						message: `Failed to abort build "${input.jobId}": ${(abortErr as Error).message}`,
 						stdout: true,
 					});
@@ -111,7 +111,7 @@ export function useAbortJobOnSignal(input: UseAbortJobOnSignalInput): Disposable
 			try {
 				await apifyClient.run(input.jobId).abort({ gracefully });
 			} catch (abortErr) {
-				error({
+				logError({
 					message: `Failed to abort run "${input.jobId}": ${(abortErr as Error).message}`,
 					stdout: true,
 				});

--- a/src/lib/outputs.ts
+++ b/src/lib/outputs.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 import chalk from 'chalk';
 
 export interface LogOptions {
@@ -27,6 +29,13 @@ export function simpleLog(options: SimpleLogOptions) {
 }
 
 export function error(options: SimpleLogOptions) {
+	internalLog({
+		[options.stdout ? 'stdoutOutput' : 'stderrOutput']: [chalk.red('Error:'), options.message],
+	});
+	process.exitCode ||= 1;
+}
+
+export function logError(options: SimpleLogOptions) {
 	internalLog({
 		[options.stdout ? 'stdoutOutput' : 'stderrOutput']: [chalk.red('Error:'), options.message],
 	});

--- a/test/local/commands/datasets/rename.test.ts
+++ b/test/local/commands/datasets/rename.test.ts
@@ -1,0 +1,21 @@
+import process from 'node:process';
+
+import { describe, afterEach, it, expect } from 'vitest';
+
+import { DatasetsRenameCommand } from '../../../../src/commands/datasets/rename.js';
+import { testRunCommand } from '../../../../src/lib/command-framework/apify-command.js';
+import { useConsoleSpy } from '../../../__setup__/hooks/useConsoleSpy.js';
+
+const { lastErrorMessage } = useConsoleSpy();
+
+describe('apify datasets rename', () => {
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	it('exits with code 1 when neither new-name nor --unname is provided', async () => {
+		await testRunCommand(DatasetsRenameCommand, { args_nameOrId: 'my-dataset' });
+		expect(process.exitCode).toBe(1);
+		expect(lastErrorMessage()).toMatch(/You must provide either a new name or the --unname flag/);
+	});
+});

--- a/test/local/lib/outputs.test.ts
+++ b/test/local/lib/outputs.test.ts
@@ -1,0 +1,34 @@
+import process from 'node:process';
+
+import { describe, afterEach, it, expect } from 'vitest';
+
+import { error, logError } from '../../../src/lib/outputs.js';
+import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
+
+useConsoleSpy();
+
+describe('outputs', () => {
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	describe('error()', () => {
+		it('sets process.exitCode to 1', () => {
+			error({ message: 'something went wrong' });
+			expect(process.exitCode).toBe(1);
+		});
+
+		it('does not downgrade an already-set non-zero exitCode', () => {
+			process.exitCode = 5;
+			error({ message: 'something went wrong' });
+			expect(process.exitCode).toBe(5);
+		});
+	});
+
+	describe('logError()', () => {
+		it('does NOT set process.exitCode', () => {
+			logError({ message: 'transient error in callback' });
+			expect(process.exitCode).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1254.

## Summary

Many commands printed a red Error message but still exited with code 0, breaking CI and shell scripting.

Three root causes fixed:
- RC-1 (73 sites): Added process.exitCode ||= 1 to error() in outputs.ts — fixes all error()+return call sites at once
- RC-2 (5 sites): Replaced process.exit(1) with return in _shared.ts, init.ts, upgrade.ts so telemetry finally block fires
- RC-3: Moved missing-required-args check inside try/finally so those invocations emit telemetry

Special cases: two contexts must not set process.exitCode (HTTP route handlers in edit-input-schema.ts and signal handler in useAbortJobOnSignal.ts). Added logError() — same output, no exitCode side-effect.

## Test plan
- New unit tests: test/local/lib/outputs.test.ts (error() sets exitCode, logError() does not)
- New integration test: test/local/commands/datasets/rename.test.ts (exit code 1 on validation failure)
- Manual: node dist/apify.js datasets rename my-dataset now exits with code 1
