### PR TITLE
docs: Add `apify runtime skill` command for Agent Skills

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -519,6 +519,10 @@ SUBCOMMANDS
                       Apify CLI targets the Apify platform again, unless the API
                       and console URL environment variables point it somewhere
                       else.
+  runtime skill       Prints the Actor runtime's Agent Skill -
+                      the instructions an agent needs to drive the runtime (the
+                      dev-folder loop, debug mode, browser view, migration
+                      testing, the API fallback).
 ```
 
 ##### `apify runtime install`
@@ -618,6 +622,31 @@ DESCRIPTION
 
 USAGE
   $ apify runtime disconnect
+```
+
+##### `apify runtime skill`
+
+```sh
+DESCRIPTION
+  Prints the Actor runtime's Agent Skill - the instructions an agent needs to 
+  drive the runtime (the dev-folder loop, debug mode, browser view, migration 
+  testing, the API fallback).
+  The skill ships inside the runtime image, so it always describes the runtime 
+  you actually have. It is read over HTTP when the runtime is running, and 
+  straight out of the installed image when it is not - so 'apify runtime 
+  install' is all it needs.
+  Use --install to put it in your agent's skills directory, where it loads on 
+  demand in this and later sessions instead of only the terminal it was printed 
+  into.
+
+USAGE
+  $ apify runtime skill [--install] [--raw]
+
+FLAGS
+      --install  Write the skill into every agent skills directory found,
+                 instead of printing it.
+      --raw      Print the file exactly as it ships, frontmatter and all,
+                 with no added header.
 ```
 
 ##### `apify actor`

--- a/scripts/generate-cli-docs.ts
+++ b/scripts/generate-cli-docs.ts
@@ -34,6 +34,7 @@ const categories: Record<string, CommandsInCategory[]> = {
 		{ command: Commands.runtimeStatus },
 		{ command: Commands.runtimeConnect },
 		{ command: Commands.runtimeDisconnect },
+		{ command: Commands.runtimeSkill },
 
 		{ command: Commands.actor },
 		{ command: Commands.actorCalculateMemory },

--- a/skills/apify/SKILL.md
+++ b/skills/apify/SKILL.md
@@ -91,6 +91,8 @@ apify key-value-stores keys <storeId> --json
 
 `apify runtime` runs a self-contained local Apify platform as a container on Docker or Podman. Use it to develop and test Actors against a platform-compatible API without touching the user's cloud account. It ships on the `runtime` npm dist-tag, not on `latest`.
 
+This section covers only how to *get* a runtime. Once you have one, **run `apify runtime skill --install`** (or `apify runtime skill` to read it now) — the runtime ships its own Agent Skill describing everything it can do: the no-rebuild dev-folder loop, IDE debugging, watching a Playwright/Puppeteer browser, migration testing, and relaying unimplemented calls to the real platform. That skill lives in the runtime image, so it always matches the runtime you actually have; do not reconstruct it from memory.
+
 **Prerequisite: Docker or Podman.** One of them must be installed and running before any `apify runtime` command works; the CLI does not install either. It uses the first engine found on PATH (Docker before Podman); `APIFY_CONTAINER_ENGINE=podman` forces Podman.
 
 With Podman, the API socket must be served: check with `podman info --format '{{.Host.RemoteSocket.Exists}}'` (must print `true`). If it does not, run `systemctl --user enable --now podman.socket` (rootless) or `sudo systemctl enable --now podman.socket` (rootful); without systemd, `podman system service --time=0 &`. On macOS/Windows, `podman machine start` first. Rootful and rootless Podman both work.
@@ -139,6 +141,7 @@ export APIFY_DISABLE_KEYRING=1
 
 $APIFY runtime install
 $APIFY runtime start --detach --data-dir ./runtime-data   # omit --detach to run in the foreground (Ctrl+C stops it)
+$APIFY runtime skill --install                            # install the runtime's own skill, then follow it
 $APIFY login --token local-dev-token                      # the runtime accepts any token
 $APIFY actors ls --json                                   # now talks to the local runtime
 $APIFY runtime stop

--- a/src/commands/runtime/_index.ts
+++ b/src/commands/runtime/_index.ts
@@ -13,6 +13,7 @@ import {
 import { RuntimeConnectCommand } from './connect.js';
 import { RuntimeDisconnectCommand } from './disconnect.js';
 import { RuntimeInstallCommand } from './install.js';
+import { RuntimeSkillCommand } from './skill.js';
 import { RuntimeStartCommand } from './start.js';
 import { RuntimeStatusCommand } from './status.js';
 import { RuntimeStopCommand } from './stop.js';
@@ -78,6 +79,7 @@ export class RuntimeIndexCommand extends ApifyCommand<typeof RuntimeIndexCommand
 		RuntimeStatusCommand,
 		RuntimeConnectCommand,
 		RuntimeDisconnectCommand,
+		RuntimeSkillCommand,
 	];
 
 	async run() {

--- a/src/commands/runtime/connect.ts
+++ b/src/commands/runtime/connect.ts
@@ -6,6 +6,7 @@ import {
 	ACTOR_RUNTIME_API_URL,
 	ACTOR_RUNTIME_CONSOLE_URL,
 	findRunningRuntimeEngine,
+	runtimeSkillHintLines,
 } from '../../lib/runtime/docker.js';
 import { overridingRuntimeEnvVars, setConnectedToActorRuntime } from '../../lib/runtime/target.js';
 
@@ -40,6 +41,8 @@ export class RuntimeConnectCommand extends ApifyCommand<typeof RuntimeConnectCom
 				`  Console: ${ACTOR_RUNTIME_CONSOLE_URL}`,
 				'',
 				`Run ${chalk.white.bold('apify runtime disconnect')} to target the Apify platform again.`,
+				'',
+				...runtimeSkillHintLines(),
 			].join('\n'),
 		});
 

