### PR TITLE
fix(actors ls): do not crash when an Actor record has no stats

### DIFF
--- a/src/commands/actors/ls.ts
+++ b/src/commands/actors/ls.ts
@@ -287,7 +287,7 @@ export class ActorsLsCommand extends ApifyCommand<typeof ActorsLsCommand> {
 				'Last run': lastRunDisplayedTimestamp,
 				'Last run status': item.lastRun ? prettyPrintStatus(item.lastRun.status) : '',
 				'Modified at': MultilineTimestampFormatter.display(item.modifiedAt),
-				Builds: item.actor ? chalk.cyan(item.actor.stats.totalBuilds) : chalk.gray('Unknown'),
+				Builds: item.actor?.stats ? chalk.cyan(item.actor.stats.totalBuilds) : chalk.gray('Unknown'),
 				'Last run duration': ResponsiveTable.isSmallTerminal() ? kSkipColumn : chalk.cyan(lastRunDuration),
 				'Default build': defaultBuild,
 				_Small_LastRunText: runStatus,

--- a/test/local/commands/actors-ls.test.ts
+++ b/test/local/commands/actors-ls.test.ts
@@ -1,0 +1,69 @@
+import type { ApifyClient } from 'apify-client';
+
+import { ActorsLsCommand } from '../../../src/commands/actors/ls.js';
+import { testRunCommand } from '../../../src/lib/command-framework/apify-command.js';
+import { useAuthSetup } from '../../__setup__/hooks/useAuthSetup.js';
+import { useConsoleSpy } from '../../__setup__/hooks/useConsoleSpy.js';
+
+const { mockGetLoggedClientOrThrow } = vitest.hoisted(() => ({
+	mockGetLoggedClientOrThrow: vitest.fn(),
+}));
+
+vitest.mock('../../../src/lib/utils.js', async (importOriginal) => {
+	const original = await importOriginal<typeof import('../../../src/lib/utils.js')>();
+	return {
+		...original,
+		getLoggedClientOrThrow: mockGetLoggedClientOrThrow,
+	};
+});
+
+useAuthSetup();
+
+const { logMessages } = useConsoleSpy();
+
+const listItem = {
+	id: 'abc123',
+	createdAt: new Date('2024-01-01T00:00:00Z'),
+	modifiedAt: new Date('2024-01-02T00:00:00Z'),
+	name: 'some-actor',
+	username: 'someone-else',
+	title: 'Some Actor',
+	stats: { totalRuns: 3, lastRunStartedAt: '2024-01-02T00:00:00Z' },
+};
+
+// The API omits `stats` on some Actor records even though apify-client types it as required.
+const actorWithoutStats = {
+	id: 'abc123',
+	name: 'some-actor',
+	username: 'someone-else',
+	title: 'Some Actor',
+	defaultRunOptions: { build: 'latest', timeoutSecs: 3600, memoryMbytes: 1024 },
+};
+
+const fakeClient = () =>
+	({
+		actors: () => ({
+			list: async () => ({ count: 1, desc: false, items: [listItem], limit: 20, offset: 0, total: 1 }),
+		}),
+		actor: () => ({
+			get: async () => actorWithoutStats,
+			runs: () => ({
+				list: async () => ({ count: 0, desc: true, items: [], limit: 1, offset: 0, total: 0 }),
+			}),
+		}),
+	}) as unknown as ApifyClient;
+
+afterEach(() => {
+	mockGetLoggedClientOrThrow.mockReset();
+});
+
+describe('apify actors ls', () => {
+	it('renders the table when an Actor record has no stats', async () => {
+		mockGetLoggedClientOrThrow.mockResolvedValue(fakeClient());
+
+		await testRunCommand(ActorsLsCommand, { flags_my: true });
+
+		expect(logMessages.error).toEqual([]);
+		expect(logMessages.log.join('\n')).toContain('Some Actor');
+	});
+});


### PR DESCRIPTION
> [!NOTE]
> `apify actors ls` crashed with `Cannot read properties of undefined (reading 'totalBuilds')`. The `stats` field is missing on some Actor records; the code only guarded `item.actor`. One-line guard plus a regression test.

## What changed

- `src/commands/actors/ls.ts` — `item.actor ? …` → `item.actor?.stats ? …` for the `Builds` column.
- `test/local/commands/actors-ls.test.ts` — renders the table with an Actor record that has no `stats`. Fails on `master` with the exact error above.

## Why it happened

- `apify-client` types `Actor.stats` as required (`ActorStats`), so TypeScript saw the access as safe. The API does not always send it.
- The `Builds` value is computed for both tables even though only the `--my` table shows that column, so plain `apify actors ls` hits it too.
- Existing e2e tests all pass `--json`, which returns before table rendering. The render path had no coverage.

## Notes

- Not reproducible on every account — depends on which Actors are in your recent list.
- `apify-client`'s `ActorStats` is inaccurate in two more ways: `totalMetamorphs` is required but absent from 3 of 5 public Actor responses I checked, and `publicActorRunStats30Days`, `actorReviewCount`, `actorReviewRating`, `bookmarkCount` are returned but undeclared. Worth a separate issue on `apify-client-js`.
- No install-size impact.

Reported by @mtrunkat in #cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)