--- a/src/commands/runtime/install.ts
+++ b/src/commands/runtime/install.ts
@@ -2,7 +2,12 @@ import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
 import { Args } from '../../lib/command-framework/args.js';
 import { Flags } from '../../lib/command-framework/flags.js';
 import { simpleLog, success } from '../../lib/outputs.js';
-import { DEFAULT_ACTOR_RUNTIME_IMAGE, DOCKER_GET_DOCKER_URL, PODMAN_INSTALL_URL } from '../../lib/runtime/docker.js';
+import {
+	DEFAULT_ACTOR_RUNTIME_IMAGE,
+	DOCKER_GET_DOCKER_URL,
+	PODMAN_INSTALL_URL,
+	runtimeSkillHintLines,
+} from '../../lib/runtime/docker.js';
 import { ensureActorRuntimeImage } from '../../lib/runtime/ensure.js';
 
 export class RuntimeInstallCommand extends ApifyCommand<typeof RuntimeInstallCommand> {
@@ -55,5 +60,6 @@ export class RuntimeInstallCommand extends ApifyCommand<typeof RuntimeInstallCom
 
 		success({ message: 'Actor runtime is installed.' });
 		simpleLog({ message: `Start it with 'apify runtime start'.` });
+		simpleLog({ message: ['', ...runtimeSkillHintLines()].join('\n') });
 	}
 }

--- a/src/commands/runtime/skill.ts
+++ b/src/commands/runtime/skill.ts
@@ -1,0 +1,113 @@
+import process from 'node:process';
+
+import chalk from 'chalk';
+
+import { ApifyCommand } from '../../lib/command-framework/apify-command.js';
+import { Flags } from '../../lib/command-framework/flags.js';
+import { error, info, simpleLog, success } from '../../lib/outputs.js';
+import {
+	describeSkillSource,
+	frameSkillForReading,
+	resolveRuntimeSkill,
+	skillTargets,
+	stampSkill,
+	writeSkillTo,
+} from '../../lib/runtime/skill.js';
+import { tildify } from '../../lib/utils.js';
+
+export class RuntimeSkillCommand extends ApifyCommand<typeof RuntimeSkillCommand> {
+	static override name = 'skill' as const;
+
+	static override description =
+		`Prints the Actor runtime's Agent Skill - the instructions an agent needs to drive the runtime ` +
+		`(the dev-folder loop, debug mode, browser view, migration testing, the API fallback).\n` +
+		`The skill ships inside the runtime image, so it always describes the runtime you actually have. ` +
+		`It is read over HTTP when the runtime is running, and straight out of the installed image when ` +
+		`it is not - so 'apify runtime install' is all it needs.\n` +
+		`Use --install to put it in your agent's skills directory, where it loads on demand in this and ` +
+		`later sessions instead of only the terminal it was printed into.`;
+
+	static override group = 'Local Actor Development';
+
+	static override examples = [
+		{
+			description: `Install the skill for the agents on this machine.`,
+			command: 'apify runtime skill --install',
+		},
+		{
+			description: 'Print the skill to read it now.',
+			command: 'apify runtime skill',
+		},
+		{
+			description: `Save it somewhere else.`,
+			command: 'apify runtime skill > SKILL.md',
+		},
+	];
+
+	static override docsUrl = 'https://docs.apify.com/cli/docs/reference#apify-runtime-skill';
+
+	static override flags = {
+		install: Flags.boolean({
+			description: `Write the skill into every agent skills directory found, instead of printing it.`,
+			default: false,
+		}),
+		raw: Flags.boolean({
+			description: `Print the file exactly as it ships, frontmatter and all, with no added header.`,
+			default: false,
+		}),
+	};
+
+	async run() {
+		const resolved = await resolveRuntimeSkill();
+
+		if (!resolved) {
+			error({
+				message: [
+					`Could not read the Actor runtime's Agent Skill.`,
+					`  The skill ships inside the runtime image, so install it first:`,
+					chalk.white.bold(`    apify runtime install`),
+				].join('\n'),
+			});
+			process.exitCode = 1;
+			return;
+		}
+
+		const { content, source } = resolved;
+
+		if (!this.flags.install) {
+			// stdout only, so 'apify runtime skill > SKILL.md' stays a clean file - the same contract
+			// 'apify help --skill' already has.
+			simpleLog({
+				stdout: true,
+				message: (this.flags.raw ? content : frameSkillForReading(content, source)).trimEnd(),
+			});
+			return;
+		}
+
+		const stamped = stampSkill(content, source);
+		const written: string[] = [];
+
+		for (const target of skillTargets()) {
+			try {
+				await writeSkillTo(target, stamped);
+				written.push(`  ${tildify(target.directory)}  ${chalk.gray(`(${target.label})`)}`);
+			} catch (err) {
+				// One unwritable location (a read-only home, a project directory owned by someone else)
+				// must not lose the installs that did work.
+				info({ message: chalk.gray(`Skipped ${tildify(target.directory)}: ${(err as Error).message}`) });
+			}
+		}
+
+		if (!written.length) {
+			error({ message: `Could not write the skill to any agent skills directory.` });
+			process.exitCode = 1;
+			return;
+		}
+
+		success({ message: `Installed the Actor runtime skill from ${describeSkillSource(source)}:` });
+		simpleLog({ message: written.join('\n') });
+		simpleLog({
+			message: chalk.gray(`\nAgents pick it up on their next start. Re-run this after upgrading the runtime image.`),
+		});
+	}
+}

--- a/src/commands/runtime/start.ts
+++ b/src/commands/runtime/start.ts
@@ -17,6 +17,7 @@ import {
 	findRunningRuntimeEngine,
 	resolveEngineSocketPath,
 	runtimeEnvExportLines,
+	runtimeSkillHintLines,
 } from '../../lib/runtime/docker.js';
 import { ensureActorRuntimeImage, installedActorRuntimeImage } from '../../lib/runtime/ensure.js';
 
@@ -88,6 +89,8 @@ export class RuntimeStartCommand extends ApifyCommand<typeof RuntimeStartCommand
 				'',
 				'Point the Apify CLI at the runtime with:',
 				...runtimeEnvExportLines().map((line) => chalk.white.bold(`  ${line}`)),
+				'',
+				...runtimeSkillHintLines(),
 			].join('\n'),
 		});
 

--- a/src/commands/runtime/status.ts
+++ b/src/commands/runtime/status.ts
@@ -11,6 +11,7 @@ import {
 	findRunningRuntimeEngine,
 	inspectRuntimeContainer,
 	type PublishedPort,
+	runtimeSkillHintLines,
 } from '../../lib/runtime/docker.js';
 import { installedActorRuntimeImage } from '../../lib/runtime/ensure.js';
 import { isConnectedToActorRuntime, overridingRuntimeEnvVars, resolveApiBaseUrl } from '../../lib/runtime/target.js';
@@ -115,6 +116,10 @@ export class RuntimeStatusCommand extends ApifyCommand<typeof RuntimeStatusComma
 				'Set in this shell, taking precedence over the connection above:',
 				...overrides.map(([name, value]) => `  ${name}=${value}`),
 			);
+		}
+
+		if (engine) {
+			lines.push('', ...runtimeSkillHintLines());
 		}
 
 		simpleLog({ message: lines.join('\n') });

--- a/src/lib/runtime/docker.ts
+++ b/src/lib/runtime/docker.ts
@@ -321,3 +321,13 @@ export function buildRuntimeRunArgs({
 
 	return args;
 }
+
+/** The one line that tells an agent this runtime documents itself, printed wherever the CLI has just
+ * given it a runtime ('runtime install', 'start', 'connect', 'status'). An agent reads the output of the
+ * command it ran and has no other reason to go looking, so this is the moment that reaches it. */
+export function runtimeSkillHintLines(): string[] {
+	return [
+		`Agents: run 'apify runtime skill --install' to install this runtime's Agent Skill,`,
+		`        or 'apify runtime skill' to read it now.`,
+	];
+}

--- a/src/lib/runtime/skill.ts
+++ b/src/lib/runtime/skill.ts
@@ -1,0 +1,183 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import { execa } from 'execa';
+
+import { APIFY_CLIENT_DEFAULT_HEADERS } from '../consts.js';
+import { userHomeDir } from '../utils.js';
+import { ACTOR_RUNTIME_API_URL, findRunningRuntimeEngine, imageExistsLocally, type ContainerEngine } from './docker.js';
+import { installedActorRuntimeImage } from './ensure.js';
+import { resolveApiBaseUrl } from './target.js';
+
+/** The skill's directory name wherever it is installed, and its `name` in the file's own frontmatter. */
+export const RUNTIME_SKILL_NAME = 'apify-actor-runtime';
+
+/** Where the skill lives inside the runtime image - `skills/actor-runtime/` under the image's WORKDIR. */
+const SKILL_DIR_IN_IMAGE = '/usr/src/app/skills/actor-runtime';
+
+const SKILL_FILE = 'SKILL.md';
+
+/** How the skill was obtained, for the header `--install` stamps onto the written file. */
+export type SkillSource = { kind: 'runtime'; baseUrl: string } | { kind: 'image'; image: string };
+
+export interface ResolvedSkill {
+	content: string;
+	source: SkillSource;
+}
+
+export function describeSkillSource(source: SkillSource): string {
+	return source.kind === 'runtime' ? `the runtime at ${source.baseUrl}` : `the '${source.image}' image`;
+}
+
+/**
+ * `GET /actor-runtime/skill` from a running runtime. Unauthenticated by design (see the runtime's
+ * `api.md`), so this works before `apify login` - which matters, because explaining how to log in is one
+ * of the things the skill does. Resolves to null for anything that isn't a runtime answering.
+ */
+async function fetchSkillFromRuntime(baseUrl: string): Promise<string | null> {
+	try {
+		const response = await fetch(`${baseUrl.replace(/\/v2\/?$/, '')}/actor-runtime/skill`, {
+			headers: APIFY_CLIENT_DEFAULT_HEADERS,
+		});
+		if (!response.ok) return null;
+
+		const content = await response.text();
+		return content.trim() ? content : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Copies the skill out of the runtime image without starting it - `create`/`cp`/`rm`, so a stopped
+ * runtime (or one never started at all) still answers. `cp` takes the whole directory rather than the one
+ * file so that reference material added to the skill later comes along without changing this code.
+ *
+ * This is what makes 'apify runtime install' the real prerequisite for 'apify runtime skill', rather than
+ * 'apify runtime start', and it keeps working with no network once the image is local.
+ */
+async function readSkillFromImage(engine: ContainerEngine, image: string): Promise<string | null> {
+	const scratch = await mkdtemp(join(tmpdir(), 'apify-runtime-skill-'));
+	let container: string | undefined;
+
+	try {
+		const { stdout } = await execa(engine, ['create', image]);
+		container = stdout.trim().split('\n').at(-1)?.trim();
+		if (!container) return null;
+
+		await execa(engine, ['cp', `${container}:${SKILL_DIR_IN_IMAGE}/.`, scratch]);
+		return await readFile(join(scratch, SKILL_FILE), 'utf8');
+	} catch {
+		return null;
+	} finally {
+		if (container) await execa(engine, ['rm', '-f', container]).catch(() => {});
+		await rm(scratch, { recursive: true, force: true });
+	}
+}
+
+/**
+ * The skill for the runtime this CLI is pointed at, tried cheapest-first: over HTTP when a runtime is
+ * up, then out of the installed image. Null means neither - the caller should say to run
+ * 'apify runtime install'.
+ *
+ * There is deliberately no copy bundled with the CLI to fall back to. The skill describes the image that
+ * is actually present, and a CLI-side copy could only ever describe the image the CLI was released
+ * against.
+ */
+export async function resolveRuntimeSkill(): Promise<ResolvedSkill | null> {
+	const baseUrl = resolveApiBaseUrl() ?? ACTOR_RUNTIME_API_URL;
+
+	const overHttp = await fetchSkillFromRuntime(baseUrl);
+	if (overHttp) return { content: overHttp, source: { kind: 'runtime', baseUrl } };
+
+	const engine = await findRunningRuntimeEngine();
+	const image = installedActorRuntimeImage();
+
+	// A running container whose HTTP answer we did not get means an older runtime without the endpoint;
+	// its own image is still the right place to look. Otherwise fall back to whichever engine has the
+	// image on disk.
+	for (const candidate of engine ? [engine] : (['docker', 'podman'] as const)) {
+		if (!(await imageExistsLocally(candidate, image))) continue;
+
+		const fromImage = await readSkillFromImage(candidate, image);
+		if (fromImage) return { content: fromImage, source: { kind: 'image', image } };
+	}
+
+	return null;
+}
+
+/**
+ * Replaces the YAML frontmatter with a sentence naming what the reader is holding and which runtime it
+ * describes. Frontmatter is metadata for a skill *loader*; a caller that is printing has no loader, and
+ * an agent reading raw `name:`/`description:` lines in a tool result gets nothing from them. Everything
+ * after the frontmatter is passed through untouched.
+ */
+export function frameSkillForReading(content: string, source: SkillSource): string {
+	const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '').trimStart();
+
+	return [
+		`<!-- Agent Skill '${RUNTIME_SKILL_NAME}', read from ${describeSkillSource(source)}. -->`,
+		'',
+		`> Follow these instructions when working with Actors against this runtime. To keep them loaded in`,
+		`> later sessions instead of only this one, run \`apify runtime skill --install\`.`,
+		'',
+		body,
+	].join('\n');
+}
+
+/** A skills directory an agent reads, and whether it is the user's or this project's. */
+export interface SkillTarget {
+	directory: string;
+	label: string;
+}
+
+/**
+ * Where to install, per the Agent Skills convention: `~/.claude/skills` for Claude Code, `~/.agents/skills`
+ * for the agents that follow the open standard (Codex and most others), and the project-local
+ * `.agents/skills` when the caller is sitting in a directory that already has one - never created
+ * speculatively, since writing an agent directory into someone's repo uninvited is its own problem.
+ */
+export function skillTargets(home = userHomeDir(), cwd = process.cwd()): SkillTarget[] {
+	const targets: SkillTarget[] = [];
+
+	if (home) {
+		targets.push(
+			{ directory: join(home, '.claude', 'skills', RUNTIME_SKILL_NAME), label: 'Claude Code' },
+			{ directory: join(home, '.agents', 'skills', RUNTIME_SKILL_NAME), label: 'Codex and other agents' },
+		);
+	}
+
+	// Only when the project already keeps agent skills of its own. Creating '.claude/' or '.agents/' in
+	// whatever repository the user happened to be standing in - very likely a tracked, committable change
+	// they did not ask for - is worse than not installing there at all.
+	for (const [directory, label] of [
+		['.claude', 'this project (Claude Code)'],
+		['.agents', 'this project'],
+	] as const) {
+		if (existsSync(join(cwd, directory, 'skills'))) {
+			targets.push({ directory: join(cwd, directory, 'skills', RUNTIME_SKILL_NAME), label });
+		}
+	}
+
+	return targets;
+}
+
+/**
+ * Stamps the source and date into the installed copy, as an HTML comment under the frontmatter so it
+ * survives in every renderer without disturbing the frontmatter a loader reads. An installed skill is a
+ * snapshot; this is what makes an old one recognisable as one.
+ */
+export function stampSkill(content: string, source: SkillSource, now = new Date()): string {
+	const stamp = `<!-- Installed by 'apify runtime skill --install' from ${describeSkillSource(source)} on ${now.toISOString().slice(0, 10)}. Re-run it after upgrading the runtime. -->`;
+	const frontmatter = /^(---\r?\n[\s\S]*?\r?\n---\r?\n)/.exec(content);
+
+	return frontmatter ? `${frontmatter[1]}\n${stamp}\n${content.slice(frontmatter[1].length)}` : `${stamp}\n${content}`;
+}
+
+export async function writeSkillTo(target: SkillTarget, content: string): Promise<void> {
+	await mkdir(target.directory, { recursive: true });
+	await writeFile(join(target.directory, SKILL_FILE), content);
+}

--- a/test/local/lib/runtime-skill.test.ts
+++ b/test/local/lib/runtime-skill.test.ts
@@ -1,0 +1,114 @@
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	describeSkillSource,
+	frameSkillForReading,
+	RUNTIME_SKILL_NAME,
+	skillTargets,
+	stampSkill,
+	writeSkillTo,
+} from '../../../src/lib/runtime/skill.js';
+
+const SKILL = ['---', 'name: apify-actor-runtime', 'description: drives the runtime', '---', '', '# Body', 'text'].join(
+	'\n',
+);
+
+describe('frameSkillForReading', () => {
+	it('replaces the frontmatter with a header saying what the reader is holding', () => {
+		const framed = frameSkillForReading(SKILL, { kind: 'runtime', baseUrl: 'http://localhost:3333' });
+
+		// Frontmatter is metadata for a skill loader; a caller that is printing has none.
+		expect(framed).not.toContain('description: drives the runtime');
+		expect(framed).toContain('Follow these instructions when working with Actors against this runtime');
+		expect(framed).toContain('apify runtime skill --install');
+		expect(framed).toContain('# Body');
+	});
+
+	it('names where the skill came from', () => {
+		expect(frameSkillForReading(SKILL, { kind: 'image', image: 'apify/actor-runtime:latest' })).toContain(
+			`the 'apify/actor-runtime:latest' image`,
+		);
+	});
+
+	it('passes through a file that has no frontmatter', () => {
+		expect(frameSkillForReading('# Body only', { kind: 'image', image: 'x' })).toContain('# Body only');
+	});
+});
+
+describe('stampSkill', () => {
+	it('records the source and date below the frontmatter, leaving the frontmatter first', () => {
+		const stamped = stampSkill(SKILL, { kind: 'image', image: 'apify/actor-runtime:latest' }, new Date('2026-09-11'));
+
+		// A loader reads the frontmatter from the top of the file - the stamp must not displace it.
+		expect(stamped.startsWith('---\nname: apify-actor-runtime')).toBe(true);
+		expect(stamped).toContain('2026-09-11');
+		expect(stamped).toContain(`the 'apify/actor-runtime:latest' image`);
+		expect(stamped).toContain('# Body');
+	});
+
+	it('still stamps a file with no frontmatter', () => {
+		const stamped = stampSkill('# Body only', { kind: 'runtime', baseUrl: 'http://localhost:3333' });
+
+		expect(stamped).toContain('Installed by');
+		expect(stamped).toContain('# Body only');
+	});
+});
+
+describe('describeSkillSource', () => {
+	it('distinguishes a live runtime from a stopped image', () => {
+		expect(describeSkillSource({ kind: 'runtime', baseUrl: 'http://localhost:3333' })).toBe(
+			'the runtime at http://localhost:3333',
+		);
+		expect(describeSkillSource({ kind: 'image', image: 'apify/actor-runtime:latest' })).toBe(
+			`the 'apify/actor-runtime:latest' image`,
+		);
+	});
+});
+
+describe('skillTargets', () => {
+	it('covers Claude Code and the open-standard location under the home directory', () => {
+		const targets = skillTargets('/home/someone', '/work/project-without-agent-dirs');
+
+		expect(targets.map((target) => target.directory)).toEqual([
+			join('/home/someone', '.claude', 'skills', RUNTIME_SKILL_NAME),
+			join('/home/someone', '.agents', 'skills', RUNTIME_SKILL_NAME),
+		]);
+	});
+
+	it('adds a project location only when that project already keeps skills of its own', async () => {
+		const project = await mkdtemp(join(tmpdir(), 'apify-skill-project-'));
+
+		try {
+			expect(skillTargets('/home/someone', project)).toHaveLength(2);
+
+			await mkdir(join(project, '.agents', 'skills'), { recursive: true });
+
+			const targets = skillTargets('/home/someone', project);
+			expect(targets).toHaveLength(3);
+			expect(targets[2].directory).toBe(join(project, '.agents', 'skills', RUNTIME_SKILL_NAME));
+		} finally {
+			await rm(project, { recursive: true, force: true });
+		}
+	});
+
+	it('returns nothing rather than writing into an unrelated directory when there is no home', () => {
+		expect(skillTargets('', '/work/project-without-agent-dirs')).toEqual([]);
+	});
+});
+
+describe('writeSkillTo', () => {
+	it('creates the whole skill directory and writes SKILL.md into it', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'apify-skill-test-'));
+
+		try {
+			const directory = join(root, 'nested', '.claude', 'skills', RUNTIME_SKILL_NAME);
+			await writeSkillTo({ directory, label: 'test' }, SKILL);
+
+			expect(await readFile(join(directory, 'SKILL.md'), 'utf8')).toBe(SKILL);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Adds `apify runtime skill [--install]`, which reads the runtime's own Agent Skill over HTTP when the runtime is running, or straight out of the installed image when it is not — so `apify runtime install` is the only prerequisite.

No copy is bundled with the CLI: one could only ever describe the image the CLI was released against. `runtime install`, `start`, `connect` and `status` now print one line pointing at the command.

Refs apify/actor-runtime#53. Needs apify/actor-runtime#54 to land first, since the image must carry the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExpRUXDzyTmT828ugqkjAP